### PR TITLE
chore(ci): Disable Bazzite Deck Nvidia images for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
           - major_version: 38
             is_latest_version: true
             is_stable_version: true
+        exclude:
+          - base_name: bazzite-deck
+            image_flavor: nvidia
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action


### PR DESCRIPTION
Currently Nvidia GPUs don't support gamescope-session very well, making these images hard to justify. To be reverted when gamescope-session actually supports Nvidia cards well enough