### PR TITLE
feat(deck): Add (hidden) toggleable desktop Wayland session session support

### DIFF
--- a/system_files/deck/kinoite/usr/bin/startplasma-steamos-oneshot
+++ b/system_files/deck/kinoite/usr/bin/startplasma-steamos-oneshot
@@ -4,11 +4,22 @@ set -e
 
 die() { echo >&2 "!! $*"; exit 1; }
 
+source /etc/default/desktop-wayland
+
 SENTINEL_FILE="steamos-session-select"
-SENTINEL_VALUE="x11"
+if ${DESKTOP_WAYLAND}; then
+  SENTINEL_VALUE="wayland"
+else
+  SENTINEL_VALUE="x11"
+fi
 
 # If we proceed, execute this
-CHAINED_SESSION="/usr/bin/startplasma-x11"
+if ${DESKTOP_WAYLAND}; then
+  CHAINED_SESSION="/usr/bin/startplasma-wayland"
+else
+  CHAINED_SESSION="/usr/bin/startplasma-x11"
+fi
+
 # If we decide the sentinel is consumed, execute this command instead and fail
 RESTORE_SESSION=(steamos-session-select) # No arguments restores the session
 

--- a/system_files/deck/kinoite/usr/bin/steamos-session-select
+++ b/system_files/deck/kinoite/usr/bin/steamos-session-select
@@ -4,7 +4,7 @@ set -e
 
 die() { echo >&2 "!! $*"; exit 1; }
 
-# FIXME Purge old files and use this one
+source /etc/default/desktop-wayland
 
 # File this script will modify, in addition to (potentially) the per-user sentinel file
 CONF_FILE="/etc/sddm.conf.d/zz-steamos-autologin.conf"
@@ -15,18 +15,22 @@ SENTINEL_FILE="steamos-session-select"
 CHECK_FILE="/etc/sddm.conf.d/steamos.conf"
 
 session="${1:-gamescope}"
-session_type="x11"
+if ${DESKTOP_WAYLAND}; then
+  session_type="wayland"
+else
+  session_type="x11"
+fi
 
 session_launcher=""
 create_sentinel=""
 
 if [[ "$2" == "--sentinel-created" ]]; then
-    SENTINEL_CREATED=1
-    if [[ "$3" == "x11" ]]; then
-       session_type="x11"
-    elif [[ "$3" == "wayland" ]]; then
-       session_type="wayland"
-    fi
+  SENTINEL_CREATED=1
+  if ${DESKTOP_WAYLAND}; then
+      session_type="wayland"
+  else
+      session_type="x11"
+  fi
 fi
 
 # Update config sentinel
@@ -42,7 +46,11 @@ if [[ -z $SENTINEL_CREATED ]]; then
     if [[ -f "steamos-session-type" ]]; then
       cp steamos-session-type "$SENTINEL_FILE"
     else
-      echo "x11" > "$SENTINEL_FILE"
+      if ${DESKTOP_WAYLAND}; then
+        echo "wayland" > "$SENTINEL_FILE"
+      else
+        echo "x11" > "$SENTINEL_FILE"
+      fi
     fi
     cat "$SENTINEL_FILE"
   )
@@ -59,10 +67,10 @@ case "$session" in
     session_launcher="plasmax11.desktop"
   ;;
   plasma)
-    if [[ "$session_type" == "x11" ]]; then
-      session_launcher="plasma-steamos-oneshot.desktop"
-    else
+    if ${DESKTOP_WAYLAND}; then
       session_launcher="plasma-steamos-wayland-oneshot.desktop"
+    else
+      session_launcher="plasma-steamos-oneshot.desktop"
     fi
     create_sentinel=1
   ;;

--- a/system_files/deck/shared/etc/default/desktop-wayland
+++ b/system_files/deck/shared/etc/default/desktop-wayland
@@ -1,0 +1,1 @@
+DESKTOP_WAYLAND=false

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -259,3 +259,12 @@ unhide-grub:
   else
     sudo grub2-mkconfig -o /boot/grub2/grub.cfg
   fi
