### PR TITLE
fix(desktop): condition checked at proper section in bazzite-hardware-setup systemd service

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/bazzite-hardware-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/bazzite-hardware-setup.service
@@ -2,12 +2,12 @@
 Description=Configure Bazzite for current hardware
 After=rpm-ostreed.service
 Before=systemd-user-sessions.service jupiter-biosupdate.service jupiter-controller-update.service
+ConditionPathExists=!/etc/bazzite/hardware_setup_done
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/bazzite-hardware-setup
-ConditionPathExists=!/etc/bazzite/hardware_setup_done
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hello! I've sent this PR for making sure the boot gets a bit faster by checking this file. But sadly I forgot that the condition check should be ran at the `[Unit]` key, not the `[Service]`, so this service wasn't running for anyone for a bit of time. I'm so so sorry for wasting your time. But at least here's a fix for it