### PR TITLE
fix(deck): Extend GRUB hidden timeout to 3 seconds

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -187,7 +187,7 @@ hide-grub:
   #!/usr/bin/env bash  
   sudo sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/g' /etc/default/grub
   echo 'GRUB_TIMEOUT_STYLE=hidden' | sudo tee -a /etc/default/grub 1>/dev/null
-  echo 'GRUB_HIDDEN_TIMEOUT=1' | sudo tee -a /etc/default/grub 1>/dev/null
+  echo 'GRUB_HIDDEN_TIMEOUT=3' | sudo tee -a /etc/default/grub 1>/dev/null
   if [ -f '/boot/efi/EFI/fedora/grub.cfg' ]; then
     sudo grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
   else
@@ -196,7 +196,7 @@ hide-grub:
 
 unhide-grub:
   #!/usr/bin/env bash
-  sudo sed -i '/GRUB_HIDDEN_TIMEOUT=1/d' /etc/default/grub
+  sudo sed -i '/GRUB_HIDDEN_TIMEOUT=3/d' /etc/default/grub
   sudo sed -i '/GRUB_TIMEOUT_STYLE=hidden/d' /etc/default/grub
   sudo sed -i 's/GRUB_TIMEOUT=0/GRUB_TIMEOUT=5/g' /etc/default/grub
   if [ -f '/boot/efi/EFI/fedora/grub.cfg' ]; then


### PR DESCRIPTION
Resolves issues with 1 second being too short for Deck users to access GRUB