### PR TITLE
feat: Include ddccontrol for controlling monitor params

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,6 +45,8 @@ RUN rpm-ostree install \
     rmlint \
     compsize \
     kdeconnectd \
+    ddccontrol \
+    ddccontrol-gtk \
     input-remapper \
     system76-scheduler \
     hl2linux-selinux \


### PR DESCRIPTION
This provides a terminal utility and UI for editing monitor parameters such as brightness, contrast, and color levels on supported monitors