+
+_toggle_wayland:
+  #!/usr/bin/env bash
+  source /etc/default/desktop-wayland
+  if ${DESKTOP_WAYLAND}; then
+    sudo sed -i 's/true/false/g' /etc/default/desktop-wayland
+  else
+    sudo sed -i 's/false/true/g' /etc/default/desktop-wayland
+  fi

--- a/system_files/deck/silverblue/usr/bin/gnome-session-oneshot
+++ b/system_files/deck/silverblue/usr/bin/gnome-session-oneshot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 set -e
 
@@ -25,7 +25,7 @@ function check_sentinel()
     cd "$HOME"
     cd "$config_dir"
     sentinel_value="$(cat "$SENTINEL_FILE")"
-    if [[ "$sentinel_value" == "x11" ]]; then
+    if [[ "$sentinel_value" == "x11" || "$sentinel_value" == "wayland" ]]; then
       echo "/usr/bin/gnome-session"
     else
       return 1

--- a/system_files/deck/silverblue/usr/bin/steamos-session-select
+++ b/system_files/deck/silverblue/usr/bin/steamos-session-select
@@ -1,8 +1,10 @@
-#! /usr/bin/bash
+#!/usr/bin/bash
 
 set -e
 
 die() { echo >&2 "!! $*"; exit 1; }
+
+source /etc/default/desktop-wayland
 
 # File this script will modify, in addition to (potentially) the per-user sentinel file
 CONF_FILE="/etc/sddm.conf.d/zz-steamos-autologin.conf"
@@ -13,14 +15,22 @@ SENTINEL_FILE="steamos-session-select"
 CHECK_FILE="/etc/sddm.conf.d/steamos.conf"
 
 session="${1:-gamescope}"
-session_type="x11"
+if ${DESKTOP_WAYLAND}; then
+  session_type="wayland"
+else
+  session_type="x11"
+fi
 
 session_launcher="gamescope-session"
 create_sentinel=""
 
 if [[ "$2" == "--sentinel-created" ]]; then
   SENTINEL_CREATED=1
-  session_type="x11"
+  if ${DESKTOP_WAYLAND}; then
+    session_type="wayland"
+  else
+    session_type="x11"
+  fi
 fi
 
 # Update config sentinel
@@ -36,7 +46,11 @@ if [[ -z $SENTINEL_CREATED ]]; then
     if [[ -f "steamos-session-type" ]]; then
       cp steamos-session-type "$SENTINEL_FILE"
     else
-      echo "x11" > "$SENTINEL_FILE"
+      if ${DESKTOP_WAYLAND}; then
+        echo "wayland" > "$SENTINEL_FILE"
+      else
+        echo "x11" > "$SENTINEL_FILE"
+      fi
     fi
     cat "$SENTINEL_FILE"
   )
@@ -52,13 +66,17 @@ fi
 # We use "plasma" as "desktop" to hook up to SteamOS's scripts
 case "$session" in
   plasma-wayland-persistent)
-    session_launcher="gnome-xorg"
+    session_launcher="gnome-session"
   ;;
   plasma-x11-persistent)
     session_launcher="gnome-xorg"
   ;;
   desktop|plasma)
-    session_launcher="gnome-xorg-oneshot"
+    if ${DESKTOP_WAYLAND}; then
+      session_launcher="gnome-session-oneshot"
+    else
+      session_launcher="gnome-xorg-oneshot"
+    fi
     create_sentinel=1
   ;;
   gamescope)

--- a/system_files/deck/silverblue/usr/share/wayland-sessions/gnome-session-oneshot.desktop
+++ b/system_files/deck/silverblue/usr/share/wayland-sessions/gnome-session-oneshot.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=GNOME on Xorg (single time session)
+Name=GNOME on Wayland (single time session)
 Comment=This session logs you into GNOME one time
 Exec=/usr/bin/gnome-session-oneshot
 TryExec=/usr/bin/gnome-session-oneshot


### PR DESCRIPTION
Adds support for toggling desktop Wayland sessions on and off for use with Steam's session switching. Off by default due to Steam Input not supporting Wayland on the desktop. To enable, run `sudo just --unstable _toggle_wayland`