### PR TITLE
fix(deck): Autostart Steam using desktop shortcut rather than firstboot launcher

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -126,6 +126,8 @@ RUN rm /usr/share/applications/shredder.desktop && \
     ln -s "/usr/share/ublue-os/firstboot/launcher/login-profile.sh" \
     "/usr/etc/profile.d/ublue-firstboot.sh" && \
     cp "/usr/share/ublue-os/firstboot/yafti.yml" "/etc/yafti.yml" && \
+    mkdir -p "/etc/xdg/autostart" && \
+    cp "/usr/share/applications/steam.desktop" "/etc/xdg/autostart" && \
     pip install --prefix=/usr yafti && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-distrobox-git.repo && \

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Simply launches the "yafti" GUI with the uBlue image's configuration.
-/usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml
-
-# Open Steam so that it can update
-/usr/bin/steam


### PR DESCRIPTION
This would forcefully open Steam every boot no matter whether or not users opted out of it in Steam