### PR TITLE
fix(user-setup): Ensure user always has working justfile

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
+if [[ -f "${HOME}/.justfile" ]]; then
+  if grep -Eqvz "main|nvidia|custom" "${HOME}/.justfile"; then
+    mv "${HOME}/.justfile" "${HOME}/.justfile.old"
+    cd /usr/share/ublue-os/just
+    for justfile in *.just; do
+      echo "!include ${PWD}/${justfile}" >> "${HOME}/.justfile"
+    done
+    cd ~
+  fi
+else
+  cd /usr/share/ublue-os/just
+  for justfile in *.just; do
+    echo "!include ${PWD}/${justfile}" >> "${HOME}/.justfile"
+  done
+  cd ~
+fi
+
 if [[ $BASE_IMAGE_NAME =~ "kinoite"  ]]; then
   echo 'Running setup for Kinoite'
 


### PR DESCRIPTION
Backs up old file just in case there are user recipes there. Fixes https://github.com/ublue-os/bazzite/issues/186