### PR TITLE
fix: Let Universal Blue Update handle automatic updates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -135,6 +135,7 @@ RUN rm /usr/share/applications/shredder.desktop && \
     "/usr/etc/profile.d/ublue-firstboot.sh" && \
     cp "/usr/share/ublue-os/firstboot/yafti.yml" "/etc/yafti.yml" && \
     pip install --prefix=/usr yafti && \
+    sed -i 's/stage/none/g' /etc/rpm-ostreed.conf && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-bazzite-multilib.repo && \

--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -29,6 +29,10 @@ else
   echo 'Enabling VRR'
   gsettings set org.gnome.mutter experimental-features "['variable-refresh-rate']"
 
+  echo 'Disabling automatic GNOME Software updates'
+  gsettings set org.gnome.software download-updates false
+  gsettings set org.gnome.software download-updates-notify false
+
   echo 'Installing Gradience presets'
   mkdir -p $HOME/.config/presets/user/
   ln -s /usr/share/ublue-os/bazzite/themes/vapor.json $HOME/.config/presets/user/vapor.json


### PR DESCRIPTION
Removes the burden of updating the system from rpm-ostree and GNOME Software and places it on ublue-update