### PR TITLE
fix(steamos-automount): Don't use systemd container when adding library

### DIFF
--- a/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec
+++ b/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec
@@ -13,6 +13,7 @@ Patch2:	        https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/l
 Patch3:         https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/hwsupport/format-device.sh.patch
 Patch4:         user.patch
 Patch5:         bazzite-btrfs.patch
+Patch6:         systemd-run.patch
 
 Requires:       python3
 Requires:       python3-libevdev

--- a/spec_files/jupiter-hw-support/systemd-run.patch
+++ b/spec_files/jupiter-hw-support/systemd-run.patch
@@ -1,0 +1,13 @@
+diff --git a/usr/lib/hwsupport/steamos-automount.sh b/usr/lib/hwsupport/steamos-automount.sh
+index bdac3c4..35dd71c 100755
+--- a/usr/lib/hwsupport/steamos-automount.sh
++++ b/usr/lib/hwsupport/steamos-automount.sh
+@@ -53,7 +53,7 @@ send_steam_url()
+   if pgrep -x "steam" > /dev/null; then
+       # TODO use -ifrunning and check return value - if there was a steam process and it returns -1, the message wasn't sent
+       # need to retry until either steam process is gone or -ifrunning returns 0, or timeout i guess
+-      systemd-run -M 1000@ --user --collect --wait sh -c "./.steam/root/ubuntu12_32/steam steam://${command}/${encoded@Q}"
++      systemd-run --uid=1000 --collect --wait sh -c "/usr/bin/steam steam://${command}/${encoded@Q}"
+       echo "Sent URL to steam: steam://${command}/${arg} (steam://${command}/${encoded})"
+   else
+       echo "Could not send steam URL steam://${command}/${arg} (steam://${command}/${encoded}) -- steam not running"


### PR DESCRIPTION
We don't provide a container for systemd making this no-op, resulting in an invalid endpoint