### PR TITLE
fix: Address more just and yafti issues

### DIFF
--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -8,7 +8,76 @@ screens:
       title: "Welcome to Bazzite (Steam Deck)"
       icon: "/path/to/icon"
       description: |
-        Pick some applications to get started
+        Configure your system to get started
+  configure-bazzite:
+    source: yafti.screen.package
+    values:
+      title: Configure Bazzite
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        Automatic Duplicate File Removal:
+          description: Flattens duplicate files to take up no more space than a single copy, a considerable space savings for wine prefixes and compatdata
+          default: true
+          packages:
+          - Enable Duperemove: systemctl enable --now duperemove-weekly@$(systemd-escape $HOME).timer
+        Autostart Steam:
+          description: Launches Steam automatically on the desktop
+          default: true
+          packages:
+          - Enable Autostart: cp ~/usr/share/applications/steam.desktop ~/.config/autostart/steam-silent.desktop && sed -i 's@/usr/bin/steam-runtime  %U@/usr/bin/steam-runtime -silent %U@g' ~/.config/autostart/steam-silent.desktop
+        Decky Loader:
+          description: A plugin loader for the Steam Deck
+          default: false
+          packages:
+          - Retrieve Decky: just get-decky
+        EmuDeck:
+          description: |
+            A utility for installing and configuring emulators on the Steam Deck
+          default: false
+          packages:
+          - Retrieve EmuDeck: just get-emudeck
+        Gamescope Autologin:
+          description: Autologin to Gamescope Session
+          default: true
+          packages:
+          - Enable Gamescope Autologin: just enable-gamescope-autologin
+        Greenlight:
+          description: A utility for xCloud and xHome streaming
+          default: false
+          packages:
+          - Retrieve Greenlight: just get-greenlight
+        Kernel Arguments:
+          description: Sets kernel arguments used in SteamOS
+          default: true
+          packages:
+          - Set kargs: just set-steamos-kargs
+        Memory Tuning:
+          description: Adjust ZRAM and configure deckswap
+          default: false
+          packages:
+          - Deck Swap: just swap-on
+          - Disable ZRAM: just zram-off
+        Nix Package Manager:
+          description: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
+          default: true
+          packages:
+          - Install Nix Package Support: just install-nix
+        SteamDeckGyroDSU:
+          description: Allows emulators and other applications to receive Steam Deck gyro motion data
+          default: true
+          packages:
+          - Enable SDGyroDSU Service: systemctl --user enable --now sdgyrodsu
+        Steam Desktop Shortcuts:
+          description: Creates Steam desktop shortcuts
+          default: true
+          packages:
+          - Create Steam shortcuts: just create-steam-shortcuts
+        Wallpaper Engine:
+          description: Enables Wallpaper Engine
+          default: true
+          packages:
+          - Enable Wallpaper Engine: just enable-wallpaper-engine
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent
     values:
