### PR TITLE
fix(sign-image): Use package screen instead of consent screen

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -11,15 +11,20 @@ screens:
       description: |
         Configure your system to get started. Completion of this process is required for Game mode to function.
   sign-image:
-    source: yafti.screen.consent
-    condition:
-      run: grep -qvz "signed" <<< $(rpm-ostree status)
+    source: yafti.screen.package
     values:
-      title: Sign Bazzite
-      description: |
-        This will sign your current install of Bazzite. Note that this may take awhile.
-      actions:
-        - run: just --unstable sign-image
+      title: Signing Bazzite
+      condition:
+        run: grep -qvz "signed" <<< $(rpm-ostree status)
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        Sign Bazzite:
+          description: |
+            This will sign your current install of Bazzite. Mandatory for offline installs. This will take awhile.
+          default: true
+          packages:
+          - Sign Bazzite: just --unstable sign-image
   configure-bazzite:
     source: yafti.screen.package
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -11,15 +11,20 @@ screens:
       description: |
         Configure your system to get started
   sign-image:
-    source: yafti.screen.consent
-    condition:
-      run: grep -qvz "signed" <<< $(rpm-ostree status)
+    source: yafti.screen.package
     values:
-      title: Sign Bazzite
-      description: |
-        This will sign your current install of Bazzite. Note that this may take awhile.
-      actions:
-        - run: just --unstable sign-image
+      title: Signing Bazzite
+      condition:
+        run: grep -qvz "signed" <<< $(rpm-ostree status)
+      show_terminal: true
+      package_manager: yafti.plugin.run
+      groups:
+        Sign Bazzite:
+          description: |
+            This will sign your current install of Bazzite. Mandatory for offline installs. This will take awhile.
+          default: true
+          packages:
+          - Sign Bazzite: just --unstable sign-image
   configure-bazzite-arch:
     source: yafti.screen.package
     values:


### PR DESCRIPTION
Currently, there doesn't seem to be confirmation that clicking accept on the consent screen actually did anything. Use a package screen instead to avoid confusion

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
