### PR TITLE
feat(deck): Handle power button

### DIFF
--- a/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec
+++ b/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec
@@ -7,6 +7,7 @@ License:        GPLv3
 URL:            https://github.com/ublue-os/bazzite
 
 Source:         https://gitlab.com/evlaV/%{packagename}/-/archive/master/%{packagename}-master.tar.gz
+Source1:        power-button-handler.py
 Patch0:         fedora.patch
 Patch1:         selinux.patch
 Patch2:	        https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/hwsupport/steamos-automount.sh.patch
@@ -17,11 +18,13 @@ Patch6:         systemd-run.patch
 Patch7:         priv-write.patch
 
 Requires:       python3
-Requires:       python3-libevdev
+Requires:       python3-evdev
 Requires:       python3-crcmod
 Requires:       python3-click
 Requires:       python3-progressbar2
 Requires:       python3-hid
+Requires:       python3-daemon
+Requires:       python3-psutil
 Requires:       hidapi
 Requires:       dmidecode
 Requires:       jq
@@ -55,7 +58,7 @@ cp -rv usr/share/* %{buildroot}%{_datadir}
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}/
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig
-cp usr/lib/hwsupport/power-button-handler.py %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
+cp %{SOURCE1} %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
 cp usr/lib/hwsupport/cirrus-fixup.sh %{buildroot}%{_sbindir}/cirrus-fixup
 cp usr/lib/hwsupport/ev2_cirrus_alsa_fixups.sh %{buildroot}%{_sbindir}/ev2_cirrus_alsa_fixups
 cp usr/lib/hwsupport/format-device.sh %{buildroot}%{_sbindir}/format-device

--- a/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec
+++ b/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec
@@ -58,7 +58,6 @@ cp -rv usr/share/* %{buildroot}%{_datadir}
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}/
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig
-cp %{SOURCE1} %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
 cp usr/lib/hwsupport/cirrus-fixup.sh %{buildroot}%{_sbindir}/cirrus-fixup
 cp usr/lib/hwsupport/ev2_cirrus_alsa_fixups.sh %{buildroot}%{_sbindir}/ev2_cirrus_alsa_fixups
 cp usr/lib/hwsupport/format-device.sh %{buildroot}%{_sbindir}/format-device
@@ -68,6 +67,7 @@ cp usr/lib/hwsupport/steamos-automount.sh %{buildroot}%{_sbindir}/steamos-automo
 cp usr/lib/hwsupport/trim-devices.sh %{buildroot}%{_sbindir}/trim-devices
 cp -rv usr/lib/udev %{buildroot}%{_prefix}/lib/udev
 cp -rv usr/bin/* %{buildroot}%{_bindir}
+cp %{SOURCE1} %{buildroot}%{_bindir}/power-button-handler
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}
 cp -rv etc/* %{buildroot}%{_sysconfdir}
 # Remove unneeded files
@@ -105,6 +105,7 @@ rm -rf %{buildroot}%{_unitdir}/multi-user.target.wants
 %{_bindir}/thumbstick_cal
 %{_bindir}/thumbstick_fine_cal
 %{_bindir}/trigger_cal
+%{_bindir}/power-button-handler
 %{_sbindir}/cirrus-fixup
 %{_sbindir}/ev2_cirrus_alsa_fixups
 %{_sbindir}/format-device

--- a/spec_files/jupiter-hw-support/jupiter-hw-support.spec
+++ b/spec_files/jupiter-hw-support/jupiter-hw-support.spec
@@ -6,15 +6,18 @@ License:        MIT
 URL:            https://github.com/ublue-os/bazzite
 
 Source:        	https://gitlab.com/evlaV/%{name}/-/archive/master/%{name}-master.tar.gz
+Source1:        power-button-handler.py
 Patch0:         fedora.patch
 Patch1:         selinux.patch
 
 Requires:       python3
-Requires:       python3-libevdev
+Requires:       python3-evdev
 Requires:       python3-crcmod
 Requires:       python3-click
 Requires:       python3-progressbar2
 Requires:       python3-hid
+Requires:       python3-daemon
+Requires:       python3-psutil
 Requires:       hidapi
 Requires:       dmidecode
 Requires:       jq
@@ -48,7 +51,7 @@ cp -rv usr/share/* %{buildroot}%{_datadir}
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}/
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig
-cp usr/lib/hwsupport/power-button-handler.py %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
+cp %{SOURCE1} %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
 cp usr/lib/hwsupport/cirrus-fixup.sh %{buildroot}%{_sbindir}/cirrus-fixup
 cp usr/lib/hwsupport/ev2_cirrus_alsa_fixups.sh %{buildroot}%{_sbindir}/ev2_cirrus_alsa_fixups
 cp usr/lib/hwsupport/format-device.sh %{buildroot}%{_sbindir}/format-device

--- a/spec_files/jupiter-hw-support/jupiter-hw-support.spec
+++ b/spec_files/jupiter-hw-support/jupiter-hw-support.spec
@@ -51,7 +51,6 @@ cp -rv usr/share/* %{buildroot}%{_datadir}
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}/
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.mod
 cp usr/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig %{buildroot}%{_prefix}/lib/hwsupport/cs35l41-dsp1-spk-prot.bin.orig
-cp %{SOURCE1} %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
 cp usr/lib/hwsupport/cirrus-fixup.sh %{buildroot}%{_sbindir}/cirrus-fixup
 cp usr/lib/hwsupport/ev2_cirrus_alsa_fixups.sh %{buildroot}%{_sbindir}/ev2_cirrus_alsa_fixups
 cp usr/lib/hwsupport/format-device.sh %{buildroot}%{_sbindir}/format-device
@@ -61,6 +60,7 @@ cp usr/lib/hwsupport/steamos-automount.sh %{buildroot}%{_sbindir}/steamos-automo
 cp usr/lib/hwsupport/trim-devices.sh %{buildroot}%{_sbindir}/trim-devices
 cp -rv usr/lib/udev %{buildroot}%{_prefix}/lib/udev
 cp -rv usr/bin/* %{buildroot}%{_bindir}
+cp %{SOURCE1} %{buildroot}%{_bindir}/power-button-handler
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}
 cp -rv etc/* %{buildroot}%{_sysconfdir}
 # Remove unneeded files
@@ -98,6 +98,7 @@ rm -rf %{buildroot}%{_unitdir}/multi-user.target.wants
 %{_bindir}/thumbstick_cal
 %{_bindir}/thumbstick_fine_cal
 %{_bindir}/trigger_cal
+%{_bindir}/power-button-handler
 %{_sbindir}/cirrus-fixup
 %{_sbindir}/ev2_cirrus_alsa_fixups
 %{_sbindir}/format-device

--- a/spec_files/jupiter-hw-support/power-button-handler.py
+++ b/spec_files/jupiter-hw-support/power-button-handler.py
@@ -1,0 +1,63 @@
+#!/bin/env python3 -u
+
+import evdev
+import threading
+import os
+import sys
+import subprocess
+import daemon
+import psutil
+
+powerbuttondev = None
+
+devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
+for device in devices:
+	if device.phys == "isa0060/serio0/input0":
+		powerbuttondev = device;
+	else:
+		device.close()
+
+longpresstimer = None
+
+inhibit = ['systemd-inhibit',
+	'--what=handle-power-key:handle-suspend-key:handle-hibernate-key',
+	'sleep',
+	'infinity']
+
+def inhibit():
+	for proc in psutil.process_iter():
+		if inhibit == proc.cmdline():
+			return
+
+	print ( "Starting inhibitor" )
+	with daemon.DaemonContext():
+		subprocess.call(inhibit)
+
+def uninhibit():
+	print ( "Stopping inhibitor" )
+	subprocess.call(['pkill', '-f', ' '.join(inhibit)])
+
+def longpress():
+	os.system( "~/.steam/root/ubuntu12_32/steam -ifrunning steam://longpowerpress" )
+	global longpresstimer
+	longpresstimer = None
+
+if powerbuttondev != None:
+	inhibit()
+
+	for event in powerbuttondev.read_loop():
+		if event.type == evdev.ecodes.EV_KEY and event.code == 116: # KEY_POWER
+			if event.value == 1:
+				longpresstimer = threading.Timer( 1.0, longpress )
+				longpresstimer.start()
+			elif event.value == 0:
+				if longpresstimer != None:
+					os.system( "~/.steam/root/ubuntu12_32/steam -ifrunning steam://shortpowerpress" )
+					longpresstimer.cancel()
+					longpresstimer = None
+
+	powerbuttondev.close()
+	uninhibit()
+	exit()
+
+print ( "power-button-handler.py: Can't find device for power button!" )


### PR DESCRIPTION
Moves power-button-handler into Bazzite and out of jupiter-hw-support, extends it with systemd-inhibit to block the power button only when it's running.