### PR TITLE
Added GModCEFCodecFix  to justfile

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -104,6 +104,13 @@ fix-tf2-tcmalloc:
   -v $HOME/.steam/steam/steamapps/common/Team\ Fortress\ 2/bin:/hl2_linux:Z \
   ghcr.io/maisatanel/tcmalloc-hl2-fixer:main
 
+patch-gmod:
+  #!/usr/bin/env bash
+  curl -o ~/.patch-gmod https://github.com/solsticegamestudios/GModCEFCodecFix/releases/download/20230731/GModCEFCodecFix-Linux
+  chmod +x ~/.patch-gmod
+  ~/.patch-gmod
+  rm -f ~/.patch-gmod
+
 enable-vapor-theme:
   #!/usr/bin/env bash
   source /etc/default/bazzite

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -106,10 +106,13 @@ fix-tf2-tcmalloc:
 
 patch-gmod:
   #!/usr/bin/env bash
-  curl -o ~/.patch-gmod https://github.com/solsticegamestudios/GModCEFCodecFix/releases/download/20230731/GModCEFCodecFix-Linux
-  chmod +x ~/.patch-gmod
-  ~/.patch-gmod
-  rm -f ~/.patch-gmod
+  wget \
+    $(curl -s https://api.github.com/repos/solsticegamestudios/GModCEFCodecFix/releases/latest | \
+    jq -r ".assets[] | select(.name | test(\"GModCEFCodecFix-Linux\")) | .browser_download_url") \
+    -P /tmp/patch-gmod
+  chmod +x /tmp/patch-gmod
+  /tmp/patch-gmod
+  rm -f /tmp/patch-gmod
 
 enable-vapor-theme:
   #!/usr/bin/env bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -77,6 +77,13 @@ fix-tf2-tcmalloc:
   -v $HOME/.steam/steam/steamapps/common/Team\ Fortress\ 2/bin:/hl2_linux:Z \
   ghcr.io/maisatanel/tcmalloc-hl2-fixer:main
 
+patch-gmod:
+  #!/usr/bin/env bash
+  curl -o ~/.patch-gmod https://github.com/solsticegamestudios/GModCEFCodecFix/releases/download/20230731/GModCEFCodecFix-Linux
+  chmod +x ~/.patch-gmod
+  ~/.patch-gmod
+  rm -f ~/.patch-gmod
+
 enable-vapor-theme:
   #!/usr/bin/env bash
   source /etc/default/bazzite

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -79,10 +79,13 @@ fix-tf2-tcmalloc:
 
 patch-gmod:
   #!/usr/bin/env bash
-  curl -o ~/.patch-gmod https://github.com/solsticegamestudios/GModCEFCodecFix/releases/download/20230731/GModCEFCodecFix-Linux
-  chmod +x ~/.patch-gmod
-  ~/.patch-gmod
-  rm -f ~/.patch-gmod
+  wget \
+    $(curl -s https://api.github.com/repos/solsticegamestudios/GModCEFCodecFix/releases/latest | \
+    jq -r ".assets[] | select(.name | test(\"GModCEFCodecFix-Linux\")) | .browser_download_url") \
+    -P /tmp/patch-gmod
+  chmod +x /tmp/patch-gmod
+  /tmp/patch-gmod
+  rm -f /tmp/patch-gmod
 
 enable-vapor-theme:
   #!/usr/bin/env bash


### PR DESCRIPTION
It is this here: https://github.com/solsticegamestudios/GModCEFCodecFix I put it into the justfile

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
