### PR TITLE
chore: Remove layered lutris package

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -162,7 +162,6 @@ RUN rpm-ostree install \
 # Install new packages & dock updater - done manually due to proprietary parts preventing it from being on Copr
 RUN rpm-ostree install \
     steam \
-    lutris \
     gamescope \
     gamescope-session \
     jupiter-fan-control \


### PR DESCRIPTION
Test PR to see if this resolves our dependency issues, if it does we can continue with this based on:

1. Existing Steam Deck guides assume flatpak Lutris
2. Layered lutris installs wine as a layer, which is a waste of space on 64GB decks
3. Only feature gained is LatencyFleX, which does not outweigh 1 & 2.