### PR TITLE
fix(ci): Yet another patch to ensure the PR number is always in the tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           COMMIT_TAGS+=("${SHA_SHORT}-${MAJOR_VERSION}")
           if [[ "${{ matrix.is_latest_version }}" == "true" ]] && \
              [[ "${{ matrix.is_stable_version }}" == "true" ]]; then
-              COMMIT_TAGS+=("pr-${{ github.event.number }}")
+              COMMIT_TAGS+=("pr-${{ github.event.pull_request.number }}")
               COMMIT_TAGS+=("${SHA_SHORT}")
           fi
 


### PR DESCRIPTION
Got this in main, overlooked it here. Didn't notice it as the prior fix still resulted in a proper push.