### PR TITLE
fix: Don't copy Steam shortcut to autostart on desktop

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -126,8 +126,6 @@ RUN rm /usr/share/applications/shredder.desktop && \
     ln -s "/usr/share/ublue-os/firstboot/launcher/login-profile.sh" \
     "/usr/etc/profile.d/ublue-firstboot.sh" && \
     cp "/usr/share/ublue-os/firstboot/yafti.yml" "/etc/yafti.yml" && \
-    mkdir -p "/etc/xdg/autostart" && \
-    cp "/usr/share/applications/steam.desktop" "/etc/xdg/autostart" && \
     pip install --prefix=/usr yafti && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-distrobox-git.repo && \
@@ -259,6 +257,8 @@ RUN rm /usr/share/applications/winetricks.desktop && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-info && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-notice && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-warning && \
+    mkdir -p "/etc/xdg/autostart" && \
+    cp "/usr/share/applications/steam.desktop" "/etc/xdg/autostart" && \
     cp "/usr/share/ublue-os/firstboot/yafti.yml" "/etc/yafti.yml" && \
     sed -i 's/#HandlePowerKey=poweroff/HandlePowerKey=suspend/g' /etc/systemd/logind.conf && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \


### PR DESCRIPTION
This shortcut doesn't exist on desktop as Steam isn't layered