### PR TITLE
feat: Set SteamOS BTRFS mount flags for all BTRFS partitions

### DIFF
--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -94,6 +94,11 @@ screens:
           default: true
           packages:
           - Create Steam shortcuts: just --unstable create-steam-shortcuts
+        SteamOS BTRFS Mount Flags:
+          description: Sets SteamOS BTRFS mount flags
+          default: true
+          packages:
+          - Set SteamOS BTRFS mount flags: sudo -A just --unstable set-btrfs-flags
         Use EXT4 for SD Cards:
           description: Disable BTRFS support for SD cards for direct compatibility with SD cards formatted on stock SteamOS (Not recommended).
           default: false

--- a/system_files/deck/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/usr/share/ublue-os/just/custom.just
@@ -112,6 +112,9 @@ enable-duperemove:
   systemctl enable --now duperemove-weekly@$(systemd-escape $HOME).timer
   systemctl enable --now duperemove-weekly@$(systemd-escape /run/media/mmcblk0p1).timer
 
+set-btrfs-flags:
+  sudo sed -i 's/compress=zstd:1/noatime,lazytime,commit=120,compress-force=zstd:1,space_cache=v2,discard=async/g' /etc/fstab
+
 switch-to-ext4:
   sudo sed -i 's@STEAMOS_BTRFS_SDCARD_FORMAT_FS="btrfs"@STEAMOS_BTRFS_SDCARD_FORMAT_FS="ext4"@g' /etc/default/steamos-btrfs
 

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -66,6 +66,11 @@ screens:
           default: false
           packages:
           - Enable Big Picture Mode: just --unstable enable-big-picture
+        SteamOS BTRFS Mount Flags:
+          description: Sets SteamOS BTRFS mount flags
+          default: true
+          packages:
+          - Set SteamOS BTRFS mount flags: sudo -A just --unstable set-btrfs-flags
         System76 Scheduler:
           description: Enables System76 scheduler
           default: true

--- a/system_files/desktop/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/usr/share/ublue-os/just/custom.just
@@ -46,6 +46,9 @@ enable-wallpaper-engine:
   plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
   rm -rf /tmp/wallpaper-engine-kde-plugin
 
+set-btrfs-flags:
+  sudo sed -i 's/compress=zstd:1/noatime,lazytime,commit=120,compress-force=zstd:1,space_cache=v2,discard=async/g' /etc/fstab
+
 zram-on:
   #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)


### PR DESCRIPTION
Adds a script to just and entry to yafti setting the mount flags used by SteamOS BTRFS for all BTRFS drives in fstab