### PR TITLE
feat: Improve management of Flatpaks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -185,6 +185,10 @@ RUN rpm-ostree install \
     git clone https://gitlab.com/evlaV/jupiter-dock-updater-bin.git --depth 1 /tmp/jupiter-dock-updater-bin && \
     mv -v /tmp/jupiter-dock-updater-bin/packaged/usr/lib/jupiter-dock-updater /usr/lib/jupiter-dock-updater
 
+# Add Flathub
+RUN flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+    flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
+
 # Cleanup & Finalize
 RUN rm /usr/share/applications/winetricks.desktop && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-info && \

--- a/Containerfile
+++ b/Containerfile
@@ -99,8 +99,9 @@ RUN rm /usr/share/applications/shredder.desktop && \
     mkdir -p /etc/flatpak/remotes.d && \
     wget -q https://dl.flathub.org/repo/flathub.flatpakrepo -P /etc/flatpak/remotes.d && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
-    mkdir -p /etc/flatpak/flathub && \
+    mkdir -p /etc/flatpak/{flathub,objects} && \
     cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
+    cp -r /var/lib/flatpak/repo/objects/* /etc/flatpak/objects && \
     systemctl unmask flatpak-system-install.service && \
     systemctl enable flatpak-system-install.service && \
     systemctl disable rpm-ostreed-automatic.timer && \
@@ -202,8 +203,9 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
     flatpak remove --system --noninteractive --all && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
-    rm -rf /etc/flatpak/flathub/* && \
+    rm -rf /etc/flatpak/{flathub,objects}/* && \
     cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
+    cp -r /var/lib/flatpak/repo/objects/* /etc/flatpak/objects && \
     systemctl enable plasma-autologin.service && \
     systemctl enable jupiter-fan-control.service && \
     systemctl enable vpower.service && \

--- a/Containerfile
+++ b/Containerfile
@@ -79,8 +79,7 @@ RUN if grep -v "nvidia" <<< "${IMAGE_NAME}"; then \
 ; fi 
 
 # Add Flathub
-RUN flatpak remove --system --noninteractive --all && \
-    flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+RUN flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
     flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
 
 # Cleanup & Finalize
@@ -100,6 +99,10 @@ RUN rm /usr/share/applications/shredder.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
+    flatpak remove --system --noninteractive --all && \
+    cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
+    systemctl unmask flatpak-system-install.service && \
+    systemctl enable flatpak-system-install.service && \
     systemctl disable rpm-ostreed-automatic.timer && \
     systemctl --global enable ublue-update.timer && \
     systemctl enable input-remapper.service && \
@@ -197,6 +200,8 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-wallpaper-engine-kde-plugin.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
+    flatpak remove --system --noninteractive --all && \
+    cat etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
     systemctl enable plasma-autologin.service && \
     systemctl enable jupiter-fan-control.service && \
     systemctl enable vpower.service && \

--- a/Containerfile
+++ b/Containerfile
@@ -202,7 +202,7 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
     flatpak remove --system --noninteractive --all && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
-    mkdir -p /etc/flatpak/flathub && \
+    rm -rf /etc/flatpak/flathub/* && \
     cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
     systemctl enable plasma-autologin.service && \
     systemctl enable jupiter-fan-control.service && \

--- a/Containerfile
+++ b/Containerfile
@@ -78,6 +78,10 @@ RUN if grep -v "nvidia" <<< "${IMAGE_NAME}"; then \
         rocm-opencl \
 ; fi 
 
+# Add Flathub
+RUN flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+    flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
+
 # Cleanup & Finalize
 RUN rm /usr/share/applications/shredder.desktop && \
     rm /usr/share/vulkan/icd.d/lvp_icd.*.json && \

--- a/Containerfile
+++ b/Containerfile
@@ -79,7 +79,8 @@ RUN if grep -v "nvidia" <<< "${IMAGE_NAME}"; then \
 ; fi 
 
 # Add Flathub
-RUN flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+RUN flatpak remove --system --noninteractive --all && \
+    flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
     flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
 
 # Cleanup & Finalize

--- a/Containerfile
+++ b/Containerfile
@@ -98,9 +98,9 @@ RUN rm /usr/share/applications/shredder.desktop && \
     flatpak remove --system --noninteractive --all && \
     mkdir -p /etc/flatpak/remotes.d && \
     wget -q https://dl.flathub.org/repo/flathub.flatpakrepo -P /etc/flatpak/remotes.d && \
-    mkdir -p /etc/flatpak/cache && \
-    export FLATPAK_SYSTEM_CACHE_DIR='/etc/flatpak/cache' && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
+    mkdir -p /etc/flatpak/flathub && \
+    cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
     systemctl unmask flatpak-system-install.service && \
     systemctl enable flatpak-system-install.service && \
     systemctl disable rpm-ostreed-automatic.timer && \
@@ -201,7 +201,9 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
     flatpak remove --system --noninteractive --all && \
-    cat etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
+    cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
+    mkdir -p /etc/flatpak/flathub && \
+    cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
     systemctl enable plasma-autologin.service && \
     systemctl enable jupiter-fan-control.service && \
     systemctl enable vpower.service && \

--- a/Containerfile
+++ b/Containerfile
@@ -76,11 +76,7 @@ RUN if grep -v "nvidia" <<< "${IMAGE_NAME}"; then \
     rpm-ostree install \
         rocm-hip \
         rocm-opencl \
-; fi 
-
-# Add Flathub
-RUN flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
-    flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
+; fi
 
 # Cleanup & Finalize
 RUN rm /usr/share/applications/shredder.desktop && \
@@ -100,6 +96,8 @@ RUN rm /usr/share/applications/shredder.desktop && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
     flatpak remove --system --noninteractive --all && \
+    mkdir -p /etc/flatpak/remotes.d && \
+    wget -q https://dl.flathub.org/repo/flathub.flatpakrepo -P /etc/flatpak/remotes.d && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
     systemctl unmask flatpak-system-install.service && \
     systemctl enable flatpak-system-install.service && \
@@ -184,10 +182,6 @@ RUN rpm-ostree install \
     python-crcmod && \
     git clone https://gitlab.com/evlaV/jupiter-dock-updater-bin.git --depth 1 /tmp/jupiter-dock-updater-bin && \
     mv -v /tmp/jupiter-dock-updater-bin/packaged/usr/lib/jupiter-dock-updater /usr/lib/jupiter-dock-updater
-
-# Add Flathub
-RUN flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
-    flatpak remote-modify --system flathub --no-filter --title="Flathub (System)"
 
 # Cleanup & Finalize
 RUN rm /usr/share/applications/winetricks.desktop && \

--- a/Containerfile
+++ b/Containerfile
@@ -98,6 +98,8 @@ RUN rm /usr/share/applications/shredder.desktop && \
     flatpak remove --system --noninteractive --all && \
     mkdir -p /etc/flatpak/remotes.d && \
     wget -q https://dl.flathub.org/repo/flathub.flatpakrepo -P /etc/flatpak/remotes.d && \
+    mkdir -p /etc/flatpak/cache && \
+    export FLATPAK_SYSTEM_CACHE_DIR='/etc/flatpak/cache' && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
     systemctl unmask flatpak-system-install.service && \
     systemctl enable flatpak-system-install.service && \

--- a/system_files/deck/etc/flatpak/install
+++ b/system_files/deck/etc/flatpak/install
@@ -1,0 +1,4 @@
+com.github.Matoking.protontricks
+net.davidotek.pupgui2
+org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
+org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -36,11 +36,6 @@ screens:
           default: false
           packages:
           - Retrieve Decky: sudo -A just --unstable get-decky
-        Chiaki4Deck:
-          description: PlayStation Remote Play
-          default: false
-          packages:
-          - Install Chiaki4Deck: just --unstable get-chiaki
         EmuDeck:
           description: |
             A utility for installing and configuring emulators on the Steam Deck
@@ -152,8 +147,9 @@ screens:
           default: false
           packages:
           - Bottles: com.usebottles.bottles
+          - Chiaki4Deck (PlayStation Remote Play): io.github.streetpea.Chiaki4deck
           - Discord: com.discordapp.Discord
-          - DOSBox Staging: io.github.dosbox-staging 
+          - DOSBox Staging: io.github.dosbox-staging
           - GeForce NOW Electron: io.github.hmlendea.geforcenow-electron
           - Heroic Games Launcher (GOG &amp; Epic): com.heroicgameslauncher.hgl
           - itch: io.itch.itch

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -134,15 +134,6 @@ screens:
       show_terminal: true
       package_manager: yafti.plugin.flatpak
       groups:
-        Bazzite:
-          description: Core Applications
-          default: true
-          packages:
-          - MangoHud (Flatpak): org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
-          - Mozilla Firefox: org.mozilla.firefox
-          - Protontricks: com.github.Matoking.protontricks
-          - ProtonUp-Qt (Proton Updater): net.davidotek.pupgui2
-          - vkBasalt (Flatpak): org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08
         Web Browsers:
           description: Additional browsers to complement Firefox
           default: false
@@ -151,6 +142,7 @@ screens:
           - Google Chrome: com.google.Chrome
           - LibreWolf: io.gitlab.librewolf-community
           - Microsoft Edge: com.microsoft.Edge
+          - Mozilla Firefox: org.mozilla.firefox
           - Opera: com.opera.Opera
         Gaming:
           description: "Rock and Stone!"

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -126,7 +126,6 @@ screens:
       - run: /usr/lib/fedora-third-party/fedora-third-party-opt-out
       - run: /usr/bin/fedora-third-party disable
       - run: flatpak remote-delete fedora --force
-      - run: flatpak remove --system --noninteractive --all
       - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   applications:
     source: yafti.screen.package

--- a/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/usr/share/ublue-os/firstboot/yafti.yml
@@ -133,6 +133,9 @@ screens:
       title: Application Installation
       show_terminal: true
       package_manager: yafti.plugin.flatpak
+      package_manager_defaults:
+        user: true
+        system: false
       groups:
         Web Browsers:
           description: Additional browsers to complement Firefox

--- a/system_files/deck/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/usr/share/ublue-os/just/custom.just
@@ -59,11 +59,6 @@ get-boilr:
     -O ~/Desktop/BoilR
   chmod +x ~/Desktop/BoilR
 
-get-chiaki:
-  flatpak install \
-    $(curl -s https://api.github.com/repos/streetpea/chiaki4deck/releases/latest | \
-    jq -r ".assets[] | select(.name | test(\"flatpakref\")) | .browser_download_url")
-
 enable-wallpaper-engine:
   echo 'Installing Wallpaper Engine Plugin for KDE...'
   git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin

--- a/system_files/deck/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/usr/share/ublue-os/just/custom.just
@@ -29,7 +29,7 @@ get-emudeck:
 get-steamcmd:
   echo 'Installing SteamCMD...'
   wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz -O /tmp/steamcmd.tar.gz
-  tar -xvzf steamcmd.tar.gz -C ~/.steam
+  tar -xvzf /tmp/steamcmd.tar.gz -C ~/.steam
   rm /tmp/steamcmd.tar.gz
 
 enable-system76-scheduler:

--- a/system_files/desktop/etc/flatpak/install
+++ b/system_files/desktop/etc/flatpak/install
@@ -1,0 +1,3 @@
+net.davidotek.pupgui2
+org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
+org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08

--- a/system_files/desktop/etc/systemd/system/flatpak-system-install.service
+++ b/system_files/desktop/etc/systemd/system/flatpak-system-install.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Install System Flatpak on boot
+Documentation=https://github.com/ublue-os/endlish-oesque/issues/10
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ublue-flatpak-system-install
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat /etc/flatpaks | while read line; do
+  flatpak install --system --noninteractive --no-pull flathub $line
+done && mv /etc/flatpak/install /etc/flatpak/installed

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-cat /etc/flatpaks | while read line; do
+cat /etc/flatpak/install | while read line; do
   flatpak install --system --noninteractive --no-pull flathub $line
 done && mv /etc/flatpak/install /etc/flatpak/installed

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -6,5 +6,5 @@ if [[ -f '/etc/flatpak/install' ]]; then
   cat /etc/flatpak/install | while read line; do
     flatpak install --system --noninteractive --no-pull flathub $line
   done && mv /etc/flatpak/install /etc/flatpak/installed
-  rm -rf /etc/flatpak/{flathub,objects}
 fi
+rm -rf /etc/flatpak/{flathub,objects}

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -2,8 +2,9 @@
 
 if [[ -f '/etc/flatpak/install' ]]; then
   cp -r /etc/flatpak/flathub/* /var/lib/flatpak/repo/refs/remotes/flathub
+  cp -r /etc/flatpak/objects/* /var/lib/flatpak/repo/objects
   cat /etc/flatpak/install | while read line; do
     flatpak install --system --noninteractive --no-pull flathub $line
   done && mv /etc/flatpak/install /etc/flatpak/installed
-  rm -rf /etc/flatpak/flathub
+  rm -rf /etc/flatpak/{flathub,objects}
 fi

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 if [[ -f '/etc/flatpak/install' ]]; then
-  export FLATPAK_SYSTEM_CACHE_DIR='/etc/flatpak/cache'
+  cp -r /etc/flatpak/flathub/* /var/lib/flatpak/repo/refs/remotes/flathub
   cat /etc/flatpak/install | while read line; do
     flatpak install --system --noninteractive --no-pull flathub $line
   done && mv /etc/flatpak/install /etc/flatpak/installed
-  unset FLATPAK_SYSTEM_CACHE_DIR
-  rm -rf /etc/flatpak/cache
+  rm -rf /etc/flatpak/flathub
 fi

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 if [[ -f '/etc/flatpak/install' ]]; then
+  export FLATPAK_SYSTEM_CACHE_DIR='/etc/flatpak/cache'
   cat /etc/flatpak/install | while read line; do
     flatpak install --system --noninteractive --no-pull flathub $line
   done && mv /etc/flatpak/install /etc/flatpak/installed
+  unset FLATPAK_SYSTEM_CACHE_DIR
+  rm -rf /etc/flatpak/cache
 fi

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-cat /etc/flatpak/install | while read line; do
-  flatpak install --system --noninteractive --no-pull flathub $line
-done && mv /etc/flatpak/install /etc/flatpak/installed
+if [[ -f '/etc/flatpak/install' ]]; then
+  cat /etc/flatpak/install | while read line; do
+    flatpak install --system --noninteractive --no-pull flathub $line
+  done && mv /etc/flatpak/install /etc/flatpak/installed
+fi

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -97,18 +97,6 @@ screens:
   applications:
     source: yafti.screen.package
     values:
-      title: Application Installation
-      show_terminal: true
-      package_manager: yafti.plugin.flatpak
-      groups:
-        Bazzite:
-          description: Core Applications
-          default: true
-          packages:
-          - MangoHud (Flatpak): org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
-          - Mozilla Firefox: org.mozilla.firefox
-          - ProtonUp-Qt (Proton Updater): net.davidotek.pupgui2
-          - vkBasalt (Flatpak): org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08
         Web Browsers:
           description: Additional browsers to complement Firefox
           default: false
@@ -117,6 +105,7 @@ screens:
           - Google Chrome: com.google.Chrome
           - LibreWolf: io.gitlab.librewolf-community
           - Microsoft Edge: com.microsoft.Edge
+          - Mozilla Firefox: org.mozilla.firefox
           - Opera: com.opera.Opera
         Gaming:
           description: "Rock and Stone!"

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -100,6 +100,9 @@ screens:
       title: Application Installation
       show_terminal: true
       package_manager: yafti.plugin.flatpak
+      package_manager_defaults:
+        user: true
+        system: false
       groups:
         Web Browsers:
           description: Additional browsers to complement Firefox

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -97,6 +97,10 @@ screens:
   applications:
     source: yafti.screen.package
     values:
+      title: Application Installation
+      show_terminal: true
+      package_manager: yafti.plugin.flatpak
+      groups:
         Web Browsers:
           description: Additional browsers to complement Firefox
           default: false

--- a/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/usr/share/ublue-os/firstboot/yafti.yml
@@ -93,7 +93,6 @@ screens:
       - run: /usr/lib/fedora-third-party/fedora-third-party-opt-out
       - run: /usr/bin/fedora-third-party disable
       - run: flatpak remote-delete fedora --force
-      - run: flatpak remove --system --noninteractive --all
       - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   applications:
     source: yafti.screen.package


### PR DESCRIPTION
Inspired by and based on the work being done on Endlish-Oesque/Beyond, namely: https://github.com/ublue-os/beyond/pull/88

- Introduces script that installs system flatpaks automatically
- Moves system flatpaks out of yafti and defaults to user installation
- Adds Flathub as a system flatpakrepo by default
- Fixes errors/warnings from Flatpaks on desktop installations in yafti

This also moves Firefox to the web browser section instead of including it as a system package, letting users use the desktop shortcut to install it (matches SteamOS), select it in the web browser section, or select any other browser they are interested in