### PR TITLE
Enable virtual keyboard at login

### DIFF
--- a/etc/sddm.conf.d/virtualkbd.conf
+++ b/etc/sddm.conf.d/virtualkbd.conf
@@ -1,0 +1,2 @@
+[General]
+InputMethod=qtvirtualkeyboard


### PR DESCRIPTION
Useful for devices with touchscreens like the Steam Deck. Provides a mode of input at login when a wired keyboard isn't available