### PR TITLE
feat: Add a script for fixing tcmalloc for TF2

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -91,6 +91,11 @@ get-boilr:
     cp ~/.local/share/applications/BoilR.desktop ~/Desktop
   fi
 
+fix-tf2-tcmalloc:
+  podman run \
+  -v $HOME/.steam/steam/steamapps/common/Team\ Fortress\ 2/bin:/hl2_linux:Z \
+  ghcr.io/maisatanel/tcmalloc-hl2-fixer:main
+
 enable-vapor-theme:
   #!/usr/bin/env bash
   source /etc/default/bazzite


### PR DESCRIPTION
Wanted to play TF2 on my Deck and discovered that it segfaults immediately on launch. I've encountered this issue before: this is because of Valve using an ancient version of tcmalloc for Source 1 games. So I made a [32-bit Debian container with latest tcmalloc installed which copies a fresher version of tcmalloc_minimal.so to the TF2 install folder](https://github.com/maisatanel/tcmalloc-hl2-fixer). Figured this would be useful as one of just scripts.