### PR TITLE
fix(gnome): Remove GNOME Classic sessions

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -98,6 +98,7 @@ RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
         gnome-shell-extension-system76-scheduler \
         openssh-askpass && \
     rpm-ostree override remove \
+        gnome-classic-session.noarch \
         gnome-tour \
         yelp \
 ; fi


### PR DESCRIPTION
We don't need these, and as a side effect this moves GNOME on Wayland to the top of SDDM