### PR TITLE
fix(yafti): Revert to using grep and remove direct usage of image identifiers

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Source Bazzite defaults
-source /etc/default/bazzite
-
 # Simply launches the "yafti" GUI with the uBlue image's configuration.
 /usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml
 

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -249,7 +249,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]
+        run: grep -q 'silverblue' <<< $(cat /etc/default/bazzite)
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 
-# Source Bazzite defaults
-source /etc/default/bazzite
-
 # Simply launches the "yafti" GUI with the uBlue image's configuration.
 /usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -93,14 +93,12 @@ screens:
     values:
       title: AMD Additions
       condition:
-        run: [[ ${IMAGE_FLAVOR} == 'main' ]]
+        run: grep -q 'main' <<< $(cat /etc/default/bazzite)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
         CoreCtrl:
           description: AMD GPU Overclocking
-          condition:
-            run: grep -qv "nvidia" <<< $(cat /etc/default/bazzite)
           default: false
           packages:
           - Install CoreCtrl: just --unstable install-corectrl
@@ -109,7 +107,7 @@ screens:
     values:
       title: Nvidia Additions
       condition:
-        run: [[ ${IMAGE_FLAVOR} == 'nvidia' ]]
+        run: grep -q 'nvidia' <<< $(cat /etc/default/bazzite)
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
@@ -162,7 +160,7 @@ screens:
           - Bottles: com.usebottles.bottles
           - Chiaki (PlayStation Remote Play): re.chiaki.Chiaki
           - Discord: com.discordapp.Discord
-          - DOSBox Staging: io.github.dosbox-staging 
+          - DOSBox Staging: io.github.dosbox-staging
           - GeForce NOW Electron: io.github.hmlendea.geforcenow-electron
           - Heroic Games Launcher (GOG &amp; Epic): com.heroicgameslauncher.hgl
           - itch: io.itch.itch
@@ -270,7 +268,7 @@ screens:
     values:
       title: "GNOME Theme"
       condition:
-        run: [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]
+        run: grep -q 'silverblue' <<< $(cat /etc/default/bazzite)
       links:
       - "Vapor Theme":
           run: just --unstable enable-vapor-theme


### PR DESCRIPTION
Sourcing these doesn't seem to cut it as yafti doesn't acknowledge them so instead just use cat to obtain the file contents for the same result