### PR TITLE
fix: Add Yafti icon and only setup Steam desktop shortcuts under KDE

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -84,11 +84,6 @@ screens:
           default: true
           packages:
           - Enable SDGyroDSU Service: systemctl --user enable --now sdgyrodsu
-        Steam Desktop Shortcuts:
-          description: Creates Steam desktop shortcuts
-          default: true
-          packages:
-          - Create Steam shortcuts: just --unstable create-steam-shortcuts
         SteamOS BTRFS Mount Flags:
           description: Sets SteamOS BTRFS mount flags
           default: true

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -22,11 +22,6 @@ set-steamos-kargs:
   echo 'Setting kargs...'
   rpm-ostree kargs --append="amd_pstate=active" --append="amd_iommu=off" --append="amdgpu.gttsize=8128" --append="spi_amd.speed_dev=1" --append="audit=0" --append="initcall_blacklist=simpledrm_platform_driver_init" --delete-if-present="nomodeset"
 
-create-steam-shortcuts:
-  cp /usr/share/applications/steam.desktop ~/Desktop
-  sed -i 's@Steam (Runtime)@Steam@g' ~/Desktop/steam.desktop
-  cp /etc/skel.d/Desktop/Return.desktop ~/Desktop
-
 get-decky:
   #!/usr/bin/env bash
   export HOME=$(getent passwd ${SUDO_USER:-$USER} | cut -d: -f6)
@@ -105,6 +100,10 @@ setup-desktop-environment:
     git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin
     plasmapkg2 -i /tmp/wallpaper-engine-kde-plugin/plugin
     rm -rf /tmp/wallpaper-engine-kde-plugin
+    echo 'Creating Steam shortcuts..'
+    cp /usr/share/applications/steam.desktop ~/Desktop
+    sed -i 's@Steam (Runtime)@Steam@g' ~/Desktop/steam.desktop
+    cp /etc/skel.d/Desktop/Return.desktop ~/Desktop
   fi
 
 enable-vapor-theme:

--- a/system_files/desktop/shared/usr/share/applications/yafti.desktop
+++ b/system_files/desktop/shared/usr/share/applications/yafti.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=Yafti
+Icon=/usr/share/ublue-os/bazzite/logo.svg
+Exec=/usr/bin/yafti --force


### PR DESCRIPTION
Adds a desktop icon that utilizes the new '--force' option in Yafti to allow users to rerun it whenever they need to