### PR TITLE
fix: Issues with conditionals

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -101,6 +101,7 @@ RUN if grep -v "gnome" <<< "${IMAGE_NAME}"; then \
         gnome-shell-extension-appindicator \
         gnome-shell-extension-gsconnect \
         gnome-shell-extension-system76-scheduler && \
+        openssh-askpass \
     rpm-ostree override remove \
         gnome-tour \
         yelp \

--- a/Containerfile
+++ b/Containerfile
@@ -71,7 +71,7 @@ RUN rpm-ostree install \
     yad
 
 # Configure KDE & GNOME
-RUN if grep -v "gnome" <<< "${IMAGE_NAME}"; then \
+RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
     rpm-ostree override replace \
     --experimental \
     --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
@@ -108,7 +108,7 @@ RUN if grep -v "gnome" <<< "${IMAGE_NAME}"; then \
 ; fi
 
 # Install ROCM on non-Nvidia images
-RUN if grep -v "nvidia" <<< "${IMAGE_NAME}"; then \
+RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
     rpm-ostree install \
         rocm-hip \
         rocm-opencl \
@@ -145,7 +145,7 @@ RUN rm /usr/share/applications/shredder.desktop && \
     systemctl --global enable ublue-update.timer && \
     systemctl enable displaylink.service && \
     systemctl enable input-remapper.service && \
-    if grep "gnome" <<< "${IMAGE_NAME}"; then \
+    if grep -q "gnome" <<< "${IMAGE_NAME}"; then \
         systemctl disable gdm.service && \
         systemctl enable sddm.service && \
         rm /usr/share/applications/yad-icon-browser.desktop \
@@ -188,7 +188,7 @@ RUN rpm-ostree install \
 RUN rpm-ostree override remove \
     ddccontrol \
     ddccontrol-gtk && \
-    if grep -v "gnome" <<< "${IMAGE_NAME}"; then \
+    if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
         rpm-ostree override remove \
             steamdeck-kde-presets-desktop \
     ; fi
@@ -209,7 +209,7 @@ RUN rpm-ostree override replace \
         udisks2
 
 # Configure KDE & GNOME
-RUN if grep -v "gnome" <<< "${IMAGE_NAME}"; then \
+RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
     rpm-ostree override remove \
         krfb \
         krfb-libs && \
@@ -261,10 +261,10 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-wallpaper-engine-kde-plugin.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
-    if grep "gnome" <<< "${IMAGE_NAME}"; then \
+    if grep -q "gnome" <<< "${IMAGE_NAME}"; then \
         systemctl enable gnome-autologin.service \
     ; fi && \
-    if grep -v "gnome" <<< "${IMAGE_NAME}"; then \
+    if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
         systemctl enable plasma-autologin.service \
     ; fi && \
     systemctl enable jupiter-fan-control.service && \

--- a/Containerfile
+++ b/Containerfile
@@ -100,8 +100,8 @@ RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
         gnome-shell-extension-user-theme \
         gnome-shell-extension-appindicator \
         gnome-shell-extension-gsconnect \
-        gnome-shell-extension-system76-scheduler && \
-        openssh-askpass \
+        gnome-shell-extension-system76-scheduler \
+        openssh-askpass && \
     rpm-ostree override remove \
         gnome-tour \
         yelp \

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Source Bazzite defaults
+source /etc/default/bazzite
+
 # Simply launches the "yafti" GUI with the uBlue image's configuration.
 /usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml
 

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -111,13 +111,6 @@ screens:
           default: true
           packages:
           - Enable System76 Scheduler: just --unstable enable-system76-scheduler
-        Wallpaper Engine:
-          description: Enables Wallpaper Engine
-          condition:
-            run: grep -v "gnome" <<< $(rpm-ostree status)
-          default: true
-          packages:
-          - Enable Wallpaper Engine: just --unstable enable-wallpaper-engine
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent
     values:
@@ -251,6 +244,16 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
+  enable-wallpaper-engine:
+    source: yafti.screen.consent
+    values:
+      title: Enabling Wallpaper Engine
+      condition:
+        run: grep -v "gnome" <<< $(rpm-ostree status)
+      description: |
+        Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
+      actions:
+      - run: just --unstable enable-wallpaper-engine
   setup-gradience:
     source: yafti.screen.consent
     values:

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -237,26 +237,14 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
-  enable-wallpaper-engine:
+  setup-desktop-environment:
     source: yafti.screen.consent
     values:
-      title: Enabling Wallpaper Engine
-      condition:
-        run: grep -qv "gnome" <<< $(cat /etc/default/bazzite)
+      title: Setting up your Desktop Environment
       description: |
-        Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
+        Configures your desktop environment, including needed plugins/extensions.
       actions:
-      - run: just --unstable enable-wallpaper-engine
-  setup-gradience:
-    source: yafti.screen.consent
-    values:
-      title: Setting up Gradience
-      condition:
-        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
-      description: |
-        Adds Valve-inspired themes to Gradience
-      actions:
-      - run: just --unstable setup-gradience
+      - run: just --unstable setup-desktop-environment
   theme:
     source: yafti.screen.title
     values:

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -52,13 +52,6 @@ screens:
           default: false
           packages:
           - Retrieve Greenlight: just --unstable get-greenlight
-        GSConnect:
-          condition:
-            run: grep "gnome" <<< $(rpm-ostree status)
-          description: A KDE connect implementation for GNOME
-          default: true
-          packages:
-          - Enable GSConnect: just --unstable enable-gsconnect
         Hide GRUB Menu:
           description: |
             NOTE: Press the escape key before boot to show the menu

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -231,7 +231,6 @@ screens:
           - Bitwarden: com.bitwarden.desktop
           - Calibre: com.calibre_ebook.calibre
           - Fedora Media Writer: org.fedoraproject.MediaWriter