@@ -132,75 +201,6 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
-  configure-bazzite:
-    source: yafti.screen.package
-    values:
-      title: Configure Bazzite
-      show_terminal: true
-      package_manager: yafti.plugin.run
-      groups:
-        Automatic Duplicate File Removal:
-          description: Flattens duplicate files to take up no more space than a single copy, a considerable space savings for wine prefixes and compatdata
-          default: true
-          packages:
-          - Enable Duperemove: systemctl enable --now duperemove-weekly@$(systemd-escape $HOME).timer
-        Autostart Steam:
-          description: Launches Steam automatically on the desktop
-          default: true
-          packages:
-          - Enable Autostart: cp ~/usr/share/applications/steam.desktop ~/.config/autostart/steam-silent.desktop && sed -i 's@/usr/bin/steam-runtime  %U@/usr/bin/steam-runtime -silent %U@g' ~/.config/autostart/steam-silent.desktop
-        Decky Loader:
-          description: A plugin loader for the Steam Deck
-          default: false
-          packages:
-          - Retrieve Decky: just get-decky
-        EmuDeck:
-          description: |
-            A utility for installing and configuring emulators on the Steam Deck
-          default: false
-          packages:
-          - Retrieve EmuDeck: just get-emudeck
-        Gamescope Autologin:
-          description: Autologin to Gamescope Session
-          default: true
-          packages:
-          - Enable Gamescope Autologin: just enable-gamescope-autologin
-        Greenlight:
-          description: A utility for xCloud and xHome streaming
-          default: false
-          packages:
-          - Retrieve Greenlight: just get-greenlight
-        Kernel Arguments:
-          description: Sets kernel arguments used in SteamOS
-          default: true
-          packages:
-          - Set kargs: just set-steamos-kargs
-        Memory Tuning:
-          description: Adjust ZRAM and configure deckswap
-          default: false
-          packages:
-          - Deck Swap: just swap-on
-          - Disable ZRAM: just zram-off
-        Nix Package Manager:
-          description: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
-          default: true
-          packages:
-          - Install Nix Package Support: just install-nix
-        SteamDeckGyroDSU:
-          description: Allows emulators and other applications to receive Steam Deck gyro motion data
-          default: true
-          packages:
-          - Enable SDGyroDSU Service: systemctl --user enable --now sdgyrodsu
-        Steam Desktop Shortcuts:
-          description: Creates Steam desktop shortcuts
-          default: true
-          packages:
-          - Create Steam shortcuts: just create-steam-shortcuts
-        Wallpaper Engine:
-          description: Enables Wallpaper Engine
-          default: true
-          packages:
-          - Enable Wallpaper Engine: just enable-wallpaper-engine
   final-screen:
     source: yafti.screen.title
     values:

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -62,7 +62,7 @@ screens:
           description: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
           default: true
           packages:
-          - Install Nix Package Support: just install-nix
+          - Install Nix Package Support: guisu just install-nix
         SteamDeckGyroDSU:
           description: Allows emulators and other applications to receive Steam Deck gyro motion data
           default: true

--- a/system_files/desktop/etc/profile.d/guisu.sh
+++ b/system_files/desktop/etc/profile.d/guisu.sh
@@ -1,0 +1,2 @@
+alias guisu="kdesu -u ${USER} -c"
+

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -8,7 +8,55 @@ screens:
       title: "Welcome to Bazzite (Desktop)"
       icon: "/path/to/icon"
       description: |
-        Pick some applications to get started
+        Configure your system to get started
+  configure-bazzite:
+    source: yafti.screen.package
+    values:
+      title: Configure Bazzite
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        Bazzite Arch Distrobox:
+          description: This will install an Arch distrobox configured for gaming. Steam and Lutris will then be exported.
+          default: true
+          condition:
+            run: distrobox list | grep -v bazzite-arch
+          packages:
+          - Install Bazzite Arch: just install-bazzite-arch
+          - Export Steam: distrobox-enter -n bazzite-arch -- '  distrobox-export --app steam'
+          - Export Lutris: distrobox-enter -n bazzite-arch -- '  distrobox-export --app lutris'
+          - Export Protontricks: distrobox-enter -n bazzite-arch -- '  distrobox-export --app protontricks'
+          - Autostart Steam: cp ~/.local/share/applications/bazzite-arch-steam.desktop ~/.config/autostart/bazzite-arch-steam-silent.desktop && sed -i 's@/usr/bin/steam-runtime  %U@/usr/bin/steam-runtime -silent %U@g' ~/.config/autostart/bazzite-arch-steam-silent.desktop
+        Automatic Duplicate File Removal:
+          description: Flattens duplicate files to take up no more space than a single copy, a considerable space savings for wine prefixes and compatdata
+          default: true
+          packages:
+          - Enable Duperemove: systemctl enable --now duperemove-weekly@$(systemd-escape $HOME).timer
+        Greenlight:
+          description: A utility for xCloud and xHome streaming
+          default: false
+          packages:
+          - Retrieve Greenlight: just get-greenlight
+        Memory Tuning:
+          description: Adjust ZRAM configuration
+          default: false
+          packages:
+          - Disable ZRAM: just zram-off
+        Nix Package Manager:
+          description: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
+          default: true
+          packages:
+          - Install Nix Package Support: just install-nix
+        System76 Scheduler:
+          description: Enables System76 scheduler
+          default: true
+          packages:
+          - Enable System76 Scheduler: just enable-system76-scheduler
+        Wallpaper Engine:
+          description: Enables Wallpaper Engine
+          default: true
+          packages:
+          - Enable Wallpaper Engine: just enable-wallpaper-engine
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent
     values:
