### PR TITLE
fix(GNOME): Allow gnome-ssh-askpass to inhibit shortcuts

### DIFF
--- a/system_files/desktop/silverblue/usr/share/applications/gnome-ssh-askpass.desktop
+++ b/system_files/desktop/silverblue/usr/share/applications/gnome-ssh-askpass.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=GNOME ssh-askpass
+GenericName=ssh-askpass
+Type=Application
+Exec=/usr/libexec/openssh/gnome-ssh-askpass
+Terminal=false
+NoDisplay=true


### PR DESCRIPTION
If initially opted into

Otherwise GNOME Shell (specifically under Wayland) will continuously prompt the user asking for permission to do so. This requires a desktop file be present so this adds one and hides it from the application menu