### PR TITLE
(fix) Make batterylimit.service work properly

### DIFF
--- a/system_files/deck/shared/etc/systemd/system/batterylimit.service
+++ b/system_files/deck/shared/etc/systemd/system/batterylimit.service
@@ -4,7 +4,7 @@ Description=Service for setting the Steam Deck Battery Charging Limit
 [Service]
 Type=oneshot
 EnvironmentFile=-/etc/default/%p
-ExecStart=echo ${MAX_BATTERY_CHARGE_LEVEL} > /sys/class/hwmon/hwmon*/max_battery_charge_level
+ExecStart=/usr/bin/bash -c "echo ${MAX_BATTERY_CHARGE_LEVEL} > /sys/class/hwmon/hwmon*/max_battery_charge_level"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It seems that you cannot use input redirection directly when running the command. Pass the command to bash instead seems to make it work correctly.