### PR TITLE
fix(deck): Address large image sizes due to layering Flatpak objects

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -102,6 +102,7 @@ RUN rm /usr/share/applications/shredder.desktop && \
     mkdir -p /etc/flatpak/remotes.d && \
     wget -q https://dl.flathub.org/repo/flathub.flatpakrepo -P /etc/flatpak/remotes.d && \
     cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
+    cat /etc/flatpak/deck | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
     mkdir -p /etc/flatpak/{flathub,objects} && \
     cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
     cp -r /var/lib/flatpak/repo/objects/* /etc/flatpak/objects && \
@@ -203,11 +204,6 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-wallpaper-engine-kde-plugin.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
-    flatpak remove --system --noninteractive --all && \
-    cat /etc/flatpak/install | while read line; do flatpak install --system --noninteractive --no-deploy flathub $line; done && \
-    rm -rf /etc/flatpak/{flathub,objects}/* && \
-    cp -r /var/lib/flatpak/repo/refs/remotes/flathub/* /etc/flatpak/flathub && \
-    cp -r /var/lib/flatpak/repo/objects/* /etc/flatpak/objects && \
     systemctl enable plasma-autologin.service && \
     systemctl enable jupiter-fan-control.service && \
     systemctl enable vpower.service && \

--- a/system_files/deck/etc/flatpak/install
+++ b/system_files/deck/etc/flatpak/install
@@ -1,4 +1,0 @@
-com.github.Matoking.protontricks
-net.davidotek.pupgui2
-org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
-org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08

--- a/system_files/desktop/etc/flatpak/deck
+++ b/system_files/desktop/etc/flatpak/deck
@@ -1,0 +1,1 @@
+com.github.Matoking.protontricks

--- a/system_files/desktop/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/usr/bin/ublue-flatpak-system-install
@@ -7,4 +7,13 @@ if [[ -f '/etc/flatpak/install' ]]; then
     flatpak install --system --noninteractive --no-pull flathub $line
   done && mv /etc/flatpak/install /etc/flatpak/installed
 fi
-rm -rf /etc/flatpak/{flathub,objects}
+
+if [[ -f '/etc/flatpak/deck' ]]; then
+  if grep "deck" <<< $(rpm-ostree status); then
+    cat /etc/flatpak/deck | while read line; do
+      flatpak install --system --noninteractive --no-pull flathub $line
+    done && cat /etc/flatpak/deck >> /etc/flatpak/installed
+  fi
+fi
+
+rm -rf /etc/flatpak/{deck,flathub,objects}


### PR DESCRIPTION
Installs all flatpaks without deploying them in the base image, and uses a configuration file to deploy Deck flatpaks