### PR TITLE
fix: Avoid conflict between gamescope-autologin and session selector

### DIFF
--- a/system_files/deck/shared/usr/bin/gamescope-autologin
+++ b/system_files/deck/shared/usr/bin/gamescope-autologin
@@ -4,6 +4,12 @@ USER=$(id -nu 1000)
 
 # SteamOS SDDM config
 SDDM_CONF='/etc/sddm.conf.d/steamos.conf'
+AUTOLOGIN_CONF='/etc/sddm.conf.d/zz-steamos-autologin.conf'
+
+# Avoid autologin conflict
+if [[ -f ${AUTOLOGIN_CONF} ]]; then
+  rm -f ${AUTOLOGIN_CONF}
+fi
 
 # Configure autologin
 sed -i 's/.*Session=.*/Session=gamescope-session.desktop/g' ${SDDM_CONF}


### PR DESCRIPTION
Addresses an issue where gamescope-autologin doesn't function correctly if this file exists after starting Steam. Appears isolated to GNOME. This doesn't cause issues with sessions switching as the file gets created by steamos-session-select regardless