### PR TITLE
fix(desktop): boot scripts slowdown

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
+DONEFILE=/etc/bazzite/hardware_setup_done
+if [[ -e "$DONEFILE" ]] ; then 
+  printf "Hardware was already properly set up. To run this script again, delete %s\n" "$DONEFILE"
+  exit 0
+fi
+
 # GLOBAL
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 KARGS=$(rpm-ostree kargs)
@@ -75,9 +81,11 @@ if [[ ! $KARGS =~ "rd.luks.options" ]]; then
   NEEDED_KARGS="$NEEDED_KARGS --append=rd.luks.options=discard"
 fi
 
-if [[ ! -z "$NEEDED_KARGS" ]]; then
+if [[ -n "$NEEDED_KARGS" ]]; then
   echo "Found needed karg changes, applying the following: $NEEDED_KARGS"
-  rpm-ostree kargs ${NEEDED_KARGS} --reboot
+  rpm-ostree kargs ${NEEDED_KARGS} --reboot || exit 1
+  mkdir -p "$(dirname "$DONEFILE")"
+  touch "$DONEFILE"
 else
   echo "No karg changes needed"
 fi

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -2,10 +2,6 @@
 source /etc/default/bazzite
 
 DONEFILE=/etc/bazzite/hardware_setup_done
-if [[ -e "$DONEFILE" ]] ; then 
-  printf "Hardware was already properly set up. To run this script again, delete %s\n" "$DONEFILE"
-  exit 0
-fi
 
 # GLOBAL
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
-FLATPAK_INSTALLED_CONDITION_CHECK="/etc/bazzite/sys_flatpak_configured"
+DONEFILE="/etc/bazzite/sys_flatpak_done"
 
-if [[ -f "$FLATPAK_INSTALLED_CONDITION_CHECK" ]] ; then
-  printf "System flatpaks are already installed (%s)" "$FLATPAK_INSTALLED_CONDITION_CHECK"
+if [[ -f "$DONEFILE" ]] ; then
+  printf "System flatpaks were already installed. To run this script again, delete %s\n" "$DONEFILE"
   exit 0
 fi
 
@@ -36,5 +36,5 @@ if [[ -f '/etc/flatpak/deck' ]]; then
 fi
 
 rm -rf /etc/flatpak/{deck,flathub,objects}
-mkdir /etc/bazzite
-touch "$FLATPAK_INSTALLED_CONDITION_CHECK"
+mkdir -p "$(dirname "$DONEFILE")"
+touch "$DONEFILE"

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
-DONEFILE="/etc/bazzite/sys_flatpak_done"
-
-if [[ -f "$DONEFILE" ]] ; then
-  printf "System flatpaks were already installed. To run this script again, delete %s\n" "$DONEFILE"
-  exit 0
-fi
-
 if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/lib/fedora-third-party/fedora-third-party-opt-out
   /usr/bin/fedora-third-party disable
@@ -36,5 +29,3 @@ if [[ -f '/etc/flatpak/deck' ]]; then
 fi
 
 rm -rf /etc/flatpak/{deck,flathub,objects}
-mkdir -p "$(dirname "$DONEFILE")"
-touch "$DONEFILE"

--- a/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
+++ b/system_files/desktop/shared/usr/bin/ublue-flatpak-system-install
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
+FLATPAK_INSTALLED_CONDITION_CHECK="/etc/bazzite/sys_flatpak_configured"
+
+if [[ -f "$FLATPAK_INSTALLED_CONDITION_CHECK" ]] ; then
+  printf "System flatpaks are already installed (%s)" "$FLATPAK_INSTALLED_CONDITION_CHECK"
+  exit 0
+fi
+
 if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/lib/fedora-third-party/fedora-third-party-opt-out
   /usr/bin/fedora-third-party disable
@@ -29,3 +36,5 @@ if [[ -f '/etc/flatpak/deck' ]]; then
 fi
 
 rm -rf /etc/flatpak/{deck,flathub,objects}
+mkdir /etc/bazzite
+touch "$FLATPAK_INSTALLED_CONDITION_CHECK"

--- a/system_files/desktop/shared/usr/lib/systemd/system/bazzite-hardware-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/bazzite-hardware-setup.service
@@ -7,6 +7,7 @@ Before=systemd-user-sessions.service jupiter-biosupdate.service jupiter-controll
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/bazzite-hardware-setup
+ConditionPathExists=!/etc/bazzite/hardware_setup_done
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Some scripts slow down the boot process when their services are enabled. The only fix for now is just to disable them, but with this PR it checks whether or not they already ran and skips them if so.
The problems is that if for some reason someone changes their hardware, those should be manually ran again by the user, so maybe there should be an option in Yafti or something like that for re-enabling these scripts.