### PR TITLE
chore: Remove duplicate f3 installation from Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -166,7 +166,6 @@ RUN rpm-ostree install \
     vkBasalt \
     mangohud \
     sdgyrodsu \
-    f3 \
     python-vdf \
     python-crcmod
 


### PR DESCRIPTION
We have this marked as a dependency of jupiter-hw-support-btrfs here: https://github.com/ublue-os/bazzite/blob/71279c26b2d3583dc79f623d7503ec4af5c95da9/spec_files/jupiter-hw-support/jupiter-hw-support-btrfs.spec#L31