### PR TITLE
fix(deck/autologin): Use GNOME on Xorg

### DIFF
--- a/system_files/deck/silverblue/usr/bin/gnome-xorg-oneshot
+++ b/system_files/deck/silverblue/usr/bin/gnome-xorg-oneshot
@@ -25,7 +25,7 @@ function check_sentinel()
     cd "$HOME"
     cd "$config_dir"
     sentinel_value="$(cat "$SENTINEL_FILE")"
-    if [[ "$sentinel_value" == "wayland" ]]; then
+    if [[ "$sentinel_value" == "x11" ]]; then
       echo "/usr/bin/gnome-session"
     else
       return 1

--- a/system_files/deck/silverblue/usr/bin/steamos-session-select
+++ b/system_files/deck/silverblue/usr/bin/steamos-session-select
@@ -13,14 +13,14 @@ SENTINEL_FILE="steamos-session-select"
 CHECK_FILE="/etc/sddm.conf.d/steamos.conf"
 
 session="${1:-gamescope}"
-session_type="wayland"
+session_type="x11"
 
 session_launcher="gamescope-session"
 create_sentinel=""
 
 if [[ "$2" == "--sentinel-created" ]]; then
   SENTINEL_CREATED=1
-  session_type="wayland"
+  session_type="x11"
 fi
 
 # Update config sentinel
@@ -36,7 +36,7 @@ if [[ -z $SENTINEL_CREATED ]]; then
     if [[ -f "steamos-session-type" ]]; then
       cp steamos-session-type "$SENTINEL_FILE"
     else
-      echo "wayland" > "$SENTINEL_FILE"
+      echo "x11" > "$SENTINEL_FILE"
     fi
     cat "$SENTINEL_FILE"
   )
@@ -52,13 +52,13 @@ fi
 # We use "plasma" as "desktop" to hook up to SteamOS's scripts
 case "$session" in
   plasma-wayland-persistent)
-    session_launcher="gnome-session"
+    session_launcher="gnome-xorg"
   ;;
   plasma-x11-persistent)
-    session_launcher="gnome-session"
+    session_launcher="gnome-xorg"
   ;;
   desktop|plasma)
-    session_launcher="gnome-session-oneshot"
+    session_launcher="gnome-xorg-oneshot"
     create_sentinel=1
   ;;
   gamescope)

--- a/system_files/deck/silverblue/usr/share/xsessions/gnome-xorg-oneshot.desktop
+++ b/system_files/deck/silverblue/usr/share/xsessions/gnome-xorg-oneshot.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=GNOME on Wayland (single time session)
+Name=GNOME on Xorg (single time session)
 Comment=This session logs you into GNOME one time
-Exec=/usr/bin/gnome-session-oneshot
-TryExec=/usr/bin/gnome-session-oneshot
+Exec=/usr/bin/gnome-xorg-oneshot
+TryExec=/usr/bin/gnome-xorg-oneshot
 Type=Application
 DesktopNames=GNOME
 X-GDM-SessionRegisters=true

--- a/system_files/desktop/silverblue/usr/bin/gnome-autologin
+++ b/system_files/desktop/silverblue/usr/bin/gnome-autologin
@@ -10,5 +10,5 @@ if [ ! -f ${SDDM_CONF} ]; then
 fi
 
 # Configure autologin
-sed -i 's/.*Session=.*/Session=gnome-session.desktop/g' ${SDDM_CONF}
+sed -i 's/.*Session=.*/Session=gnome-xorg.desktop/g' ${SDDM_CONF}
 sed -i 's/.*User=.*/User='${USER}'/g' ${SDDM_CONF}


### PR DESCRIPTION
Beneficial for Steam Deck as Steam Input doesn't function under Wayland on desktops yet, and beneficial for HTPCs as Nvidia doesn't handle Wayland quite well as of yet