### PR TITLE
feat(gnome): Use GDM on desktop

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -87,7 +87,6 @@ RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
         gnome-control-center \
         gnome-control-center-filesystem && \
     rpm-ostree install \
-        sddm \
         steamdeck-backgrounds \
         gradience \
         adw-gtk3-theme \
@@ -140,8 +139,6 @@ RUN rm /usr/share/applications/shredder.desktop && \
     systemctl enable displaylink.service && \
     systemctl enable input-remapper.service && \
     if grep -q "gnome" <<< "${IMAGE_NAME}"; then \
-        systemctl disable gdm.service && \
-        systemctl enable sddm.service && \
         rm /usr/share/applications/yad-icon-browser.desktop \
     ; fi && \
     echo -e "IMAGE_NAME=${IMAGE_NAME}\nBASE_IMAGE_NAME=${BASE_IMAGE_NAME}\nIMAGE_FLAVOR=${IMAGE_FLAVOR}\nFEDORA_MAJOR_VERSION=${FEDORA_MAJOR_VERSION}" >> /etc/default/bazzite && \
@@ -212,6 +209,7 @@ RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
 ; else \
     rpm-ostree install \
         gnome-shell-extension-bazzite-menu \
+        sddm \
 ; fi
 
 # Install new packages & dock updater - done manually due to proprietary parts preventing it from being on Copr
@@ -256,6 +254,8 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
     mv /etc/sddm.conf /etc/sddm.conf.d/steamos.conf && \
     if grep -q "gnome" <<< "${IMAGE_NAME}"; then \
+        systemctl disable gdm.service && \
+        systemctl enable sddm.service && \
         systemctl enable gnome-autologin.service \
     ; fi && \
     if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \

--- a/Containerfile
+++ b/Containerfile
@@ -78,14 +78,19 @@ RUN if grep -qv "gnome" <<< "${IMAGE_NAME}"; then \
     rpm-ostree install \
         steamdeck-kde-presets-desktop \
         wallpaper-engine-kde-plugin \
-        kdeconnectd \
+        kdeconnectd && \
+    rpm-ostree override replace \
+    --experimental \
+    --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
+        xorg-x11-server-Xwayland.spec \
 ; else \
     rpm-ostree override replace \
     --experimental \
     --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
         mutter \
         gnome-control-center \
-        gnome-control-center-filesystem && \
+        gnome-control-center-filesystem \
+        xorg-x11-server-Xwayland.spec && \
     rpm-ostree install \
         steamdeck-backgrounds \
         gradience \

--- a/system_files/deck/silverblue/usr/bin/gnome-autologin
+++ b/system_files/deck/silverblue/usr/bin/gnome-autologin
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+USER=$(id -nu 1000)
+
+# SteamOS SDDM config
+SDDM_CONF='/etc/sddm.conf.d/steamos.conf'
+if [ ! -f ${SDDM_CONF} ]; then
+    # Fallback to sddm.conf
+    SDDM_CONF = '/etc/sddm.conf'
+fi
+
+# Configure autologin
+sed -i 's/.*Session=.*/Session=gnome-xorg.desktop/g' ${SDDM_CONF}
+sed -i 's/.*User=.*/User='${USER}'/g' ${SDDM_CONF}

--- a/system_files/desktop/silverblue/etc/gdm/custom.conf
+++ b/system_files/desktop/silverblue/etc/gdm/custom.conf
@@ -1,0 +1,16 @@
+# GDM configuration storage
+
+[daemon]
+#AutomaticLoginEnable=True
+#AutomaticLogin=
+#WaylandEnable=false
+#DefaultSession=gnome-xorg
+
+[security]
+
+[xdmcp]
+
+[chooser]
+
+[debug]
+#Enable=true

--- a/system_files/desktop/silverblue/usr/bin/gnome-autologin
+++ b/system_files/desktop/silverblue/usr/bin/gnome-autologin
@@ -2,13 +2,10 @@
 
 USER=$(id -nu 1000)
 
-# SteamOS SDDM config
-SDDM_CONF='/etc/sddm.conf.d/steamos.conf'
-if [ ! -f ${SDDM_CONF} ]; then
-    # Fallback to sddm.conf
-    SDDM_CONF = '/etc/sddm.conf'
-fi
+# GDM config
+GDM_CONF='/etc/gdm/custom.conf'
 
 # Configure autologin
-sed -i 's/.*Session=.*/Session=gnome-xorg.desktop/g' ${SDDM_CONF}
-sed -i 's/.*User=.*/User='${USER}'/g' ${SDDM_CONF}
+sed -i 's/.*AutomaticLoginEnable=.*/AutomaticLoginEnable=true/g' ${GDM_CONF}
+sed -i 's/.*AutomaticLogin=.*/AutomaticLogin='${USER}'/g' ${GDM_CONF}
+sed -i 's/.*DefaultSession=.*/DefaultSession=gnome-xorg/g' ${GDM_CONF}


### PR DESCRIPTION
Restores GDM on desktop and implements GNOME autologin with GDM support. This allows users to use screen locking. Omitted from Steam Deck as there isn't a seemingly clean way to implement this for session switching. Will investigate in the future