### PR TITLE
fix(deck): Fix stuttering volume in microphone

### DIFF
--- a/system_files/deck/shared/etc/pipewire/99-input-denoising.conf
+++ b/system_files/deck/shared/etc/pipewire/99-input-denoising.conf
@@ -9,11 +9,10 @@ context.modules = [
                     type = ladspa
                     name = rnnoise
                     plugin = /usr/lib64/ladspa/librnnoise_ladspa.so
-                    label = noise_suppressor_mono
+                    label = noise_suppressor_stereo
                     control = {
                         "VAD Threshold (%)" = 23.0
                         "VAD Grace Period (ms)" = 200
-                        "Retroactive VAD Grace (ms)" = 0
                     }
                 }
                 {

--- a/system_files/deck/shared/etc/wireplumber/main.lua.d/60-alsa-acp5x-config.lua
+++ b/system_files/deck/shared/etc/wireplumber/main.lua.d/60-alsa-acp5x-config.lua
@@ -1,0 +1,19 @@
+--ACP5X card hardware never hibernates, so remove the pops and lags.
+
+table.insert (alsa_monitor.rules, {
+  matches = {
+    {
+      -- Matches all sources from card acp5x
+      { "node.name", "matches", "alsa_input.*" },
+      { "alsa.card_name", "matches", "acp5x" },
+    },
+    {
+      -- Matches all sinks from card acp5x
+      { "node.name", "matches", "alsa_output.*" },
+      { "alsa.card_name", "matches", "acp5x" },
+    },
+  },
+  apply_properties = {
+    ["session.suspend-timeout-seconds"] = 0,
+  }
+})

--- a/system_files/deck/shared/etc/wireplumber/main.lua.d/60-alsa-card0-config.lua
+++ b/system_files/deck/shared/etc/wireplumber/main.lua.d/60-alsa-card0-config.lua
@@ -1,0 +1,25 @@
+-- HDMI output is always plugged in card 0 (HD_Audio Generic)
+-- We always give higher priority to nodes from that card
+-- Disable suspend timeout for HDMI to remove audio delay after idle
+
+table.insert (alsa_monitor.rules, {
+  matches = {
+    {
+      -- Matches all sources from card HD-Audio Generic
+      { "node.name", "matches", "alsa_input.*" },
+      { "alsa.card_name", "matches", "HD-Audio Generic" },
+    },
+    {
+      -- Matches all sinks from card HD-Audio Generic
+      { "node.name", "matches", "alsa_output.*" },
+      { "alsa.card_name", "matches", "HD-Audio Generic" },
+    },
+  },
+  apply_properties = {
+    ["priority.driver"]        = 900,
+    ["priority.session"]       = 900,
+    ["api.alsa.period-size"]   = 256,
+    ["api.alsa.headroom"]      = 1024,
+    ["session.suspend-timeout-seconds"] = 0
+  }
+})

--- a/system_files/deck/shared/etc/wireplumber/main.lua.d/60-alsa-ps-controller-config.lua
+++ b/system_files/deck/shared/etc/wireplumber/main.lua.d/60-alsa-ps-controller-config.lua
@@ -1,0 +1,21 @@
+-- PS4/PS5 Controller output is always referenced as Wireless Controller
+-- We always give the lowest priority to nodes from that card
+
+table.insert (alsa_monitor.rules, {
+  matches = {
+    {
+      -- Matches all sources from card Controller
+      { "node.name", "matches", "alsa_input.*" },
+      { "alsa.card_name", "matches", "Wireless Controller" },
+    },
+    {
+      -- Matches all sinks from card Wireless Controller
+      { "node.name", "matches", "alsa_output.*" },
+      { "alsa.card_name", "matches", "Wireless Controller" },
+    },
+  },
+  apply_properties = {
+    ["priority.driver"]        = 99,
+    ["priority.session"]       = 99,
+  }
+})

--- a/system_files/deck/shared/var/lib/alsa/asound.state
+++ b/system_files/deck/shared/var/lib/alsa/asound.state
@@ -1,0 +1,2508 @@
+state.Generic {
+	control.1 {
+		iface CARD
+		name 'HDMI/DP,pcm=3 Jack'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'IEC958 Playback Con Mask'
+		value '0fff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'IEC958 Playback Pro Mask'
+		value '0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'IEC958 Playback Default'
+		value '0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'IEC958 Playback Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.6 {
+		iface PCM
+		device 3
+		name ELD
+		value ''
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 0
+		}
+	}
+	control.7 {
+		iface CARD
+		name 'HDMI/DP,pcm=7 Jack'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'IEC958 Playback Con Mask'
+		index 1
+		value '0fff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'IEC958 Playback Pro Mask'
+		index 1
+		value '0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'IEC958 Playback Default'
+		index 1
+		value '0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'IEC958 Playback Switch'
+		index 1
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.12 {
+		iface PCM
+		device 7
+		name ELD
+		value ''
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 0
+		}
+	}
+	control.13 {
+		iface CARD
+		name 'HDMI/DP,pcm=8 Jack'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'IEC958 Playback Con Mask'
+		index 2
+		value '0fff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'IEC958 Playback Pro Mask'
+		index 2
+		value '0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'IEC958 Playback Default'
+		index 2
+		value '0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'IEC958 Playback Switch'
+		index 2
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.18 {
+		iface PCM
+		device 8
+		name ELD
+		value '100008006c14000100000000000000003669a83c4d41473237345152462d514409170700'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 36
+		}
+	}
+	control.19 {
+		iface CARD
+		name 'HDMI/DP,pcm=9 Jack'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'IEC958 Playback Con Mask'
+		index 3
+		value '0fff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'IEC958 Playback Pro Mask'
+		index 3
+		value '0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'IEC958 Playback Default'
+		index 3
+		value '0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'IEC958 Playback Switch'
+		index 3
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface PCM
+		device 9
+		name ELD
+		value ''
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 0
+		}
+	}
+	control.25 {
+		iface PCM
+		device 3
+		name 'Playback Channel Map'
+		value.0 0
+		value.1 0
+		value.2 0
+		value.3 0
+		value.4 0
+		value.5 0
+		value.6 0
+		value.7 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 8
+			range '0 - 36'
+		}
+	}
+	control.26 {
+		iface PCM
+		device 7
+		name 'Playback Channel Map'
+		value.0 0
+		value.1 0
+		value.2 0
+		value.3 0
+		value.4 0
+		value.5 0
+		value.6 0
+		value.7 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 8
+			range '0 - 36'
+		}
+	}
+	control.27 {
+		iface PCM
+		device 8
+		name 'Playback Channel Map'
+		value.0 0
+		value.1 0
+		value.2 0
+		value.3 0
+		value.4 0
+		value.5 0
+		value.6 0
+		value.7 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 8
+			range '0 - 36'
+		}
+	}
+	control.28 {
+		iface PCM
+		device 9
+		name 'Playback Channel Map'
+		value.0 0
+		value.1 0
+		value.2 0
+		value.3 0
+		value.4 0
+		value.5 0
+		value.6 0
+		value.7 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 8
+			range '0 - 36'
+		}
+	}
+}
+state.acp5x {
+	control.1 {
+		iface MIXER
+		name 'Mic Volume'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 2400
+			dbvalue.0 2400
+			dbvalue.1 2400
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Headphone Bypass Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 -9999999
+			dbvalue.1 -9999999
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 2
+		value.1 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 3'
+			dbmin -900
+			dbmax 0
+			dbvalue.0 -300
+			dbvalue.1 -300
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Digital Playback Volume'
+		value.0 207
+		value.1 207
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 207'
+			dbmin -9999999
+			dbmax 3750
+			dbvalue.0 3750
+			dbvalue.1 3750
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'Frontend PGA Volume'
+		value.0 27
+		value.1 27
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 37'
+			dbmin -100
+			dbmax 3600
+			dbvalue.0 2600
+			dbvalue.1 2600
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'Headphone Crosstalk Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 2400
+			dbvalue.0 -9999999
+			dbvalue.1 -9999999
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'ADC DRC KNEE4'
+		value 48
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9800
+			dbmax -3500
+			dbvalue.0 -5000
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'ADC DRC KNEE3'
+		value 45
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -8100
+			dbmax -1800
+			dbvalue.0 -3600
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'ADC DRC Noise Gate'
+		value '4:1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1:1'
+			item.1 '2:1'
+			item.2 '4:1'
+			item.3 '8:1'
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'ADC DRC Expansion Slope'
+		value '4:1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1:1'
+			item.1 '2:1'
+			item.2 '4:1'
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'ADC DRC Lower Region'
+		value '1:1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0'
+			item.1 '1:2'
+			item.2 '1:4'
+			item.3 '1:8'
+			item.4 '1:16'
+			item.5 ''
+			item.6 ''
+			item.7 '1:1'
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'ADC DRC Higher Region'
+		value '1:1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0'
+			item.1 '1:2'
+			item.2 '1:4'
+			item.3 '1:8'
+			item.4 '1:16'
+			item.5 ''
+			item.6 ''
+			item.7 '1:1'
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'ADC DRC Limiter Slope'
+		value '1:1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0'
+			item.1 '1:2'
+			item.2 '1:4'
+			item.3 '1:8'
+			item.4 '1:16'
+			item.5 '1:32'
+			item.6 '1:64'
+			item.7 '1:1'
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'ADC DRC Peak Detection Attack Time'
+		value '15Ts'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Ts
+			item.1 '3Ts'
+			item.2 '7Ts'
+			item.3 '15Ts'
+			item.4 '31Ts'
+			item.5 '63Ts'
+			item.6 '127Ts'
+			item.7 '255Ts'
+			item.8 ''
+			item.9 '511Ts'
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'ADC DRC Peak Detection Release Time'
+		value '1023Ts'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '63Ts'
+			item.1 '127Ts'
+			item.2 '255Ts'
+			item.3 '511Ts'
+			item.4 '1023Ts'
+			item.5 '2047Ts'
+			item.6 '4095Ts'
+			item.7 '8191Ts'
+			item.8 ''
+			item.9 '16383Ts'
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'ADC DRC Attack Time'
+		value '63Ts'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Ts
+			item.1 '3Ts'
+			item.2 '7Ts'
+			item.3 '15Ts'
+			item.4 '31Ts'
+			item.5 '63Ts'
+			item.6 '127Ts'
+			item.7 '255Ts'
+			item.8 '511Ts'
+			item.9 '1023Ts'
+			item.10 '2047Ts'
+			item.11 '4095Ts'
+			item.12 '8191Ts'
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'ADC DRC Decay Time'
+		value '8191Ts'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '63Ts'
+			item.1 '127Ts'
+			item.2 '255Ts'
+			item.3 '511Ts'
+			item.4 '1023Ts'
+			item.5 '2047Ts'
+			item.6 '4095Ts'
+			item.7 '8191Ts'
+			item.8 '16383Ts'
+			item.9 '32757Ts'
+			item.10 '65535Ts'
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'DRC Enable Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'ADC Decimation Rate'
+		value '64'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '32'
+			item.1 '64'
+			item.2 '128'
+			item.3 '256'
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC Oversampling Rate'
+		value '64'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '64'
+			item.1 '256'
+			item.2 '128'
+			item.3 ''
+			item.4 '32'
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'BIQ Coefficients'
+		value '035a0006fcac0000fe58000003500006fe580008'
+		comment {
+			access 'read write'
+			type BYTES
+			count 20
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'ADC Phase Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Left Digital PCM Volume'
+		value 817
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 913'
+			dbmin -9999999
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Left Analog PCM Volume'
+		value 17
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 20'
+			dbmin -9999999
+			dbmax 20
+			dbvalue.0 17
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Left PCM Soft Ramp'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 '.5ms'
+			item.2 '1ms'
+			item.3 '2ms'
+			item.4 '4ms'
+			item.5 '8ms'
+			item.6 '15ms'
+			item.7 '30ms'
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Left HW Noise Gate Enable'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'Left HW Noise Gate Delay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Left HW Noise Gate Threshold'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'Left Aux Noise Gate CH1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'Left Aux Noise Gate CH1 Entry Delay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'Left Aux Noise Gate CH1 Threshold'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'Left Aux Noise Gate CH2 Entry Delay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'Left Aux Noise Gate CH2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Left Aux Noise Gate CH2 Threshold'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Left SCLK Force Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'Left LRCLK Force Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'Left Invert Class D Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'Left Amp Gain ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Left DSP1 Preload Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Left DSP1 Firmware'
+		value Protection
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 MBC/VSS
+			item.1 MasterHiFi
+			item.2 Tx
+			item.3 'Tx Speaker'
+			item.4 Rx
+			item.5 'Rx ANC'
+			item.6 'Voice Ctrl'
+			item.7 'ASR Assist'
+			item.8 'Dbg Trace'
+			item.9 Protection
+			item.10 Calibration
+			item.11 Diagnostic
+			item.12 Misc
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Right Digital PCM Volume'
+		value 817
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 913'
+			dbmin -9999999
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'Right Analog PCM Volume'
+		value 17
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 20'
+			dbmin -9999999
+			dbmax 20
+			dbvalue.0 17
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'Right PCM Soft Ramp'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 '.5ms'
+			item.2 '1ms'
+			item.3 '2ms'
+			item.4 '4ms'
+			item.5 '8ms'
+			item.6 '15ms'
+			item.7 '30ms'
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'Right HW Noise Gate Enable'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'Right HW Noise Gate Delay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'Right HW Noise Gate Threshold'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'Right Aux Noise Gate CH1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'Right Aux Noise Gate CH1 Entry Delay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'Right Aux Noise Gate CH1 Threshold'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'Right Aux Noise Gate CH2 Entry Delay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'Right Aux Noise Gate CH2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'Right Aux Noise Gate CH2 Threshold'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'Right SCLK Force Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'Right LRCLK Force Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'Right Invert Class D Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'Right Amp Gain ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'Right DSP1 Preload Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'Right DSP1 Firmware'
+		value Protection
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 MBC/VSS
+			item.1 MasterHiFi
+			item.2 Tx
+			item.3 'Tx Speaker'
+			item.4 Rx
+			item.5 'Rx ANC'
+			item.6 'Voice Ctrl'
+			item.7 'ASR Assist'
+			item.8 'Dbg Trace'
+			item.9 Protection
+			item.10 Calibration
+			item.11 Diagnostic
+			item.12 Misc
+		}
+	}
+	control.59 {
+		iface CARD
+		name 'Headphone Jack'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.60 {
+		iface CARD
+		name 'Headset Mic Jack'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'Headphone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'Headset Mic Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'Int Mic Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'DMIC Enable Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'Left ASP TX1 Source'
+		value VMON
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'Left ASP TX2 Source'
+		value IMON
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'Left ASP TX3 Source'
+		value Zero
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'Left ASP TX4 Source'
+		value Zero
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'Left DSP RX1 Source'
+		value ASPRX1
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Left DSP RX2 Source'
+		value ASPRX1
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Left PCM Source'
+		value DSP
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ASP
+			item.1 DSP
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Left DRE Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Right ASP TX1 Source'
+		value VMON
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Right ASP TX2 Source'
+		value IMON
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Right ASP TX3 Source'
+		value Zero
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Right ASP TX4 Source'
+		value Zero
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Right DSP RX1 Source'
+		value ASPRX2
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'Right DSP RX2 Source'
+		value ASPRX2
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Zero
+			item.1 ASPRX1
+			item.2 ASPRX2
+			item.3 VMON
+			item.4 IMON
+			item.5 VPMON
+			item.6 VBSTMON
+			item.7 DSPTX1
+			item.8 DSPTX2
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'Right PCM Source'
+		value DSP
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ASP
+			item.1 DSP
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'Right DRE Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 HALO_STATE'
+		value '00000002'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 HALO_HEARTBEAT'
+		value '0001273b'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 AUDIO_BLK_SIZE'
+		value '00000020'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 BUILD_JOB_NAME'
+		value '004d616e0075616c00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 12
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 BUILD_JOB_NUMBER'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 L_SAMPLE_RATE_HW'
+		value '0000bb80'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 ATE_NUMBER_BANDS'
+		value '00000001'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 FIRMWARE_STATE'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 EVENT_TIMEOUT'
+		value '00002ee0'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 OFFSET_HOLD_TIME'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 E_FULL_US_BYPASS'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'Left DSP1 Protection 400a4 MAX_LRCLK_DELAY'
+		value '00000010'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CSPL_ENABLE'
+		value '00000001'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CSPL_COMMAND'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CSPL_STATE'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CSPL_ERRORNO'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CSPL_TEMPERATURE'
+		value '00058000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.98 {
+		iface MIXER
+		name 'Left DSP1 Protection cd UPDT_PRMS'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.99 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CAL_R'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.100 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CAL_AMBIENT'
+		value '00000017'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.101 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CAL_STATUS'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.102 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CAL_CHECKSUM'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.103 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CAL_SET_STATUS'
+		value '00000001'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.104 {
+		iface MIXER
+		name 'Left DSP1 Protection cd DIAG_F0'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.105 {
+		iface MIXER
+		name 'Left DSP1 Protection cd DIAG_Z_LOW_DIFF'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.106 {
+		iface MIXER
+		name 'Left DSP1 Protection cd RTLOG_ENABLE'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.107 {
+		iface MIXER
+		name 'Left DSP1 Protection cd RTLOG_STATE'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.108 {
+		iface MIXER
+		name 'Left DSP1 Protection cd RTLOG_COUNT'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.109 {
+		iface MIXER
+		name 'Left DSP1 Protection cd RTLOG_FRMPRWIN'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.110 {
+		iface MIXER
+		name 'Left DSP1 Protection cd RTLOG_VARIABLE'
+		value '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 60
+		}
+	}
+	control.111 {
+		iface MIXER
+		name 'Left DSP1 Protection cd RTLOG_DATA'
+		value '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 120
+		}
+	}
+	control.112 {
+		iface MIXER
+		name 'Left DSP1 Protection cd BDLOG_MAX_TEMP'
+		value '00058000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.113 {
+		iface MIXER
+		name 'Left DSP1 Protection cd BDLOG_MAX_EXC'
+		value '00001243'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.114 {
+		iface MIXER
+		name 'Left DSP1 Protection cd LOG_OVER_TEMP_COUNT'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.115 {
+		iface MIXER
+		name 'Left DSP1 Protection cd DLOG_OVER_EXC_COUNT'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.116 {
+		iface MIXER
+		name 'Left DSP1 Protection cd BDLOG_ABNORMAL_MUTE'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.117 {
+		iface MIXER
+		name 'Left DSP1 Protection cd BDLOG_VMON_LOW_FLAG'
+		value '00000001'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.118 {
+		iface MIXER
+		name 'Left DSP1 Protection cd REDUCE_POWER'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.119 {
+		iface MIXER
+		name 'Left DSP1 Protection cd CH_BAL'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.120 {
+		iface MIXER
+		name 'Left DSP1 Protection cd ATTENUATION'
+		value '007fffff'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.121 {
+		iface MIXER
+		name 'Left DSP1 Protection cd SPK_OUTPUT_POWER'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.122 {
+		iface MIXER
+		name 'Left DSP1 Protection cd ALGO_FRAME_DELAY'
+		value '00000005'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.123 {
+		iface MIXER
+		name 'Left DSP1 Protection cd PDATE_PARAMS_CONFIG'
+		value '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 400
+		}
+	}
+	control.124 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b EVNTLG_ENABLED'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.125 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b WAS_DISABLED'
+		value '00000001'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.126 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b BUFFER'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.127 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b RANSFER_COMPLETED'
+		value '00000001'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.128 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b NUM_LOST_EVENTS'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.129 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b OST_EVENT_COUNTER'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.130 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b TRIGGER_INTERRUPT'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.131 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b FREE_SLOTS'
+		value '00000020'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.132 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b W_PTR'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.133 {
+		iface MIXER
+		name 'Left DSP1 Protection f20b EVENTS'
+		value '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 256
+		}
+	}
+	control.134 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 HALO_STATE'
+		value '00000002'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.135 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 HALO_HEARTBEAT'
+		value '00012741'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.136 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 AUDIO_BLK_SIZE'
+		value '00000020'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.137 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 BUILD_JOB_NAME'
+		value '004d616e0075616c00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 12
+		}
+	}
+	control.138 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 UILD_JOB_NUMBER'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.139 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 _SAMPLE_RATE_HW'
+		value '0000bb80'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.140 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 TE_NUMBER_BANDS'
+		value '00000001'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.141 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 FIRMWARE_STATE'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.142 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 EVENT_TIMEOUT'
+		value '00002ee0'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.143 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 FFSET_HOLD_TIME'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.144 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 _FULL_US_BYPASS'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.145 {
+		iface MIXER
+		name 'Right DSP1 Protection 400a4 MAX_LRCLK_DELAY'
+		value '00000010'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.146 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CSPL_ENABLE'
+		value '00000001'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.147 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CSPL_COMMAND'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.148 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CSPL_STATE'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.149 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CSPL_ERRORNO'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.150 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CSPL_TEMPERATURE'
+		value '00058000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.151 {
+		iface MIXER
+		name 'Right DSP1 Protection cd UPDT_PRMS'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.152 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CAL_R'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.153 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CAL_AMBIENT'
+		value '00000017'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.154 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CAL_STATUS'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.155 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CAL_CHECKSUM'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.156 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CAL_SET_STATUS'
+		value '00000001'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.157 {
+		iface MIXER
+		name 'Right DSP1 Protection cd DIAG_F0'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.158 {
+		iface MIXER
+		name 'Right DSP1 Protection cd DIAG_Z_LOW_DIFF'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.159 {
+		iface MIXER
+		name 'Right DSP1 Protection cd RTLOG_ENABLE'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.160 {
+		iface MIXER
+		name 'Right DSP1 Protection cd RTLOG_STATE'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.161 {
+		iface MIXER
+		name 'Right DSP1 Protection cd RTLOG_COUNT'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.162 {
+		iface MIXER
+		name 'Right DSP1 Protection cd RTLOG_FRMPRWIN'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.163 {
+		iface MIXER
+		name 'Right DSP1 Protection cd RTLOG_VARIABLE'
+		value '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 60
+		}
+	}
+	control.164 {
+		iface MIXER
+		name 'Right DSP1 Protection cd RTLOG_DATA'
+		value '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 120
+		}
+	}
+	control.165 {
+		iface MIXER
+		name 'Right DSP1 Protection cd BDLOG_MAX_TEMP'
+		value '00058000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.166 {
+		iface MIXER
+		name 'Right DSP1 Protection cd BDLOG_MAX_EXC'
+		value '00001243'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.167 {
+		iface MIXER
+		name 'Right DSP1 Protection cd OG_OVER_TEMP_COUNT'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.168 {
+		iface MIXER
+		name 'Right DSP1 Protection cd LOG_OVER_EXC_COUNT'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.169 {
+		iface MIXER
+		name 'Right DSP1 Protection cd DLOG_ABNORMAL_MUTE'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.170 {
+		iface MIXER
+		name 'Right DSP1 Protection cd DLOG_VMON_LOW_FLAG'
+		value '00000001'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.171 {
+		iface MIXER
+		name 'Right DSP1 Protection cd REDUCE_POWER'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.172 {
+		iface MIXER
+		name 'Right DSP1 Protection cd CH_BAL'
+		value '00000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.173 {
+		iface MIXER
+		name 'Right DSP1 Protection cd ATTENUATION'
+		value '007fffff'
+		comment {
+			access 'read write'
+			type BYTES
+			count 4
+		}
+	}
+	control.174 {
+		iface MIXER
+		name 'Right DSP1 Protection cd SPK_OUTPUT_POWER'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.175 {
+		iface MIXER
+		name 'Right DSP1 Protection cd ALGO_FRAME_DELAY'
+		value '00000005'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.176 {
+		iface MIXER
+		name 'Right DSP1 Protection cd DATE_PARAMS_CONFIG'
+		value '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 400
+		}
+	}
+	control.177 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b EVNTLG_ENABLED'
+		value '00000000'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.178 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b WAS_DISABLED'
+		value '00000001'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.179 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b BUFFER'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.180 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b ANSFER_COMPLETED'
+		value '00000001'
+		comment {
+			access 'read write volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.181 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b NUM_LOST_EVENTS'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.182 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b ST_EVENT_COUNTER'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.183 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b RIGGER_INTERRUPT'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.184 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b FREE_SLOTS'
+		value '00000020'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.185 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b W_PTR'
+		value '00000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 4
+		}
+	}
+	control.186 {
+		iface MIXER
+		name 'Right DSP1 Protection f20b EVENTS'
+		value '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read volatile'
+			type BYTES
+			count 256
+		}
+	}
+}


### PR DESCRIPTION
~~This still needs an additional manual fix using alsamixer, pushing up microphone volume to 100, then running sudo alsactl store -F once to permanently store the configuration of the audio card, otherwise by default the microphone hardware volume will lower it again back to 52 (which is barely audible even cranked to 100 from the audio panel menu).~~
Fixed by adding the saved state as a default configuration file.

To my hears this feels almost identical to SteamOS now.
