### PR TITLE
chore: Add spec file for duperemove 0.12

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -81,7 +81,9 @@ RUN rpm-ostree install \
     lato-fonts \
     fira-code-fonts && \
     wget https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/systemd/system/btrfs-dedup@.service -O /usr/lib/systemd/system/btrfs-dedup@.service && \
-    wget https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/systemd/system/btrfs-dedup@.timer -O /usr/lib/systemd/system/btrfs-dedup@.timer
+    wget https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/systemd/system/btrfs-dedup@.timer -O /usr/lib/systemd/system/btrfs-dedup@.timer && \
+    sed -i 's/ExecStart=rmlint/ExecStart=rmlint --algorithm=xxhash/g' /usr/lib/systemd/system/btrfs-dedup@.service && \
+    sed -i 's/duperemove -r/duperemove --hash=xxhash -r/g' /usr/lib/systemd/system/btrfs-dedup@.service 
 
 # Configure KDE & GNOME
 RUN if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Ported SteamOS and ChimeraOS packages, among others used by Bazzite, are built o
 |Package|Status|
 |---|---|
 |ds-inhibit|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/ds-inhibit/status_image/last_build.png?)|
+|duperemove|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/duperemove/status_image/last_build.png?)|
 |[extest](https://github.com/Supreeeme/extest)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite-multilib/package/extest/status_image/last_build.png?)|
 |gamescope|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/gamescope/status_image/last_build.png?)|
 |[gamescope-session](https://github.com/ChimeraOS/gamescope-session)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/gamescope-session/status_image/last_build.png?)|

--- a/spec_files/duperemove/duperemove.spec
+++ b/spec_files/duperemove/duperemove.spec
@@ -1,0 +1,117 @@
+%define _legacy_common_support 1
+
+Name:           duperemove
+Version:        0.12
+Release:        5%{?dist}
+Summary:        Tools for deduping file systems
+License:        GPL-2.0-only
+URL:            https://github.com/markfasheh/%{name}
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  libgcrypt-devel
+BuildRequires:  xxhash-devel
+BuildRequires:  libatomic
+BuildRequires:  gcc
+BuildRequires:  git
+# Enable devtoolset so we get libatomic in EPEL-7
+%if 0%{?el7}
+BuildRequires:  devtoolset-7-toolchain, devtoolset-7-libatomic-devel
+%endif
+BuildRequires: make
+
+%description
+Duperemove is a simple tool for finding duplicated extents and
+submitting them for deduplication. When given a list of files it will
+hash their contents on a block by block basis and compare those hashes
+to each other, finding and categorizing extents that match each other.
+
+When given the -d option, duperemove will submit those extents for
+deduplication using the btrfs-extent-same ioctl.
+
+%prep
+git init .
+git remote add -t \* -f origin %{url}.git
+git checkout v%{version}
+
+%build
+make
+
+%install
+make install DESTDIR=%{buildroot} PREFIX=%{_prefix} BINDIR=%{_sbindir}
+
+%files
+%doc README.md
+%license LICENSE
+%{_mandir}/man8/btrfs-extent-same*.8*
+%{_mandir}/man8/%{name}*.8*
+%{_mandir}/man8/hashstats*.8*
+%{_mandir}/man8/show-shared-extents*.8*
+%{_sbindir}/btrfs-extent-same
+%{_sbindir}/%{name}
+%{_sbindir}/hashstats
+%{_sbindir}/show-shared-extents
+
+%changelog
+* Wed Jul 19 2023 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.3-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_39_Mass_Rebuild
+
+* Thu Jan 19 2023 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.3-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_38_Mass_Rebuild
+
+* Thu Jul 21 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.3-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
+
+* Thu Jan 20 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.3-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
+
+* Wed Sep  8 2021 Jonathan Dieter <jdieter@gmail.com> - 0.11.3-1
+- Update to 0.11.3 with bug fixes
+- Remove patch to use system xxhash since upstream does that by default now
+
+* Wed Jul 21 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.1-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild
+
+* Tue Jan 26 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.1-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
+
+* Mon Jul 27 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.1-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
+
+* Mon Feb 03 2020 Jonathan Dieter <jdieter@gmail.com> - 0.11.1-3
+- Work around GCC 10 build failure
+
+* Tue Jan 28 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Tue Dec 10 2019 Jonathan Dieter <jdieter@gmail.com> - 0.11.1-1.1
+- Fix build for EPEL-8
+
+* Sun Dec 08 2019 Jonathan Dieter <jdieter@gmail.com> - 0.11.1-1
+- New release
+
+* Wed Jul 24 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.11-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Thu Jan 31 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.11-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Sat Oct 20 2018 Jonathan Dieter <jdieter@gmail.com> - 0.11-3
+- Add devsettool BR and build for EPEL
+
+* Fri Oct 19 2018 Jonathan Dieter <jdieter@gmail.com> - 0.11-2
+- Add missing BR
+- Fix build to use build flags
+
+* Sat Oct 13 2018 Jonathan Dieter <jdieter@gmail.com> - 0.11-1
+- Bump to 0.11
+- Unbundle xxhash
+
+* Fri Nov 13 2015 Francesco Frassinelli <fraph24@gmail.com> - 0.10-1
+- Version bump; license and minor packaging issues fixed
+
+* Thu Jul 30 2015 Francesco Frassinelli <fraph24@gmail.com> - 0.09.5-2
+- %%license macro added
+
+* Sun Jul 19 2015 Francesco Frassinelli <fraph24@gmail.com> - 0.09.5-1
+- Initial build
+


### PR DESCRIPTION
feat: Explicitly use xxhash for duperemove and rmlint

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
