### PR TITLE
Pass Version Tag From Upstream Using Scopeo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Get current version
         id: labels
         run: |
-          docker pull ghcr.io/ublue-os/${{ format('bazzite{0}', matrix.image_name) }}:${{ matrix.major_version }}
-          ver=$(docker inspect ghcr.io/ublue-os/${{ format('bazzite{0}', matrix.image_name) }}:${{ matrix.major_version }} | jq -r '.[].Config.Labels["org.opencontainers.image.version"]')
+          ver=$(skopeo inspect docker://ghcr.io/ublue-os/kinoite-nvidia:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
           echo "VERSION=$ver" >> $GITHUB_OUTPUT
 
       # Build metadata


### PR DESCRIPTION
This mirrors [the upstream patch](https://github.com/ublue-os/nvidia/pull/79). The version tag fix I submitted previously did not work correctly. This commit changes to the better method now used in main and nvidia. I have tested this using images in my repo.

Thanks!