### PR TITLE
fix(steamos-update): Get progress bar working again

### DIFF
--- a/system_files/deck/usr/bin/steamos-update
+++ b/system_files/deck/usr/bin/steamos-update
@@ -25,7 +25,8 @@ if command -v ublue-update > /dev/null; then
     # Fake upgrade progress bar
     fake_progress() {
       local value=0
-      while read -r line; do
+      while [ ! -f '/tmp/upgrade-check' ]; do
+        sleep 5
         if [ ${value} -lt '100' ]; then
           echo ${value}'%'
           value=$(( value + 3 ))
@@ -35,7 +36,7 @@ if command -v ublue-update > /dev/null; then
     }
     upgrade() {
       # Pull exit code from ublue-update
-      ublue-update --force
+      ublue-update --force > /dev/null 2>&1
       echo $? > /tmp/upgrade-check
     }
     upgrade | fake_progress


### PR DESCRIPTION
Universal Blue update isn't verbose unless something is logged or an exception is raised. Because of this, we can't just monitor its output and increment the progress bar. Instead, we need to wait for it to complete.

Since there isn't an entirely clean way of doing that, we'll just wait for the creation of '/tmp/update-check'

This also removes output from the updater to ensure that formatting stays consistent when the output is passed to Steam.