@@ -133,54 +181,6 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
-  configure-bazzite:
-    source: yafti.screen.package
-    values:
-      title: Configure Bazzite
-      show_terminal: true
-      package_manager: yafti.plugin.run
-      groups:
-        Bazzite Arch Distrobox:
-          description: This will install an Arch distrobox configured for gaming. Steam and Lutris will then be exported.
-          default: true
-          condition:
-            run: distrobox list | grep -v bazzite-arch
-          packages:
-          - Install Bazzite Arch: just install-bazzite-arch
-          - Export Steam: distrobox-enter -n bazzite-arch -- '  distrobox-export --app steam'
-          - Export Lutris: distrobox-enter -n bazzite-arch -- '  distrobox-export --app lutris'
-          - Export Protontricks: distrobox-enter -n bazzite-arch -- '  distrobox-export --app protontricks'
-          - Autostart Steam: cp ~/.local/share/applications/bazzite-arch-steam.desktop ~/.config/autostart/bazzite-arch-steam-silent.desktop && sed -i 's@/usr/bin/steam-runtime  %U@/usr/bin/steam-runtime -silent %U@g' ~/.config/autostart/bazzite-arch-steam-silent.desktop
-        Automatic Duplicate File Removal:
-          description: Flattens duplicate files to take up no more space than a single copy, a considerable space savings for wine prefixes and compatdata
-          default: true
-          packages:
-          - Enable Duperemove: systemctl enable --now duperemove-weekly@$(systemd-escape $HOME).timer
-        Greenlight:
-          description: A utility for xCloud and xHome streaming
-          default: false
-          packages:
-          - Retrieve Greenlight: just get-greenlight
-        Memory Tuning:
-          description: Adjust ZRAM configuration
-          default: false
-          packages:
-          - Disable ZRAM: just zram-off
-        Nix Package Manager:
-          descrption: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
-          default: true
-          packages:
-          - Install Nix Package Support: just install-nix
-        System76 Scheduler:
-          description: Enables System76 scheduler
-          default: true
-          packages:
-          - Enable System76 Scheduler: just enable-system76-scheduler
-        Wallpaper Engine:
-          description: Enables Wallpaper Engine
-          default: true
-          packages:
-          - Enable Wallpaper Engine: just enable-wallpaper-engine
   final-screen:
     source: yafti.screen.title
     values:

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -46,7 +46,7 @@ screens:
           description: Nix is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible
           default: true
           packages:
-          - Install Nix Package Support: just install-nix
+          - Install Nix Package Support: guisu just install-nix
         System76 Scheduler:
           description: Enables System76 scheduler
           default: true

--- a/system_files/desktop/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/usr/share/ublue-os/just/custom.just
@@ -1,5 +1,5 @@
 install-bazzite-arch:
-  #!/usr/bash/env bash
+  #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)
   if grep 'nvidia' <<< ${KARGS}; then
     echo 'Installing Bazzite Arch (Nvidia)...'


### PR DESCRIPTION
Corrects incorrect path in install-bazzite-arch, moves system configuration to the front of yafti, and introduces an alias for handling situations where we need the GUI to ask for escalated privledges (I.E. installing Nix)