### PR TITLE
Adjust Yafti config to add Nix Package Manager and additional supporting Flatpaks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,8 @@ RUN rpm-ostree override remove ublue-os-update-services && \
 # Add Copr repos
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-$(rpm -E %fedora)/kylegospo-bazzite-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/system76-scheduler/repo/fedora-$(rpm -E %fedora)/kylegospo-system76-scheduler-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-system76-scheduler.repo && \
-    wget https://copr.fedorainfracloud.org/coprs/kylegospo/hl2linux-selinux/repo/fedora-$(rpm -E %fedora)/kylegospo-hl2linux-selinux-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo
+    wget https://copr.fedorainfracloud.org/coprs/kylegospo/hl2linux-selinux/repo/fedora-$(rpm -E %fedora)/kylegospo-hl2linux-selinux-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo && \
+    wget https://copr.fedorainfracloud.org/coprs/kylegospo/obs-vkcapture/repo/fedora-$(rpm -E %fedora)/kylegospo-obs-vkcapture-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-obs-vkcapture.repo
 
 # Install new packages
 RUN rpm-ostree install \
@@ -40,7 +41,10 @@ RUN rpm-ostree install \
     hl2linux-selinux \
     btop \
     fish \
-    python3-pip
+    python3-pip \
+    libobs_glcapture \
+    libobs_vkcapture \
+    obs-vkcapture
 
 # Remove unneeded packages
 RUN rpm-ostree override remove \
@@ -59,6 +63,7 @@ RUN pip install --prefix=/usr yafti && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-system76-scheduler.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo && \
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-obs-vkcapture.repo && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
     systemctl disable rpm-ostreed-automatic.timer && \
@@ -83,7 +88,8 @@ RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/LatencyFleX/repo/fedo
 
 # Re-enable Copr repos
 RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \
-    sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo
+    sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo && \
+    sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_kylegospo-obs-vkcapture.repo
 
 # Remove system76-scheduler
 RUN rpm-ostree override remove system76-scheduler
@@ -133,6 +139,7 @@ RUN sed -i 's/#HandlePowerKey=poweroff/HandlePowerKey=suspend/g' /etc/systemd/lo
 RUN sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-latencyflex.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-hl2linux-selinux.repo && \
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-obs-vkcapture.repo && \
     systemctl enable set-cfs-tweaks.service && \
     systemctl disable input-remapper.service && \
     systemctl --global disable ublue-update.timer && \

--- a/system_files/deck/etc/environment
+++ b/system_files/deck/etc/environment
@@ -1,0 +1,1 @@
+OBS_USE_EGL=1

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -179,6 +179,11 @@ screens:
           packages:
           - Deck Swap: just swap-on
           - Disable ZRAM: just zram-off
+        Nix Package Manager:
+          descrption: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
+          default: true
+          packages:
+            - Install Nix Package Support: curl -s https://raw.githubusercontent.com/dnkmmr69420/nix-installer-scripts/main/installer-scripts/silverblue-nix-installer.sh | bash
         SteamDeckGyroDSU:
           descrption: Allows emulators and other applications to receive Steam Deck gyro motion data
           default: true

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -35,9 +35,11 @@ screens:
           default: true
           packages:
           - Lutris: net.lutris.Lutris
+          - MangoHud (Flatpak): org.freedesktop.Platform.VulkanLayer.MangoHud
           - Mozilla Firefox: org.mozilla.firefox
           - Protontricks: com.github.Matoking.protontricks
           - ProtonUp-Qt (Proton Updater): net.davidotek.pupgui2
+          - vkBasalt (Flatpak): org.freedesktop.Platform.VulkanLayer.vkBasalt
           - Wallpaper Engine: just enable-wallpaper-engine
         Web Browsers:
           description: Additional browsers to complement Firefox
@@ -94,7 +96,8 @@ screens:
           default: false
           packages:
           - OBS Studio: com.obsproject.Studio
-          - VkCapture for OBS: com.obsproject.Studio.OBSVkCapture 
+          - OBSVkCapture Layer: org.freedesktop.Platform.VulkanLayer.OBSVkCapture
+          - OBSVkCapture Plugin: com.obsproject.Studio.Plugin.OBSVkCapture
           - Gstreamer for OBS: com.obsproject.Studio.Plugin.Gstreamer
           - Gstreamer VAAPI for OBS: com.obsproject.Studio.Plugin.GStreamerVaapi
           - Boatswain for Streamdeck: com.feaneron.Boatswain

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -168,6 +168,11 @@ screens:
           default: false
           packages:
           - Disable ZRAM: just zram-off
+        Nix Package Manager:
+          descrption: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
+          default: true
+          packages:
+            - Install Nix Package Support: curl -s https://raw.githubusercontent.com/dnkmmr69420/nix-installer-scripts/main/installer-scripts/silverblue-nix-installer.sh | bash
   final-screen:
     source: yafti.screen.title
     values:

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -34,9 +34,11 @@ screens:
           description: Core Applications
           default: true
           packages:
+          - MangoHud (Flatpak): org.freedesktop.Platform.VulkanLayer.MangoHud
           - Mozilla Firefox: org.mozilla.firefox
           - ProtonUp-Qt (Proton Updater): net.davidotek.pupgui2
           - System76 Scheduler: just enable-system76-scheduler
+          - vkBasalt (Flatpak): org.freedesktop.Platform.VulkanLayer.vkBasalt
           - Wallpaper Engine: just enable-wallpaper-engine
         Web Browsers:
           description: Additional browsers to complement Firefox
@@ -93,7 +95,8 @@ screens:
           default: false
           packages:
           - OBS Studio: com.obsproject.Studio
-          - VkCapture for OBS: com.obsproject.Studio.OBSVkCapture 
+          - OBSVkCapture Layer: org.freedesktop.Platform.VulkanLayer.OBSVkCapture
+          - OBSVkCapture Plugin: com.obsproject.Studio.Plugin.OBSVkCapture
           - Gstreamer for OBS: com.obsproject.Studio.Plugin.Gstreamer
           - Gstreamer VAAPI for OBS: com.obsproject.Studio.Plugin.GStreamerVaapi
           - Boatswain for Streamdeck: com.feaneron.Boatswain


### PR DESCRIPTION
Adds Nix to Yafti setup, along with VKBasalt and MangoHud flatpaks.

Additionally, fixes OBS flatpak plugin path, adds OBS flatpak vulkan layer, and via  new copr adds obs-vkcapture for native apps. New `etc/environment` on deck branch is due to deck being X11-only and therefore always needing it.