### PR TITLE
feat(steamos-update): Initial support for Universal Blue updater

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -129,6 +129,7 @@ RUN sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-bazzite.re
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo && \
     systemctl enable set-cfs-tweaks.service && \
     systemctl disable input-remapper.service && \
+    systemctl --global disable ublue-update.timer && \
     rm -rf \
         /tmp/* \
         /var/* && \

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,8 @@ COPY system_files/desktop/usr /usr
 
 # Add ublue-update
 COPY --from=ghcr.io/ublue-os/ublue-update:latest /rpms/ublue-update.noarch.rpm /tmp/rpms/
-RUN rpm-ostree install /tmp/rpms/ublue-update.noarch.rpm
+RUN rpm-ostree override remove ublue-os-update-services && \
+    rpm-ostree install /tmp/rpms/ublue-update.noarch.rpm
 
 # Add Copr repos
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-$(rpm -E %fedora)/kylegospo-bazzite-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \

--- a/Containerfile
+++ b/Containerfile
@@ -59,7 +59,6 @@ RUN pip install --prefix=/usr yafti && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
     systemctl disable rpm-ostreed-automatic.timer && \
-    systemctl disable flatpak-system-update.timer && \
     systemctl --global enable ublue-update.timer && \
     systemctl enable input-remapper.service && \
     rm -rf \

--- a/system_files/deck/usr/bin/steamos-update
+++ b/system_files/deck/usr/bin/steamos-update
@@ -43,7 +43,7 @@ if command -v ublue-update > /dev/null; then
     }
     upgrade() {
       # Pull exit code from ublue-update
-      ublue-update
+      ublue-update --force
       echo $? > /tmp/upgrade-check
     }
     upgrade | fake_progress

--- a/system_files/deck/usr/bin/steamos-update
+++ b/system_files/deck/usr/bin/steamos-update
@@ -5,26 +5,18 @@ if command -v ublue-update > /dev/null; then
     if [ -f '/tmp/upgrade-installed' ]; then
       exit 7 # Upgrade already installed
     else
-      # Check system state
-      ublue-update --check
+      # Perform connectivity check
+      wget -q --spider https://github.com
       if [ $? -eq 0 ]; then
-        # Perform connectivity check
-        wget -q --spider https://github.com
+        # Check system state
+        ublue-update --check
         if [ $? -eq 0 ]; then
-          # Compare installation digest to latest image
-          IMAGE=$(rpm-ostree status | grep -m1 ghcr | sed 's/^.*ghcr/ghcr/')
-          CURRENT=$(rpm-ostree status | grep -m1 Digest | tr -d '[:space:]' | sed 's/'Digest:'//g')
-          LATEST=$(skopeo inspect docker://${IMAGE} | jq '.Digest' | tr -d '"')
-          if [ ${CURRENT} == ${LATEST} ]; then
-            exit 7 # Up to date
-          else
-            exit 0 # Upgrade available
-          fi
+          exit 0 # Upgrade available
         else
-          exit 7 # Connectivity check failed
+          exit 7 # Checks failed
         fi
       else
-        exit 7 # System in use
+        exit 7 # Connectivity check failed
       fi
     fi
   elif [ "$1" == "--supports-duplicate-detection" ]; then

--- a/system_files/deck/usr/bin/steamos-update
+++ b/system_files/deck/usr/bin/steamos-update
@@ -1,24 +1,30 @@
 #!/bin/bash
 
-if command -v rpm-ostree > /dev/null; then
+if command -v ublue-update > /dev/null; then
   if [ "$1" == "check" ]; then
     if [ -f '/tmp/upgrade-installed' ]; then
       exit 7 # Upgrade already installed
     else
-      # Perform connectivity check
-      wget -q --spider https://github.com
+      # Check system state
+      ublue-update --check
       if [ $? -eq 0 ]; then
-        # Compare installation digest to latest image
-        IMAGE=$(rpm-ostree status | grep -m1 ghcr | sed 's/^.*ghcr/ghcr/')
-        CURRENT=$(rpm-ostree status | grep -m1 Digest | tr -d '[:space:]' | sed 's/'Digest:'//g')
-        LATEST=$(skopeo inspect docker://${IMAGE} | jq '.Digest' | tr -d '"')
-        if [ ${CURRENT} == ${LATEST} ]; then
-          exit 7 # Up to date
+        # Perform connectivity check
+        wget -q --spider https://github.com
+        if [ $? -eq 0 ]; then
+          # Compare installation digest to latest image
+          IMAGE=$(rpm-ostree status | grep -m1 ghcr | sed 's/^.*ghcr/ghcr/')
+          CURRENT=$(rpm-ostree status | grep -m1 Digest | tr -d '[:space:]' | sed 's/'Digest:'//g')
+          LATEST=$(skopeo inspect docker://${IMAGE} | jq '.Digest' | tr -d '"')
+          if [ ${CURRENT} == ${LATEST} ]; then
+            exit 7 # Up to date
+          else
+            exit 0 # Upgrade available
+          fi
         else
-          exit 0 # Upgrade available
+          exit 7 # Connectivity check failed
         fi
       else
-        exit 7 # Connectivity check failed
+        exit 7 # System in use
       fi
     fi
   elif [ "$1" == "--supports-duplicate-detection" ]; then
@@ -36,20 +42,20 @@ if command -v rpm-ostree > /dev/null; then
       echo 100%
     }
     upgrade() {
-      # Pull exit code from rpm-ostree
-      rpm-ostree upgrade --unchanged-exit-77
+      # Pull exit code from ublue-update
+      ublue-update
       echo $? > /tmp/upgrade-check
     }
     upgrade | fake_progress
     # Check if upgrade failed
     UPGRADE_CHECK=/tmp/upgrade-check
     rm /tmp/upgrade-check
-    if [ ${UPGRADE_CHECK} -eq 77 ]; then
-      exit 0 # Upgrade failed
-    else
+    if [ ${UPGRADE_CHECK} -eq 0 ]; then
       touch /tmp/upgrade-installed
+    else
+      exit 0 # Upgrade failed
     fi
   fi
 else
-  exit 7 # rpm-ostree not installed
+  exit 7 # ublue-update not installed
 fi


### PR DESCRIPTION
This implements ublue-update in steamos-update, replacing the usage of rpm-ostree. This will allow for not only system updates, but flatpak updates and distrobox updates as well