### PR TITLE
Fix waydroid script

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -22,10 +22,14 @@ configure-waydroid:
   #!/usr/bin/env bash
   SCRIPT='/tmp/waydroid_script'
   git clone https://github.com/casualsnek/waydroid_script --depth 1 ${SCRIPT}
-  sudo pip install --user -r ${SCRIPT}/requirements.txt
+  python -m venv venv
+  source venv/bin/activate
+  sudo pip install -r ${SCRIPT}/requirements.txt
   sudo ${SCRIPT}/main.py
-  sudo pip uninstall -r ${SCRIPT}/requirements.txt
-  rm -rf ${SCRIPT}
+  sudo pip uninstall -r ${SCRIPT}/requirements.txt -y
+  deactivate
+  sudo rm -rf ${SCRIPT}
+
 
 get-decky:
   #!/usr/bin/env bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -26,10 +26,13 @@ configure-waydroid:
   #!/usr/bin/env bash
   SCRIPT='/tmp/waydroid_script'
   git clone https://github.com/casualsnek/waydroid_script --depth 1 ${SCRIPT}
-  sudo pip install --user -r ${SCRIPT}/requirements.txt
+  python -m venv venv
+  source venv/bin/activate
+  sudo pip install -r ${SCRIPT}/requirements.txt
   sudo ${SCRIPT}/main.py
-  sudo pip uninstall -r ${SCRIPT}/requirements.txt
-  rm -rf ${SCRIPT}
+  sudo pip uninstall -r ${SCRIPT}/requirements.txt -y
+  deactivate
+  sudo rm -rf ${SCRIPT}
 
 install-corectrl:
   echo 'Installing CoreCtrl...'


### PR DESCRIPTION
This fixes the just configure-waydroid script not properly cleaning itself up, and puts all of the dependencies into a virtual environment to further prevent any messiness. 