### PR TITLE
chore(just): Don't sign image in a subshell

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -284,6 +284,5 @@ _toggle_wayland:
   fi
 
 sign-image:
-  #!/usr/bin/env bash
-  source /etc/default/bazzite
+  source /etc/default/bazzite && \
   rpm-ostree rebase ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${FEDORA_MAJOR_VERSION}

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -199,6 +199,5 @@ unhide-grub:
   fi
 
 sign-image:
-  #!/usr/bin/env bash
-  source /etc/default/bazzite
+  source /etc/default/bazzite && \
   rpm-ostree rebase ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${FEDORA_MAJOR_VERSION}


### PR DESCRIPTION
This allows the signing process to be viewed in yafti's console