### PR TITLE
fix(just): Wait for any existing transactions to complete before invoking rpm-ostree

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -52,6 +52,7 @@ get-steamcmd:
 
 install-oversteer:
   sudo wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-oversteer.repo
+  ublue-update --wait
   rpm-ostree install oversteer
 
 install-nix:
@@ -217,6 +218,7 @@ switch-to-ext4:
 
 zram-on:
   #!/usr/bin/env bash
+  ublue-update --wait
   KARGS=$(rpm-ostree kargs)
   if grep -q 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --delete=zram
@@ -227,6 +229,7 @@ zram-on:
 
 zram-off:
   #!/usr/bin/env bash
+  ublue-update --wait
   KARGS=$(rpm-ostree kargs)
   if grep -qv 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --append=zram=0
@@ -320,6 +323,7 @@ _toggle_wayland:
 
 sign-image:
   source /etc/default/bazzite && \
+  ublue-update --wait && \
   if grep -qvz "/var/${IMAGE_VENDOR}/image" <<< $(rpm-ostree status); then \
     rpm-ostree rebase ostree-image-signed:$(just --unstable _get-image); \
   else \

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -32,12 +32,14 @@ configure-waydroid:
 
 install-corectrl:
   echo 'Installing CoreCtrl...'
+  ublue-update --wait
   rpm-ostree install corectrl
   echo 'Setting needed kargs for CoreCtrl...'
   rpm-ostree kargs --append="amdgpu.ppfeaturemask=0xffffffff"
 
 install-oversteer:
   sudo wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-oversteer.repo
+  ublue-update --wait
   rpm-ostree install oversteer
 
 install-nix:
@@ -157,6 +159,7 @@ set-btrfs-flags:
 
 zram-on:
   #!/usr/bin/env bash
+  ublue-update --wait
   KARGS=$(rpm-ostree kargs)
   if grep -q 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --delete=zram
@@ -167,6 +170,7 @@ zram-on:
 
 zram-off:
   #!/usr/bin/env bash
+  ublue-update --wait
   KARGS=$(rpm-ostree kargs)
   if grep -qv 'zram' <<< ${KARGS}; then
     rpm-ostree kargs --append=zram=0
@@ -229,6 +233,7 @@ unhide-grub:
 
 sign-image:
   source /etc/default/bazzite && \
+  ublue-update --wait && \
   if grep -qvz "/var/${IMAGE_VENDOR}/image" <<< $(rpm-ostree status); then \
     rpm-ostree rebase ostree-image-signed:$(just --unstable _get-image); \
   else \


### PR DESCRIPTION
Prevents rpm-ostree from failing when another transaction is in process by waiting for the current transaction to complete
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
