### PR TITLE
feat(user-setup): Enable NTP by default

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -58,6 +58,9 @@ else
   fi
 fi
 
+# Enable NTP
+timedatectl set-ntp true
+
 # Setup Flathub
 if grep -qz 'fedora' <<< $(flatpak remotes); then
   flatpak remote-delete --user fedora --force


### PR DESCRIPTION
Enable NTP by default. No one likes inaccurate clocks