-          - Flatseal Permissions Manager: com.github.tchx84.Flatseal
           - KeePassXC: org.keepassxc.KeePassXC
           - OpenRGB: org.openrgb.OpenRGB
           - qBittorrent: org.qbittorrent.qBittorrent

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -249,7 +249,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
+        run: [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -47,13 +47,6 @@ screens:
           default: true
           packages:
           - Enable Gamescope Autologin: just --unstable enable-gamescope-autologin
-        Gradience:
-          description: Adds Valve-inspired themes to Gradience
-          condition:
-            run: grep "gnome" <<< $(rpm-ostree status)
-          default: true
-          packages:
-          - Setup Gradience: just --unstable setup-gradience
         Greenlight:
           description: A utility for xCloud and xHome streaming
           default: false
@@ -258,6 +251,16 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
+  setup-gradience:
+    source: yafti.screen.consent
+    values:
+      title: Setting up Gradience
+      condition:
+        run: grep "gnome" <<< $(rpm-ostree status)
+      description: |
+        Adds Valve-inspired themes to Gradience
+      actions:
+      - run: just --unstable setup-gradience
   theme:
     source: yafti.screen.title
     values:

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -109,7 +109,7 @@ screens:
     values:
       title: Setting up Flathub
       condition:
-        run: flatpak remotes --system | grep fedora
+        run: flatpak remotes --system | grep -q fedora
       description: |
         WARNING: This will modify your Flatpaks if you are rebasing! If you do not want to do this exit the installer.
       actions:
@@ -242,7 +242,7 @@ screens:
     values:
       title: Enabling Wallpaper Engine
       condition:
-        run: grep -v "gnome" <<< $(cat /etc/default/bazzite)
+        run: grep -qv "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
       actions:
@@ -252,7 +252,7 @@ screens:
     values:
       title: Setting up Gradience
       condition:
-        run: grep "gnome" <<< $(cat /etc/default/bazzite)
+        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Adds Valve-inspired themes to Gradience
       actions:
@@ -262,7 +262,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: grep "gnome" <<< $(cat /etc/default/bazzite)
+        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -242,7 +242,7 @@ screens:
     values:
       title: Enabling Wallpaper Engine
       condition:
-        run: grep -v "gnome" <<< $(rpm-ostree status)
+        run: grep -v "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
       actions:
@@ -252,7 +252,7 @@ screens:
     values:
       title: Setting up Gradience
       condition:
-        run: grep "gnome" <<< $(rpm-ostree status)
+        run: grep "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Adds Valve-inspired themes to Gradience
       actions:
@@ -262,7 +262,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: grep "gnome" <<< $(rpm-ostree status)
+        run: grep "gnome" <<< $(cat /etc/default/bazzite)
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -1,6 +1,6 @@
 enable-gamescope-autologin:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     systemctl disable --now gnome-autologin
   else
     systemctl disable --now plasma-autologin
@@ -10,7 +10,7 @@ enable-gamescope-autologin:
 enable-desktop-autologin:
   #!/usr/bin/env bash
   systemctl disable --now gamescope-autologin
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     systemctl enable --now gnome-autologin
   else
     systemctl enable --now plasma-autologin
@@ -44,7 +44,7 @@ get-steamcmd:
 
 install-extensions-cli:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     pip install --upgrade gnome-extensions-cli
   else
     echo "This is only supported under GNOME."
@@ -52,7 +52,7 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(rpm-ostree status); then
+  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
@@ -86,7 +86,7 @@ get-boilr:
 
 enable-wallpaper-engine:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(rpm-ostree status); then
+  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
@@ -97,7 +97,7 @@ enable-wallpaper-engine:
 
 setup-gradience:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
   else 
@@ -106,7 +106,7 @@ setup-gradience:
 
 enable-vapor-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -120,7 +120,7 @@ enable-vapor-theme:
 
 enable-vgui2-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -1,18 +1,20 @@
 enable-gamescope-autologin:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     systemctl disable --now gnome-autologin
-  else
+  elif [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     systemctl disable --now plasma-autologin
   fi
   systemctl enable --now gamescope-autologin
 
 enable-desktop-autologin:
   #!/usr/bin/env bash
+  source /etc/default/bazzite
   systemctl disable --now gamescope-autologin
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     systemctl enable --now gnome-autologin
-  else
+  elif [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     systemctl enable --now plasma-autologin
   fi
 
@@ -44,7 +46,8 @@ get-steamcmd:
 
 install-extensions-cli:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     pip install --upgrade gnome-extensions-cli
   else
     echo "This is only supported under GNOME."
@@ -52,7 +55,8 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
@@ -60,7 +64,7 @@ enable-system76-scheduler:
     systemctl enable --now com.system76.Scheduler.service
     kcmshell5 kcm_kwin_scripts
     rm -rf /tmp/kwin-system76-scheduler-integration
-  else
+  elif [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     echo 'Enabling System76-Scheduler GNOME extension...'
     gnome-shell-extension-cl -e s76-scheduler@mattjakeman.com
   fi
@@ -85,7 +89,8 @@ get-boilr:
 
 setup-desktop-environment:
   #!/usr/bin/env bash
-  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     echo 'Configuring GNOME extensions...'
     gnome-shell-extension-cl -d background-logo@fedorahosted.org
     gnome-shell-extension-cl -e appindicatorsupport@rgcjonas.gmail.com
@@ -95,7 +100,7 @@ setup-desktop-environment:
     mkdir -p $HOME/.config/presets/user/
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
-  else 
+  elif [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
@@ -104,7 +109,8 @@ setup-desktop-environment:
 
 enable-vapor-theme:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
@@ -119,7 +125,8 @@ enable-vapor-theme:
 
 enable-vgui2-theme:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -62,8 +62,7 @@ enable-system76-scheduler:
     rm -rf /tmp/kwin-system76-scheduler-integration
   else
     echo 'Enabling System76-Scheduler GNOME extension...'
-    gsettings set org.gnome.shell enabled-extensions ['appindicatorsupport@rgcjonas.gmail.com', 'gsconnect@andyholmes.github.io', 's76-scheduler@mattjakeman.com', 'tofumenu@tofu', 'user-theme@gnome-shell-extensions.gcampax.github.com']
-    gsettings set org.gnome.shell.extensions.fedora-menu menu-button-icon-size 20
+    gnome-shell-extension-cl -e s76-scheduler@mattjakeman.com
   fi
 
 install-nix:
@@ -84,29 +83,29 @@ get-boilr:
     -O ~/Desktop/BoilR
   chmod +x ~/Desktop/BoilR
 
-enable-wallpaper-engine:
+setup-desktop-environment:
   #!/usr/bin/env bash
   if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+    echo 'Configuring GNOME extensions...'
+    gnome-shell-extension-cl -d background-logo@fedorahosted.org
+    gnome-shell-extension-cl -e appindicatorsupport@rgcjonas.gmail.com
+    gnome-shell-extension-cl -e gsconnect@andyholmes.github.io
+    gnome-shell-extension-cl -e tofumenu@tofu
+    gsettings set org.gnome.shell.extensions.fedora-menu menu-button-icon-size 20
+    mkdir -p $HOME/.config/presets/user/
+    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
+    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
+  else 
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
     rm -rf /tmp/wallpaper-engine-kde-plugin
-  else
-    echo "This is only supported under KDE."
-  fi
-
-setup-gradience:
-  #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
-    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
-    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
-  else 
-    echo "This is only supported under GNOME."
   fi
 
 enable-vapor-theme:
   #!/usr/bin/env bash
   if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+    gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -121,6 +120,7 @@ enable-vapor-theme:
 enable-vgui2-theme:
   #!/usr/bin/env bash
   if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+    gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -52,8 +52,8 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  echo 'Installing System76-Scheduler plugin for KDE...'
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep -v "gnome" <<< $(rpm-ostree status); then
+    echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
     systemctl --user enable --now com.system76.Scheduler.dbusproxy.service
@@ -61,6 +61,7 @@ enable-system76-scheduler:
     kcmshell5 kcm_kwin_scripts
     rm -rf /tmp/kwin-system76-scheduler-integration
   else
+    echo 'Enabling System76-Scheduler GNOME extension...'
     gsettings set org.gnome.shell enabled-extensions ['appindicatorsupport@rgcjonas.gmail.com', 'gsconnect@andyholmes.github.io', 's76-scheduler@mattjakeman.com', 'tofumenu@tofu', 'user-theme@gnome-shell-extensions.gcampax.github.com']
     gsettings set org.gnome.shell.extensions.fedora-menu menu-button-icon-size 20
   fi

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -1,6 +1,6 @@
 enable-gamescope-autologin:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     systemctl disable --now gnome-autologin
   else
     systemctl disable --now plasma-autologin
@@ -10,7 +10,7 @@ enable-gamescope-autologin:
 enable-desktop-autologin:
   #!/usr/bin/env bash
   systemctl disable --now gamescope-autologin
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     systemctl enable --now gnome-autologin
   else
     systemctl enable --now plasma-autologin
@@ -44,7 +44,7 @@ get-steamcmd:
 
 install-extensions-cli:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     pip install --upgrade gnome-extensions-cli
   else
     echo "This is only supported under GNOME."
@@ -52,7 +52,7 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
@@ -86,7 +86,7 @@ get-boilr:
 
 enable-wallpaper-engine:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
@@ -97,7 +97,7 @@ enable-wallpaper-engine:
 
 setup-gradience:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
   else 
@@ -106,7 +106,7 @@ setup-gradience:
 
 enable-vapor-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -120,7 +120,7 @@ enable-vapor-theme:
 
 enable-vgui2-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -135,7 +135,7 @@ enable-vgui2-theme:
 deckswap-on:
   #!/usr/bin/env bash
   STATUS=$(systemctl status deckswap.service)
-  if grep 'inactive' <<< ${STATUS}; then
+  if grep -q 'inactive' <<< ${STATUS}; then
     systemctl enable deckswap.service
     echo 'deckswap enabled. Please reboot.'
   else
@@ -145,7 +145,7 @@ deckswap-on:
 deckswap-off:
   #!/usr/bin/env bash
   STATUS=$(systemctl status deckswap.service)
-  if grep -v 'inactive' <<< ${STATUS}; then
+  if grep -qv 'inactive' <<< ${STATUS}; then
     systemctl disable deckswap.service
     echo 'deckswap disabled. Please reboot.'
   else
@@ -155,7 +155,7 @@ deckswap-off:
 resize-deckswap:
   #!/usr/bin/env bash
   CONFIG='/etc/default/deckswap'
-  CURRENT_SIZE=$(cat "${CONFIG}" | grep "SWAP_SIZE" | sed 's/SWAP_SIZE=//g')
+  CURRENT_SIZE=$(cat "${CONFIG}" | grep -q "SWAP_SIZE" | sed 's/SWAP_SIZE=//g')
   echo 'Current size: '${CURRENT_SIZE}
   read -p 'Enter new size (1-16) in gigabytes (1G): ' NEW_SIZE
   if [ -z "${NEW_SIZE//[0-9]}" ]; then
@@ -182,7 +182,7 @@ set-btrfs-flags:
   #!/usr/bin/env bash
   echo 'Configuring drive mount parameters...'
   sudo sed -i 's/compress=zstd:1/noatime,lazytime,commit=120,compress-force=zstd:1,space_cache=v2,discard=async/g' /etc/fstab
-  if grep '64GB' <<< $(lsblk -o MODEL); then
+  if grep -q '64GB' <<< $(lsblk -o MODEL); then
     echo 'Increasing compression for detected 64GB eMMC'
     sudo sed -i 's/compress-force=zstd:1/compress-force=zstd:3/g' /etc/fstab
   fi
@@ -193,7 +193,7 @@ switch-to-ext4:
 zram-on:
   #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)
-  if grep 'zram' <<< ${KARGS}; then
+  if grep -q 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --delete=zram
     echo 'ZRAM enabled. Please reboot.'
   else
@@ -203,7 +203,7 @@ zram-on:
 zram-off:
   #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)
-  if grep -v 'zram' <<< ${KARGS}; then
+  if grep -qv 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --append=zram=0
     echo 'ZRAM disabled. Please reboot.'
   else
@@ -213,8 +213,8 @@ zram-off:
 resize-zram:
   #!/usr/bin/env bash
   CONFIG='/etc/systemd/zram-generator.conf'
-  if grep "zram-size" <<< $(cat ${CONFIG}); then
-    CURRENT_SIZE=$(cat "${CONFIG}" | grep "zram-size" | sed 's/zram-size=//g')
+  if grep -q "zram-size" <<< $(cat ${CONFIG}); then
+    CURRENT_SIZE=$(cat "${CONFIG}" | grep -q "zram-size" | sed 's/zram-size=//g')
   else
     CURRENT_SIZE=1024
   fi
@@ -225,7 +225,7 @@ resize-zram:
       NEW_SIZE=1024
     fi
     if ((${NEW_SIZE} >= 512 && ${NEW_SIZE} <= 4096)); then
-      if grep "zram-size" <<< $(cat ${CONFIG}); then
+      if grep -q "zram-size" <<< $(cat ${CONFIG}); then
         sudo sed -i 's/zram-size='${CURRENT_SIZE}'/zram-size='${NEW_SIZE}'/g' ${CONFIG}
       else
         sudo -A echo "zram-size=${NEW_SIZE}" >> ${CONFIG}

--- a/system_files/desktop/kinoite/etc/flatpak/install
+++ b/system_files/desktop/kinoite/etc/flatpak/install
@@ -2,3 +2,4 @@ net.davidotek.pupgui2
 org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
 org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08
 org.mozilla.firefox
+com.github.tchx84.Flatseal

--- a/system_files/desktop/shared/etc/profile.d/askpass.sh
+++ b/system_files/desktop/shared/etc/profile.d/askpass.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+source /etc/default/bazzite
+if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
   SUDO_ASKPASS='/usr/bin/ksshaskpass'
-else
+elif [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
   SUDO_ASKPASS='/usr/libexec/openssh/gnome-ssh-askpass'
 fi
 export SUDO_ASKPASS

--- a/system_files/desktop/shared/etc/profile.d/askpass.sh
+++ b/system_files/desktop/shared/etc/profile.d/askpass.sh
@@ -1,2 +1,7 @@
-SUDO_ASKPASS='/usr/bin/ksshaskpass'
+#!/usr/bin/env bash
+if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+  SUDO_ASKPASS='/usr/bin/ksshaskpass'
+else
+  SUDO_ASKPASS='/usr/libexec/openssh/gnome-ssh-askpass'
+fi
 export SUDO_ASKPASS

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source /etc/default/bazzite
 
 if [[ -f '/etc/flatpak/install' ]]; then
   cp -r /etc/flatpak/flathub/* /var/lib/flatpak/repo/refs/remotes/flathub
@@ -15,7 +16,7 @@ if [[ -f '/etc/flatpak/remove' ]]; then
 fi
 
 if [[ -f '/etc/flatpak/deck' ]]; then
-  if grep -q "deck" <<< $(cat /etc/default/bazzite); then
+  if [[ ${IMAGE_NAME} == *'deck'* ]]; then
     cat /etc/flatpak/deck | while read line; do
       flatpak install --system --noninteractive --no-pull flathub $line
     done && cat /etc/flatpak/deck >> /etc/flatpak/installed

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -15,7 +15,7 @@ if [[ -f '/etc/flatpak/remove' ]]; then
 fi
 
 if [[ -f '/etc/flatpak/deck' ]]; then
-  if grep "deck" <<< $(cat /etc/default/bazzite); then
+  if grep -q "deck" <<< $(cat /etc/default/bazzite); then
     cat /etc/flatpak/deck | while read line; do
       flatpak install --system --noninteractive --no-pull flathub $line
     done && cat /etc/flatpak/deck >> /etc/flatpak/installed

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -15,7 +15,7 @@ if [[ -f '/etc/flatpak/remove' ]]; then
 fi
 
 if [[ -f '/etc/flatpak/deck' ]]; then
-  if grep "deck" <<< $(rpm-ostree status); then
+  if grep "deck" <<< $(cat /etc/default/bazzite); then
     cat /etc/flatpak/deck | while read line; do
       flatpak install --system --noninteractive --no-pull flathub $line
     done && cat /etc/flatpak/deck >> /etc/flatpak/installed

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+# Source Bazzite defaults
+source /etc/default/bazzite
+
 # Simply launches the "yafti" GUI with the uBlue image's configuration.
 /usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -14,7 +14,7 @@ screens:
     values:
       title: Configure Bazzite Arch
       condition:
-        run: grep -v "bazzite-arch" <<< $(distrobox list)
+        run: grep -qv "bazzite-arch" <<< $(distrobox list)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
@@ -93,14 +93,14 @@ screens:
     values:
       title: AMD Additions
       condition:
-        run: grep -v "nvidia" <<< $(cat /etc/default/bazzite)
+        run: grep -qv "nvidia" <<< $(cat /etc/default/bazzite)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
         CoreCtrl:
           description: AMD GPU Overclocking
           condition:
-            run: grep -v "nvidia" <<< $(cat /etc/default/bazzite)
+            run: grep -qv "nvidia" <<< $(cat /etc/default/bazzite)
           default: false
           packages:
           - Install CoreCtrl: just --unstable install-corectrl
@@ -109,7 +109,7 @@ screens:
     values:
       title: Nvidia Additions
       condition:
-        run: grep "nvidia" <<< $(cat /etc/default/bazzite)
+        run: grep -q "nvidia" <<< $(cat /etc/default/bazzite)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
@@ -128,7 +128,7 @@ screens:
     values:
       title: Setting up Flathub
       condition:
-        run: flatpak remotes --system | grep fedora
+        run: flatpak remotes --system | grep -q fedora
       description: |
         WARNING: This will modify your Flatpaks if you are rebasing! If you do not want to do this exit the installer.
       actions:
@@ -263,7 +263,7 @@ screens:
     values:
       title: Enabling Wallpaper Engine
       condition:
-        run: grep -v "gnome" <<< $(cat /etc/default/bazzite)
+        run: grep -qv "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
       actions:
@@ -273,7 +273,7 @@ screens:
     values:
       title: Setting up Gradience
       condition:
-        run: grep "gnome" <<< $(cat /etc/default/bazzite)
+        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Adds Valve-inspired themes to Gradience
       actions:
@@ -283,7 +283,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: grep "gnome" <<< $(cat /etc/default/bazzite)
+        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -102,13 +102,6 @@ screens:
           default: true
           packages:
           - Enable System76 Scheduler: just --unstable enable-system76-scheduler
-        Wallpaper Engine:
-          description: Enables Wallpaper Engine
-          condition:
-            run: grep -v "gnome" <<< $(rpm-ostree status)
-          default: true
-          packages:
-          - Enable Wallpaper Engine: just --unstable enable-wallpaper-engine
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent
     values:
@@ -245,6 +238,16 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
+  enable-wallpaper-engine:
+    source: yafti.screen.consent
+    values:
+      title: Enabling Wallpaper Engine
+      condition:
+        run: grep -v "gnome" <<< $(rpm-ostree status)
+      description: |
+        Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
+      actions:
+      - run: just --unstable enable-wallpaper-engine
   setup-gradience:
     source: yafti.screen.consent
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -52,13 +52,6 @@ screens:
           default: true
           packages:
           - Enable Duperemove: systemctl enable --now duperemove-weekly@$(systemd-escape $HOME).timer
-        CoreCtrl:
-          description: AMD GPU Overclocking
-          condition:
-            run: grep -v "nvidia" <<< $(rpm-ostree status)
-          default: false
-          packages:
-          - Install CoreCtrl: just --unstable install-corectrl
         Greenlight:
           description: A utility for xCloud and xHome streaming
           default: false
@@ -90,18 +83,46 @@ screens:
           default: true
           packages:
           - Set SteamOS BTRFS mount flags: sudo -A just --unstable set-btrfs-flags
-        Supergfxctl:
-          condition:
-            run: grep "nvidia" <<< $(rpm-ostree status)
-          description: A utility for Nvidia GPU switching
-          default: false
-          packages:
-          - Enable supergfxctl: just --unstable enable-supergfxctl
         System76 Scheduler:
           description: Enables System76 scheduler
           default: true
           packages:
           - Enable System76 Scheduler: just --unstable enable-system76-scheduler
+  amd-additions:
+    source: yafti.screen.package
+    values:
+      title: AMD Additions
+      condition:
+        run: grep -v "nvidia" <<< $(rpm-ostree status)
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        CoreCtrl:
+          description: AMD GPU Overclocking
+          condition:
+            run: grep -v "nvidia" <<< $(rpm-ostree status)
+          default: false
+          packages:
+          - Install CoreCtrl: just --unstable install-corectrl
+  nvidia-additions:
+    source: yafti.screen.package
+    values:
+      title: Nvidia Additions
+      condition:
+        run: grep "nvidia" <<< $(rpm-ostree status)
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        GreenWithEnvy:
+          description: Nvidia GPU Overclocking
+          default: false
+          packages:
+          - Install GreenWithEnvy: flatpak install --user --noninteractive com.leinardi.gwe
+        Supergfxctl:
+          description: A utility for Nvidia GPU switching
+          default: false
+          packages:
+          - Enable Supergfxctl: just --unstable enable-supergfxctl
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent
     values:
@@ -231,7 +252,6 @@ screens:
           - Easy Effects: com.github.wwmm.easyeffects
           - Fedora Media Writer: org.fedoraproject.MediaWriter
           - Flatseal Permissions Manager: com.github.tchx84.Flatseal
-          - GreenWithEnvy (Nvidia GPU Overclocking): com.leinardi.gwe
           - JamesDSP: me.timschneeberger.jdsp4linux
           - KeePassXC: org.keepassxc.KeePassXC
           - OpenRGB: org.openrgb.OpenRGB

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -40,13 +40,6 @@ screens:
           default: false
           packages:
           - Install CoreCtrl: just --unstable install-corectrl
-        Gradience:
-          description: Adds Valve-inspired themes to Gradience
-          condition:
-            run: grep "gnome" <<< $(rpm-ostree status)
-          default: true
-          packages:
-          - Setup Gradience: just --unstable setup-gradience
         Greenlight:
           description: A utility for xCloud and xHome streaming
           default: false
@@ -233,6 +226,16 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
+  setup-gradience:
+    source: yafti.screen.consent
+    values:
+      title: Setting up Gradience
+      condition:
+        run: grep "gnome" <<< $(rpm-ostree status)
+      description: |
+        Adds Valve-inspired themes to Gradience
+      actions:
+      - run: just --unstable setup-gradience
   theme:
     source: yafti.screen.title
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -258,26 +258,14 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
-  enable-wallpaper-engine:
+  setup-desktop-environment:
     source: yafti.screen.consent
     values:
-      title: Enabling Wallpaper Engine
-      condition:
-        run: grep -qv "gnome" <<< $(cat /etc/default/bazzite)
+      title: Setting up your Desktop Environment
       description: |
-        Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
+        Configures your desktop environment, including needed plugins/extensions.
       actions:
-      - run: just --unstable enable-wallpaper-engine
-  setup-gradience:
-    source: yafti.screen.consent
-    values:
-      title: Setting up Gradience
-      condition:
-        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
-      description: |
-        Adds Valve-inspired themes to Gradience
-      actions:
-      - run: just --unstable setup-gradience
+      - run: just --unstable setup-desktop-environment
   theme:
     source: yafti.screen.title
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -93,14 +93,14 @@ screens:
     values:
       title: AMD Additions
       condition:
-        run: grep -v "nvidia" <<< $(rpm-ostree status)
+        run: grep -v "nvidia" <<< $(cat /etc/default/bazzite)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
         CoreCtrl:
           description: AMD GPU Overclocking
           condition:
-            run: grep -v "nvidia" <<< $(rpm-ostree status)
+            run: grep -v "nvidia" <<< $(cat /etc/default/bazzite)
           default: false
           packages:
           - Install CoreCtrl: just --unstable install-corectrl
@@ -109,7 +109,7 @@ screens:
     values:
       title: Nvidia Additions
       condition:
-        run: grep "nvidia" <<< $(rpm-ostree status)
+        run: grep "nvidia" <<< $(cat /etc/default/bazzite)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
@@ -263,7 +263,7 @@ screens:
     values:
       title: Enabling Wallpaper Engine
       condition:
-        run: grep -v "gnome" <<< $(rpm-ostree status)
+        run: grep -v "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Enables the plugin for Wallpaper Engine, a utility that allows you to use live wallpapers on your desktop
       actions:
@@ -273,7 +273,7 @@ screens:
     values:
       title: Setting up Gradience
       condition:
-        run: grep "gnome" <<< $(rpm-ostree status)
+        run: grep "gnome" <<< $(cat /etc/default/bazzite)
       description: |
         Adds Valve-inspired themes to Gradience
       actions:
@@ -283,7 +283,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: grep "gnome" <<< $(rpm-ostree status)
+        run: grep "gnome" <<< $(cat /etc/default/bazzite)
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -93,7 +93,7 @@ screens:
     values:
       title: AMD Additions
       condition:
-        run: grep -qv "nvidia" <<< $(cat /etc/default/bazzite)
+        run: [[ ${IMAGE_FLAVOR} == 'main' ]]
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
@@ -109,7 +109,7 @@ screens:
     values:
       title: Nvidia Additions
       condition:
-        run: grep -q "nvidia" <<< $(cat /etc/default/bazzite)
+        run: [[ ${IMAGE_FLAVOR} == 'nvidia' ]]
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
@@ -270,7 +270,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: grep -q "gnome" <<< $(cat /etc/default/bazzite)
+        run: [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -251,7 +251,6 @@ screens:
           - Calibre: com.calibre_ebook.calibre
           - Easy Effects: com.github.wwmm.easyeffects
           - Fedora Media Writer: org.fedoraproject.MediaWriter
-          - Flatseal Permissions Manager: com.github.tchx84.Flatseal
           - JamesDSP: me.timschneeberger.jdsp4linux
           - KeePassXC: org.keepassxc.KeePassXC
           - OpenRGB: org.openrgb.OpenRGB

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -9,6 +9,37 @@ screens:
       icon: "/usr/share/ublue-os/bazzite/logo.svg"
       description: |
         Configure your system to get started
+  configure-bazzite-arch:
+    source: yafti.screen.package
+    values:
+      title: Configure Bazzite Arch
+      condition:
+        run: grep -v "bazzite-arch" <<< $(distrobox list)
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        Install Bazzite Arch:
+          description: This will install an Arch distrobox configured for gaming
+          default: true
+          packages:
+          - Install Bazzite Arch: just --unstable install-bazzite-arch
+        Export Launchers:
+          description: This exports Steam and Lutris
+          default: true
+          packages:
+          - Export Steam: distrobox-enter -n bazzite-arch -- '  distrobox-export --app steam'
+          - Export Lutris: distrobox-enter -n bazzite-arch -- '  distrobox-export --app lutris'
+        Export Utilities:
+          description: This exports SteamCMD and protontricks
+          default: true
+          packages:
+          - Export SteamCMD: just --unstable export-steamcmd
+          - Export Protontricks: distrobox-enter -n bazzite-arch -- '  distrobox-export --app protontricks'
+        Autostart Steam:
+          description: Starts Steam after logging in
+          default: true
+          packages:
+          - Autostart Steam: cp ~/.local/share/applications/bazzite-arch-steam.desktop ~/.config/autostart/bazzite-arch-steam-silent.desktop && sed -i 's@/usr/bin/steam-runtime  %U@/usr/bin/steam-runtime -silent %U@g' ~/.config/autostart/bazzite-arch-steam-silent.desktop
   configure-bazzite:
     source: yafti.screen.package
     values:
@@ -16,18 +47,6 @@ screens:
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
-        Bazzite Arch Distrobox:
-          description: This will install an Arch distrobox configured for gaming. Steam and Lutris will then be exported.
-          default: true
-          condition:
-            run: distrobox list | grep -v bazzite-arch
-          packages:
-          - Install Bazzite Arch: just --unstable install-bazzite-arch
-          - Export Steam: distrobox-enter -n bazzite-arch -- '  distrobox-export --app steam'
-          - Export SteamCMD: just --unstable export-steamcmd
-          - Export Lutris: distrobox-enter -n bazzite-arch -- '  distrobox-export --app lutris'
-          - Export Protontricks: distrobox-enter -n bazzite-arch -- '  distrobox-export --app protontricks'
-          - Autostart Steam: cp ~/.local/share/applications/bazzite-arch-steam.desktop ~/.config/autostart/bazzite-arch-steam-silent.desktop && sed -i 's@/usr/bin/steam-runtime  %U@/usr/bin/steam-runtime -silent %U@g' ~/.config/autostart/bazzite-arch-steam-silent.desktop
         Automatic Duplicate File Removal:
           description: Flattens duplicate files to take up no more space than a single copy, a considerable space savings for wine prefixes and compatdata
           default: true

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -61,8 +61,7 @@ enable-system76-scheduler:
     rm -rf /tmp/kwin-system76-scheduler-integration
   else
     echo 'Enabling System76-Scheduler GNOME extension...'
-    gsettings set org.gnome.shell enabled-extensions ['appindicatorsupport@rgcjonas.gmail.com', 'gsconnect@andyholmes.github.io', 's76-scheduler@mattjakeman.com', 'tofumenu@tofu', 'user-theme@gnome-shell-extensions.gcampax.github.com']
-    gsettings set org.gnome.shell.extensions.fedora-menu menu-button-icon-size 20
+    gnome-shell-extension-cl -e s76-scheduler@mattjakeman.com
   fi
 
 enable-supergfxctl: 
@@ -73,29 +72,27 @@ enable-supergfxctl:
     echo "This requires an Nvidia image."
   fi
 
-enable-wallpaper-engine:
+setup-desktop-environment:
   #!/usr/bin/env bash
   if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+    echo 'Configuring GNOME extensions...'
+    gnome-shell-extension-cl -d background-logo@fedorahosted.org
+    gnome-shell-extension-cl -e appindicatorsupport@rgcjonas.gmail.com
+    gnome-shell-extension-cl -e gsconnect@andyholmes.github.io
+    mkdir -p $HOME/.config/presets/user/
+    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
+    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
+  else 
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
     rm -rf /tmp/wallpaper-engine-kde-plugin
-  else
-    echo "This is only supported under KDE."
-  fi
-
-setup-gradience:
-  #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
-    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
-    gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
-  else 
-    echo "This is only supported under GNOME."
   fi
 
 enable-vapor-theme:
   #!/usr/bin/env bash
   if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+    gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -110,6 +107,7 @@ enable-vapor-theme:
 enable-vgui2-theme:
   #!/usr/bin/env bash
   if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+    gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -1,7 +1,7 @@
 install-bazzite-arch:
   #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)
-  if grep 'nvidia' <<< ${KARGS}; then
+  if grep -q 'nvidia' <<< ${KARGS}; then
     echo 'Installing Bazzite Arch (Nvidia)...'
     distrobox assemble create --file /usr/share/ublue-os/distrobox/bazzite-arch-nvidia
   else
@@ -28,7 +28,7 @@ remove-nix:
 
 enable-big-picture:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     systemctl enable --now gnome-autologin
   else
     systemctl enable --now plasma-autologin
@@ -43,7 +43,7 @@ get-greenlight:
 
 install-extensions-cli:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     pip install --upgrade gnome-extensions-cli
   else 
     echo "This is only supported under GNOME."
@@ -51,7 +51,7 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
@@ -67,7 +67,7 @@ enable-system76-scheduler:
 
 enable-supergfxctl: 
   #!/usr/bin/env bash
-  if grep "nvidia" <<< $(cat /etc/default/bazzite); then
+  if grep -q "nvidia" <<< $(cat /etc/default/bazzite); then
     systemctl enable --now supergfxd.service
   else
     echo "This requires an Nvidia image."
@@ -75,7 +75,7 @@ enable-supergfxctl:
 
 enable-wallpaper-engine:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
@@ -86,7 +86,7 @@ enable-wallpaper-engine:
 
 setup-gradience:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
   else 
@@ -95,7 +95,7 @@ setup-gradience:
 
 enable-vapor-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -103,13 +103,13 @@ enable-vapor-theme:
     gsettings set org.gnome.desktop.background picture-uri-dark file:///usr/share/backgrounds/steamdeck/Steam\ Deck\ Logo\ Default.jpg
     gradience-cli flatpak-overrides -e both
     gradience-cli apply -p /usr/share/ublue-os/bazzite/themes/vapor.json
-  else 
+  else
     echo "This is only supported under GNOME."
   fi
 
 enable-vgui2-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(cat /etc/default/bazzite); then
+  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -128,7 +128,7 @@ set-btrfs-flags:
 zram-on:
   #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)
-  if grep 'zram' <<< ${KARGS}; then
+  if grep -q 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --delete=zram
     echo 'ZRAM enabled. Please reboot.'
   else
@@ -138,7 +138,7 @@ zram-on:
 zram-off:
   #!/usr/bin/env bash
   KARGS=$(rpm-ostree kargs)
-  if grep -v 'zram' <<< ${KARGS}; then
+  if grep -qv 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --append=zram=0
     echo 'ZRAM disabled. Please reboot.'
   else
@@ -148,7 +148,7 @@ zram-off:
 resize-zram:
   #!/usr/bin/env bash
   CONFIG='/etc/systemd/zram-generator.conf'
-  if grep "zram-size" <<< $(cat ${CONFIG}); then
+  if grep -q "zram-size" <<< $(cat ${CONFIG}); then
     CURRENT_SIZE=$(cat "${CONFIG}" | grep "zram-size" | sed 's/zram-size=//g')
   else
     CURRENT_SIZE=1024

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -1,7 +1,7 @@
 install-bazzite-arch:
   #!/usr/bin/env bash
-  KARGS=$(rpm-ostree kargs)
-  if grep -q 'nvidia' <<< ${KARGS}; then
+  source /etc/default/bazzite
+  if [[ ${IMAGE_FLAVOR} == 'nvidia' ]]; then
     echo 'Installing Bazzite Arch (Nvidia)...'
     distrobox assemble create --file /usr/share/ublue-os/distrobox/bazzite-arch-nvidia
   else
@@ -28,9 +28,10 @@ remove-nix:
 
 enable-big-picture:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     systemctl enable --now gnome-autologin
-  else
+  elif [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     systemctl enable --now plasma-autologin
   fi
   sed -i 's@/usr/bin/steam-runtime -silent %U@/usr/bin/steam-runtime -bigpicture %U@g' ~/.config/autostart/bazzite-arch-steam-silent.desktop
@@ -43,7 +44,8 @@ get-greenlight:
 
 install-extensions-cli:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     pip install --upgrade gnome-extensions-cli
   else 
     echo "This is only supported under GNOME."
@@ -51,7 +53,8 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
@@ -59,14 +62,15 @@ enable-system76-scheduler:
     systemctl enable --now com.system76.Scheduler.service
     kcmshell5 kcm_kwin_scripts
     rm -rf /tmp/kwin-system76-scheduler-integration
-  else
+  elif [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     echo 'Enabling System76-Scheduler GNOME extension...'
     gnome-shell-extension-cl -e s76-scheduler@mattjakeman.com
   fi
 
 enable-supergfxctl: 
   #!/usr/bin/env bash
-  if grep -q "nvidia" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${IMAGE_FLAVOR} == 'nvidia' ]]; then
     systemctl enable --now supergfxd.service
   else
     echo "This requires an Nvidia image."
@@ -74,7 +78,8 @@ enable-supergfxctl:
 
 setup-desktop-environment:
   #!/usr/bin/env bash
-  if grep -qv "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     echo 'Configuring GNOME extensions...'
     gnome-shell-extension-cl -d background-logo@fedorahosted.org
     gnome-shell-extension-cl -e appindicatorsupport@rgcjonas.gmail.com
@@ -82,7 +87,7 @@ setup-desktop-environment:
     mkdir -p $HOME/.config/presets/user/
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
-  else 
+  elif [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
@@ -91,7 +96,8 @@ setup-desktop-environment:
 
 enable-vapor-theme:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
@@ -106,7 +112,8 @@ enable-vapor-theme:
 
 enable-vgui2-theme:
   #!/usr/bin/env bash
-  if grep -q "gnome" <<< $(cat /etc/default/bazzite); then
+  source /etc/default/bazzite
+  if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
     gnome-shell-extension-cl -e user-theme@gnome-shell-extensions.gcampax.github.com
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -28,7 +28,7 @@ remove-nix:
 
 enable-big-picture:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     systemctl enable --now gnome-autologin
   else
     systemctl enable --now plasma-autologin
@@ -43,7 +43,7 @@ get-greenlight:
 
 install-extensions-cli:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     pip install --upgrade gnome-extensions-cli
   else 
     echo "This is only supported under GNOME."
@@ -51,7 +51,7 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(rpm-ostree status); then
+  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
@@ -67,8 +67,7 @@ enable-system76-scheduler:
 
 enable-supergfxctl: 
   #!/usr/bin/env bash
-  status=$(rpm-ostree status)
-  if grep "nvidia" <<< ${status}; then
+  if grep "nvidia" <<< $(cat /etc/default/bazzite); then
     systemctl enable --now supergfxd.service
   else
     echo "This requires an Nvidia image."
@@ -76,7 +75,7 @@ enable-supergfxctl:
 
 enable-wallpaper-engine:
   #!/usr/bin/env bash
-  if grep -v "gnome" <<< $(rpm-ostree status); then
+  if grep -v "gnome" <<< $(cat /etc/default/bazzite); then
     echo 'Installing Wallpaper Engine Plugin for KDE...'
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
@@ -87,7 +86,7 @@ enable-wallpaper-engine:
 
 setup-gradience:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vapor.json
     gradience-cli import -p /usr/share/ublue-os/bazzite/themes/vgui2.json
   else 
@@ -96,7 +95,7 @@ setup-gradience:
 
 enable-vapor-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark
@@ -110,7 +109,7 @@ enable-vapor-theme:
 
 enable-vgui2-theme:
   #!/usr/bin/env bash
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep "gnome" <<< $(cat /etc/default/bazzite); then
     gsettings set org.gnome.desktop.wm.preferences button-layout appmenu:minimize,maximize,close
     gsettings set org.gnome.desktop.interface color-scheme prefer-dark
     gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-dark

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -51,8 +51,8 @@ install-extensions-cli:
 
 enable-system76-scheduler:
   #!/usr/bin/env bash
-  echo 'Installing System76-Scheduler plugin for KDE...'
-  if grep "gnome" <<< $(rpm-ostree status); then
+  if grep -v "gnome" <<< $(rpm-ostree status); then
+    echo 'Installing System76-Scheduler plugin for KDE...'
     git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration
     kpackagetool5 --type=KWin/Script -i /tmp/kwin-system76-scheduler-integration
     systemctl --user enable --now com.system76.Scheduler.dbusproxy.service
@@ -60,6 +60,7 @@ enable-system76-scheduler:
     kcmshell5 kcm_kwin_scripts
     rm -rf /tmp/kwin-system76-scheduler-integration
   else
+    echo 'Enabling System76-Scheduler GNOME extension...'
     gsettings set org.gnome.shell enabled-extensions ['appindicatorsupport@rgcjonas.gmail.com', 'gsconnect@andyholmes.github.io', 's76-scheduler@mattjakeman.com', 'tofumenu@tofu', 'user-theme@gnome-shell-extensions.gcampax.github.com']
     gsettings set org.gnome.shell.extensions.fedora-menu menu-button-icon-size 20
   fi

--- a/system_files/desktop/silverblue/etc/flatpak/install
+++ b/system_files/desktop/silverblue/etc/flatpak/install
@@ -7,3 +7,4 @@ com.mattjakeman.ExtensionManager
 org.gtk.Gtk3theme.adw-gtk3
 org.gtk.Gtk3theme.adw-gtk3-dark
 org.mozilla.firefox
+com.github.tchx84.Flatseal

--- a/system_files/desktop/silverblue/usr/bin/gnome-shell-extension-cl
+++ b/system_files/desktop/silverblue/usr/bin/gnome-shell-extension-cl
@@ -1,0 +1,275 @@
+#! /usr/bin/env bash
+
+#	Copyright (C) 2016
+#    	Alexandru Catalin Petrini <alexandru.c.petrini@gmail.com>
+#  This script is intended to usefully manage gnome-shell extensions,
+#  in compatible Gnome Shell versions.
+
+# Install this script by running this command:
+# $ sudo wget https://raw.githubusercontent.com/cyberalex4life/gnome-shell-extension-cl/master/gnome-shell-extension-cl -O /usr/local/bin/gnome-shell-extension-cl && sudo chmod +x /usr/local/bin/gnome-shell-extension-cl
+
+
+# -------------------------------------------------------------------------------
+
+function get_enabled_extensions() {
+    enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+                               sed -e 's|^@as ||g' | tr -d "[",",","]","\'") )
+}
+
+
+function print_enabled_extensions(){
+    get_enabled_extensions
+    for enabled_extension in "${enabled_extensions[@]}"
+    do
+        echo "$enabled_extension"
+    done
+}
+
+
+# -------------------------------------------------------------------------------
+
+function get_installed_extensions() {
+    global_installed_extensions=( $(find "/usr/share/gnome-shell/extensions/" \
+                                         -maxdepth 1 -type d -name "*@*" -exec \
+                                         /usr/bin/basename {} \;) )
+    local_installed_extensions=( $(find "$HOME/.local/share/gnome-shell/extensions/" \
+                                        -maxdepth 1 -type d -name "*@*" -exec \
+                                        /usr/bin/basename {} \;) )
+
+    if [ ${#local_installed_extensions[@]} -gt ${#global_installed_extensions[@]} ]
+    then
+        installed_extensions=( ${local_installed_extensions[@]} )
+        test_extensions=( ${global_installed_extensions[@]} )
+    else
+        installed_extensions=( ${global_installed_extensions[@]} )
+        test_extensions=( ${local_installed_extensions[@]} )
+    fi
+    for test_extension in "${test_extensions[@]}"
+    do
+        test_extension_not_doubled=true
+        for installed_extension in "${installed_extensions[@]}"
+        do
+            if [ "$test_extension" = "$installed_extension" ]
+            then
+                test_extension_not_doubled=false
+                break
+            fi
+        done
+        if  [ $test_extension_not_doubled = true ]
+        then
+            test_extension=( $test_extension )
+            installed_extensions=( "${installed_extensions[@]}" "${test_extension[@]}" )
+            #echo ${test_extension[@]}
+        fi
+    done
+    echo "${installed_extensions[@]}"
+}
+
+
+function print_installed_extensions() {
+    installed_extensions=( $(get_installed_extensions) )
+    for installed_extension in "${installed_extensions[@]}"
+    do
+        [ "$(check_extension_is_enabled "$installed_extension")" = true ] && \
+            status="enabled" || status="disabled";
+        printf "%-65s - %-10s \n" "$installed_extension" "$status"
+    done
+}
+
+
+# -------------------------------------------------------------------------------
+
+function check_extension_is_enabled() {
+    extension_to_check=$1
+    enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+                               sed -e 's|^@as ||g' | tr -d "[",",","]","\'") )
+    for enabled_extension in "${enabled_extensions[@]}"
+    do
+        if [ "$enabled_extension" = "$extension_to_check" ]
+        then
+            echo true
+            return
+        fi
+    done
+    echo false
+}
+
+
+function check_extension_in_all_extensions() {
+    extension_to_check=$1
+    installed_extensions=( $(get_installed_extensions) )
+    for installed_extension in "${installed_extensions[@]}"
+    do
+        if [ "$installed_extension" = "$extension_to_check" ]
+        then
+            echo true
+            return
+        fi
+    done
+    echo false
+}
+
+
+function version_greater() {
+    minimal_version=3.18.0
+    our_version=$(gnome-shell --version | awk '{print $3}')
+    if [ "$(echo "$our_version $minimal_version" | tr " " "\n" | sort -V | head -n 1)" != "$our_version" ]
+    then
+        echo true
+    else
+        echo false
+    fi
+}
+
+
+function disable_extension() {
+
+    arguments=("$@")
+    unset "arguments[0]"
+
+    for extension_to_disable in "${arguments[@]}"
+    do
+
+        if  [ "$(check_extension_in_all_extensions "$extension_to_disable")" = false ]
+        then
+            echo "'$extension_to_disable' is not installed."
+            continue
+        fi
+        if  [ "$(check_extension_is_enabled "$extension_to_disable")" = false ]
+        then
+            echo "'$extension_to_disable' is already disabled."
+            continue
+        fi
+        if [ "$(version_greater)" = true ]
+        then
+            gnome-shell-extension-tool -d "$extension_to_disable"
+            continue
+        fi
+        enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+                                   tr -d "[",",","]","\'") )
+        enabled_extensions_string=""
+        for enabled_extension in "${enabled_extensions[@]}"
+        do
+            if [ "$enabled_extension" != "$extension_to_disable" ]
+            then
+                enabled_extensions_string="$enabled_extensions_string '$enabled_extension', "
+            fi
+        done
+        enabled_extensions_string=${enabled_extensions_string:1:-2}
+        enabled_extensions_string="[ $enabled_extensions_string ]"
+
+        dbus-launch gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+
+    done
+    return
+}
+
+
+function enable_extension() {
+
+    arguments=("$@")
+    unset "arguments[0]"
+
+    for extension_to_enable in "${arguments[@]}"
+    do
+
+        if  [ "$(check_extension_in_all_extensions "$extension_to_enable")" = false ]
+        then
+            echo "'$extension_to_enable' is not installed."
+            continue
+        fi
+        if  [ "$(check_extension_is_enabled "$extension_to_enable")" = true ]
+        then
+            echo "'$extension_to_enable' is already enabled."
+            continue
+        fi
+        if [ "$(version_greater)" = true ]
+        then
+            gnome-shell-extension-tool -e "$extension_to_enable"
+            continue
+        fi
+        enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
+        [ "$enabled_extensions_string" != "@as [" ] && delimiter=,
+        enabled_extensions_string="${enabled_extensions_string}${delimiter} '$extension_to_enable' ]"
+
+        gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+
+    done
+    return
+}
+
+
+# -------------------------------------------------------------------------------
+
+function disable_all_extensions() {
+    get_enabled_extensions
+    for enabled_extension in "${enabled_extensions[@]}"
+    do
+        # Don't disable user-theme extensions to avoid breaking them
+        if [ "$enabled_extension" != "user-theme" ] && \
+               [ "$enabled_extension" != "user-themes" ] && \
+               [ "$enabled_extension" != "user-theme@gnome-shell-extensions.gcampax.github.com" ]
+        then
+            disable_extension "this element will be ignored" "$enabled_extension"
+        else
+            continue
+        fi
+    done
+}
+
+
+# -------------------------------------------------------------------------------
+
+function print_help() {
+
+    printf "
+GNOME Shell Extension Control Tool:
+
+usage: gnome-shell-extensions <option> [extension name]
+
+Options
+    -h,   --help                                Display help message.
+    -e,   --enable-extension <extension name>   Enable extension.
+    -d,   --disable-extension <extension name>  Disable extension.
+    -da,  --disable-all-extensions              Disables all extensions.
+    -le,  --list-enabled                        List enabled extensions.
+    -l,   --list                                List all extensions + state info.
+    -s,   --status <extension name>             Show status of extension.
+\n"
+
+}
+
+
+# -------------------------------------------------------------------------------
+
+case $1 in
+    -h|--help)
+        print_help
+        ;;
+    -e|--enable-extension)
+        enable_extension "$@"
+        ;;
+    -d|--disable-extension)
+        disable_extension "$@"
+        ;;
+    -da|--disable-all-extensions)
+        disable_all_extensions
+        ;;
+    -le|--list-enabled)
+        print_enabled_extensions
+        ;;
+    -l|--list)
+        print_installed_extensions
+        ;;
+    -s|--status)
+        if  [ "$(check_extension_is_enabled "$2")" = true ]
+        then
+            echo "enabled"
+        else
+            echo "disabled"
+        fi
+        ;;
+    *)
+        print_help
+        ;;
+esac


### PR DESCRIPTION
These commits fix issues we are running into with conditional statements throughout the tree (primarily just, and yafti)

Yafti doesn't appear to support conditional statements at this time for package groups so I have created individual screens for those specialized packages that appear to work perfectly, albeit suggestions on how to better organize these screens are welcome

Invokations of rpm-ostree have been replaced with the usage of image identifiers that get written to `/etc/default/bazzite` at build time

This also fixes an issue where GNOME extensions weren't being installed in yafti, and removes a completely no-op toggle for GS Connect from yafti in Deck images (now that it is built in anyway), and adds askpass for GNOME images