### PR TITLE
fix(user-setup): Convert to simple service and use default target

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/user/bazzite-user-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/user/bazzite-user-setup.service
@@ -4,9 +4,8 @@ Requires=xdg-desktop-autostart.target
 ConditionPathExists=!%h/.bazzite-configured
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 ExecStart=/usr/bin/bazzite-user-setup
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Convert bazzite-user-setup to a simple service and use default target (multi-user target is only available to system services, the default target is used for user services)