### PR TITLE
fix(steamos-update): Don't trigger updates during checks and increase progress bar granularity

### DIFF
--- a/system_files/deck/shared/usr/bin/steamos-update
+++ b/system_files/deck/shared/usr/bin/steamos-update
@@ -1,7 +1,28 @@
 #!/bin/bash
 
+# The Steam client is known to call this script with the following parameter combinations:
+# steamos-update --supports-duplicate-detection     -- should do nothing
+# steamos-update --enable-duplicate-detection check -- should check for update
+# steamos-update check                              -- should check for update
+# steamos-update                                    -- should perform an update
+
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    check)
+      CHECK=1
+      shift
+      ;;
+    *)
+      SKIP=1
+      shift
+      ;;
+  esac
+done
+
+
 if command -v ublue-update > /dev/null; then
-  if [ "$1" == "check" ]; then
+  if [ -n "${CHECK}" ]; then
     if [ -f '/tmp/upgrade-installed' ]; then
       exit 7 # Upgrade already installed
     else
@@ -19,7 +40,7 @@ if command -v ublue-update > /dev/null; then
         exit 7 # Connectivity check failed
       fi
     fi
-  elif [ "$1" == "--supports-duplicate-detection" ]; then
+  elif [ -n "${SKIP}" ]; then
     exit 0
   else
     # Fake upgrade progress bar

--- a/system_files/deck/shared/usr/bin/steamos-update
+++ b/system_files/deck/shared/usr/bin/steamos-update
@@ -47,10 +47,10 @@ if command -v ublue-update > /dev/null; then
     fake_progress() {
       local value=0
       while [ ! -f '/tmp/upgrade-check' ]; do
-        sleep 5
+        sleep 3
         if [ ${value} -lt '100' ]; then
           echo ${value}'%'
-          value=$(( value + 3 ))
+          value=$(( value + 1 ))
         fi
       done
       echo 100%


### PR DESCRIPTION
See: ChimeraOS/gamescope-session@2ef3a1f

Also increases the length and granularity of the progress bar