### PR TITLE
feat: Move Flatpak modifications to setup scripts

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -70,19 +70,6 @@ screens:
           default: false
           packages:
           - Switch SteamOS-BTRFS config to EXT4: sudo -A just --unstable switch-to-ext4
-  can-we-modify-your-flatpaks:
-    source: yafti.screen.consent
-    values:
-      title: Setting up Flathub
-      condition:
-        run: flatpak remotes --system | grep -q fedora
-      description: |
-        WARNING: This will modify your Flatpaks if you are rebasing! If you do not want to do this exit the installer.
-      actions:
-      - run: /usr/lib/fedora-third-party/fedora-third-party-opt-out
-      - run: /usr/bin/fedora-third-party disable
-      - run: flatpak remote-delete fedora --force
-      - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   applications:
     source: yafti.screen.package
     values:

--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -42,6 +42,12 @@ else
   fi
 fi
 
+# Setup Flathub
+if grep -qz 'fedora' <<< $(flatpak remotes); then
+  flatpak remote-delete fedora --force
+fi
+flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+
 # Prevent future executions
 echo "Writing state file"
 touch $HOME/.bazzite-configured

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
+if grep -qz 'fedora' <<< $(flatpak remotes); then
+  /usr/lib/fedora-third-party/fedora-third-party-opt-out
+  /usr/bin/fedora-third-party disable
+fi
+
 if [[ -f '/etc/flatpak/install' ]]; then
   cat /etc/flatpak/install | while read line; do
     flatpak install --system --noninteractive flathub $line

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -78,19 +78,6 @@ screens:
       packages:
         - GreenWithEnvy (GPU Overclocking): flatpak install --user --noninteractive com.leinardi.gwe
         - Supergfxctl (Hybrid GPU Switching): just --unstable enable-supergfxctl
-  can-we-modify-your-flatpaks:
-    source: yafti.screen.consent
-    values:
-      title: Setting up Flathub
-      condition:
-        run: flatpak remotes --system | grep -q fedora
-      description: |
-        WARNING: This will modify your Flatpaks if you are rebasing! If you do not want to do this exit the installer.
-      actions:
-      - run: /usr/lib/fedora-third-party/fedora-third-party-opt-out
-      - run: /usr/bin/fedora-third-party disable
-      - run: flatpak remote-delete fedora --force
-      - run: flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
   applications:
     source: yafti.screen.package
     values:


### PR DESCRIPTION
Moves Fedora's third party repository opt-out from Yafti to ublue-flatpak-system-install (this was actually previously no-op here and on Bluefin since it requires root), and moves user Flathub setup to the Bazzite user setup script