### PR TITLE
chore(ci): Enable PR tagged images on pull request approval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - '**.txt'
       - 'repo_content/**'
       - 'spec_files/**'
+  pull_request_review:
+    type: [submitted]
   push:
     branches:
       - main
@@ -26,6 +28,7 @@ env:
 jobs:
   push-ghcr:
     name: Build and push image
+    if: github.event.review.state == 'approved' || github.event_name != 'pull_request_review'
     runs-on: buildjet-2vcpu-ubuntu-2204
     permissions:
       contents: read
@@ -164,7 +167,7 @@ jobs:
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
         id: push
-        if: github.event_name != 'pull_request'
+        if: github.event.review.state == 'approved' || github.event_name != 'pull_request'
         env:
           REGISTRY_USER: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ github.token }}
@@ -179,7 +182,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: github.event_name != 'pull_request'
+        if: github.event.review.state == 'approved' || github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -187,10 +190,10 @@ jobs:
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.1.1
-        if: github.event_name != 'pull_request'
+        if: github.event.review.state == 'approved' || github.event_name != 'pull_request'
 
       - name: Sign container image
-        if: github.event_name != 'pull_request'
+        if: github.event.review.state == 'approved' || github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
@@ -199,6 +202,6 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       - name: Echo outputs
-        if: github.event_name != 'pull_request'
+        if: github.event.review.state == 'approved' || github.event_name != 'pull_request'
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"


### PR DESCRIPTION
Submits an image to the GitHub Container Registry on pull request approval, permitting approved pull requests to be tested before being merged.

Requires branch protection rule: 'Require approval of the most recent reviewable push'

This rule ensures that the state of a PR is reset after a new commit has been pushed to an open pull request.