### PR TITLE
fix(sign-image): Pull current image from rpm-ostree and fallback to image identifiers

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -288,4 +288,31 @@ _toggle_wayland:
 
 sign-image:
   source /etc/default/bazzite && \
-  rpm-ostree rebase ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${FEDORA_MAJOR_VERSION}
+  if grep -qvz "/var/${IMAGE_VENDOR}/image" <<< $(rpm-ostree status); then \
+    rpm-ostree rebase ostree-image-signed:$(just --unstable _get-image); \
+  else \
+    rpm-ostree rebase ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${FEDORA_MAJOR_VERSION}; \
+  fi
+
+_get-image:
+  #!/usr/bin/env python
+  from json import loads
+  from subprocess import PIPE, run
+
+  """Pull deployment status via rpm-ostree"""
+  status = "rpm-ostree status --json"
+  out = run(status, shell=True, stdout=PIPE).stdout
+
+  """Parse current image"""
+  deployments = loads(out)["deployments"][0]
+  current_image = deployments["container-image-reference"].split(":", 1)
+
+  """Dissect current image to form URL to latest image"""
+  protocol = "docker://"
+  url = current_image[1]
+
+  """Add protocol if URL doesn't contain it"""
+  if protocol not in url:
+    url = protocol + url
+
+  print(url)

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -195,4 +195,31 @@ unhide-grub:
 
 sign-image:
   source /etc/default/bazzite && \
-  rpm-ostree rebase ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${FEDORA_MAJOR_VERSION}
+  if grep -qvz "/var/${IMAGE_VENDOR}/image" <<< $(rpm-ostree status); then \
+    rpm-ostree rebase ostree-image-signed:$(just --unstable _get-image); \
+  else \
+    rpm-ostree rebase ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${FEDORA_MAJOR_VERSION}; \
+  fi
+
+_get-image:
+  #!/usr/bin/env python
+  from json import loads
+  from subprocess import PIPE, run
+
+  """Pull deployment status via rpm-ostree"""
+  status = "rpm-ostree status --json"
+  out = run(status, shell=True, stdout=PIPE).stdout
+
+  """Parse current image"""
+  deployments = loads(out)["deployments"][0]
+  current_image = deployments["container-image-reference"].split(":", 1)
+
+  """Dissect current image to form URL to latest image"""
+  protocol = "docker://"
+  url = current_image[1]
+
+  """Add protocol if URL doesn't contain it"""
+  if protocol not in url:
+    url = protocol + url
+
+  print(url)


### PR DESCRIPTION
If offline install media was used, use image identifiers for image signing. Otherwise, pull the current image information from rpm-ostree.

This addresses issues rebasing from tags other than tags using the Fedora version number.
