### PR TITLE
feat: Add new powerbuttond daemon from upstream Steam OS

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -261,6 +261,7 @@ RUN rpm-ostree install \
     mesa-va-drivers \
     jupiter-fan-control \
     jupiter-hw-support-btrfs \
+    powerbuttond \
     vpower \
     ds-inhibit \
     steam_notif_daemon \

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Ported SteamOS and ChimeraOS packages, among others used by Bazzite, are built o
 |jupiter-hw-support-[btrfs](https://gitlab.com/popsulfr/steamos-btrfs)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/jupiter-hw-support-btrfs/status_image/last_build.png?)|
 |[mangohud](https://github.com/flightlessmango/MangoHud)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite-multilib/package/mangohud/status_image/last_build.png?)|
 |mesa|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite-multilib/package/mesa/status_image/last_build.png?)|
+|powerbuttond|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/powerbuttond/status_image/last_build.png?)|
 |[python3-hid](https://github.com/apmorton/pyhidapi)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/python3-hid/status_image/last_build.png?)|
 |[ryzenadj](https://github.com/FlyGoat/RyzenAdj)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/ryzenadj/status_image/last_build.png?)|
 |[sddm-sugar-steamOS](https://github.com/JiayuanWen/sddm-sugar-steamOS)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/sddm-sugar-steamOS/status_image/last_build.png?)|

--- a/spec_files/powerbuttond/LICENSE
+++ b/spec_files/powerbuttond/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2023, Valve Software
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/spec_files/powerbuttond/powerbuttond.spec
+++ b/spec_files/powerbuttond/powerbuttond.spec
@@ -1,0 +1,37 @@
+Name:           powerbuttond
+Version:        {{{ git_dir_version }}}
+Release:        1%{?dist}
+Summary:        Steam Deck power button daemon
+
+License:        BSD
+URL:            https://gitlab.com/evlaV/%{name}/
+Source:         %{url}-/archive/main/%{name}-main.tar.gz
+
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  libevdev-devel
+BuildRequires:  cmake
+BuildRequires:  gcc
+
+Requires:       libevdev
+
+%description
+Steam Deck power button daemon
+
+# Disable debug packages
+%define debug_package %{nil}
+
+%prep
+%autosetup -n %{name}-main -p1
+
+%build
+%make_build
+
+%install
+install -D -m 755 %{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%{_bindir}/%{name}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Replaces previously used python solution.

See required supporting change in `gamescope-session` [here](https://github.com/KyleGospo/gamescope-session/commit/134eb89dfaaa30a028a05920f2449629d6fb36c1).