### PR TITLE
feat(deck): Layer Lutris to avoid common issues with the flatpak.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -126,6 +126,7 @@ RUN rpm-ostree install \
 # Install new packages
 RUN rpm-ostree install \
     steam \
+    lutris \
     gamescope \
     gamescope-session \
     jupiter-fan-control \

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -34,7 +34,6 @@ screens:
           description: Core Applications
           default: true
           packages:
-          - Lutris: net.lutris.Lutris
           - MangoHud (Flatpak): org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
           - Mozilla Firefox: org.mozilla.firefox
           - Protontricks: com.github.Matoking.protontricks


### PR DESCRIPTION
Current issues with the flatpak to consider this:

1. Issues with MangoHUD discovery in UI
2. Issues with vkBasalt discovery in UI
3. No LatencyFleX flatpak available
4. Need to use flatseal makes it hard for users new to Linux.

This change applies only to the deck branch, as desktop uses Lutris installed in distrobox already.