### PR TITLE
chore(hardware-setup): Versioned/rebase checks, and disable Deck services on generic devices

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -370,16 +370,6 @@ enable-deck-bios-firmware-updates:
   sudo systemctl enable jupiter-biosupdate.service
   sudo systemctl enable jupiter-controller-update.service
 
-# Disable all Steam Deck hardware specific services
-disable-deck-services:
-  #!/usr/bin/env bash
-  sudo systemctl disable --now jupiter-fan-control.service
-  sudo systemctl disable --now vpower.service
-  sudo systemctl disable --now jupiter-biosupdate.service
-  sudo systemctl disable --now jupiter-controller-update.service
-  sudo systemctl disable --now ryzenadj.service
-  sudo systemctl disable --now batterylimit.service
-
 # Disable Steam Deck BIOS updates
 disable-bios-updates:
   #!/usr/bin/env bash

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -71,6 +71,15 @@ if [[ ":Jupiter:" =~ ":$SYS_ID:"  ]]; then
   if [[ ! $KARGS =~ "initcall_blacklist" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --append=initcall_blacklist=simpledrm_platform_driver_init"
   fi
+elif [[ $IMAGE_NAME =~ "deck"  ]]; then
+  echo "Generic device detected. Performing setup..."
+
+  sudo systemctl disable --now jupiter-fan-control.service
+  sudo systemctl disable --now vpower.service
+  sudo systemctl disable --now jupiter-biosupdate.service
+  sudo systemctl disable --now jupiter-controller-update.service
+  sudo systemctl disable --now ryzenadj.service
+  sudo systemctl disable --now batterylimit.service
 fi
 
 if [[ $IMAGE_NAME =~ "nvidia"  ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -74,12 +74,12 @@ if [[ ":Jupiter:" =~ ":$SYS_ID:"  ]]; then
 elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   echo "Generic device detected. Performing setup..."
 
-  sudo systemctl disable --now jupiter-fan-control.service
-  sudo systemctl disable --now vpower.service
-  sudo systemctl disable --now jupiter-biosupdate.service
-  sudo systemctl disable --now jupiter-controller-update.service
-  sudo systemctl disable --now ryzenadj.service
-  sudo systemctl disable --now batterylimit.service
+  systemctl disable --now jupiter-fan-control.service
+  systemctl disable --now vpower.service
+  systemctl disable --now jupiter-biosupdate.service
+  systemctl disable --now jupiter-controller-update.service
+  systemctl disable --now ryzenadj.service
+  systemctl disable --now batterylimit.service
 fi
 
 if [[ $IMAGE_FLAVOR = "nvidia"  ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -16,7 +16,7 @@ KNOWN_IMAGE_FLAVOR=$(cat $KNOWN_IMAGE_FLAVOR_FILE)
 if [[ -f $HWS_VER_FILE && $HWS_VER = $HWS_VER_RAN ]]; then
   if [[ -f $KNOWN_IMAGE_NAME_FILE && -f $KNOWN_IMAGE_FLAVOR_FILE ]]; then
     # Run script if image has been rebased
-    if [[ $IMAGE_FLAVOR = $KNOWN_IMAGE_NAME && $IMAGE_FLAVOR = $KNOWN_IMAGE_FLAVOR ]]; then
+    if [[ $IMAGE_NAME = $KNOWN_IMAGE_NAME && $IMAGE_FLAVOR = $KNOWN_IMAGE_FLAVOR ]]; then
       echo "Hardware setup has already ran. Exiting..."
       exit 0
     fi

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -82,7 +82,7 @@ elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   sudo systemctl disable --now batterylimit.service
 fi
 
-if [[ $IMAGE_NAME =~ "nvidia"  ]]; then
+if [[ $IMAGE_FLAVOR = "nvidia"  ]]; then
   echo "Checking for needed karg changes (Nvidia)"
 
   if [[ ! $KARGS =~ "rd.driver.blacklist" ]]; then
@@ -96,7 +96,7 @@ if [[ $IMAGE_NAME =~ "nvidia"  ]]; then
   if [[ ! $KARGS =~ "nvidia-drm.modeset" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --append=nvidia-drm.modeset=1"
   fi
-elif [[ $IMAGE_NAME =~ "main" ]]; then
+elif [[ $IMAGE_FLAVOR = "main" ]]; then
   echo "Checking for needed karg changes"
 
   if [[ $KARGS =~ "rd.driver.blacklist" ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 source /etc/default/bazzite
 
-DONEFILE=/etc/bazzite/hardware_setup_done
+# SCRIPT VERSION
+HWS_VER=1
+HWS_VER_FILE="/etc/bazzite/hws_version"
+HWS_VER_RAN=$(cat $HWS_VERSION_FILE)
+
+if [[ -f $HWS_VER_FILE && $HWS_VER = $HWS_VER_RAN ]]; then
+  echo "Hardware setup has already ran. Exiting..."
+  exit 0
+fi
 
 # GLOBAL
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 KARGS=$(rpm-ostree kargs)
 NEEDED_KARGS=""
 echo "Current kargs: $KARGS"
+mkdir -p /etc/bazzite
 
 # FSTAB CONFIGURATION
 if [[ $(grep "compress=zstd" /etc/fstab) ]]; then
@@ -80,8 +89,8 @@ fi
 if [[ -n "$NEEDED_KARGS" ]]; then
   echo "Found needed karg changes, applying the following: $NEEDED_KARGS"
   rpm-ostree kargs ${NEEDED_KARGS} --reboot || exit 1
-  mkdir -p "$(dirname "$DONEFILE")"
-  touch "$DONEFILE"
 else
   echo "No karg changes needed"
 fi
+
+echo $HWS_VER > $HWS_VER_FILE

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -87,6 +87,20 @@ if [[ $IMAGE_NAME =~ "nvidia"  ]]; then
   if [[ ! $KARGS =~ "nvidia-drm.modeset" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --append=nvidia-drm.modeset=1"
   fi
+elif [[ $IMAGE_NAME =~ "main" ]]; then
+  echo "Checking for needed karg changes"
+
+  if [[ $KARGS =~ "rd.driver.blacklist" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=rd.driver.blacklist=nouveau"
+  fi
+
+  if [[ $KARGS =~ "modprobe.blacklist" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=modprobe.blacklist=nouveau"
+  fi
+
+  if [[ $KARGS =~ "nvidia-drm.modeset" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=nvidia-drm.modeset=1"
+  fi
 fi
 
 if [[ $KARGS =~ "nomodeset" ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -80,7 +80,7 @@ elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   systemctl disable --now jupiter-controller-update.service
   systemctl disable --now ryzenadj.service
   systemctl disable --now batterylimit.service
-  systemctl --global disable sdgyrodsu.service
+  systemctl --global disable --now sdgyrodsu.service
 fi
 
 if [[ $IMAGE_FLAVOR = "nvidia"  ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -6,9 +6,21 @@ HWS_VER=1
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VERSION_FILE)
 
+# IMAGE IDENTIFIERS
+KNOWN_IMAGE_NAME_FILE="/etc/bazzite/image_name"
+KNOWN_IMAGE_NAME=$(cat $KNOWN_IMAGE_NAME_FILE)
+KNOWN_IMAGE_FLAVOR_FILE="/etc/bazzite/image_flavor"
+KNOWN_IMAGE_FLAVOR=$(cat $KNOWN_IMAGE_FLAVOR_FILE)
+
+# Run script if updated
 if [[ -f $HWS_VER_FILE && $HWS_VER = $HWS_VER_RAN ]]; then
-  echo "Hardware setup has already ran. Exiting..."
-  exit 0
+  if [[ -f $KNOWN_IMAGE_NAME_FILE && -f $KNOWN_IMAGE_FLAVOR_FILE ]]; then
+    # Run script if image has been rebased
+    if [[ $IMAGE_FLAVOR = $KNOWN_IMAGE_NAME && $IMAGE_FLAVOR = $KNOWN_IMAGE_FLAVOR ]]; then
+      echo "Hardware setup has already ran. Exiting..."
+      exit 0
+    fi
+  fi
 fi
 
 # GLOBAL
@@ -94,3 +106,5 @@ else
 fi
 
 echo $HWS_VER > $HWS_VER_FILE
+echo $IMAGE_NAME > $KNOWN_IMAGE_NAME_FILE
+echo $IMAGE_FLAVOR > $KNOWN_IMAGE_FLAVOR_FILE

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -80,6 +80,7 @@ elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   systemctl disable --now jupiter-controller-update.service
   systemctl disable --now ryzenadj.service
   systemctl disable --now batterylimit.service
+  systemctl --global disable sdgyrodsu.service
 fi
 
 if [[ $IMAGE_FLAVOR = "nvidia"  ]]; then

--- a/system_files/desktop/shared/usr/lib/systemd/system/bazzite-hardware-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/bazzite-hardware-setup.service
@@ -2,7 +2,6 @@
 Description=Configure Bazzite for current hardware
 After=rpm-ostreed.service
 Before=systemd-user-sessions.service jupiter-biosupdate.service jupiter-controller-update.service
-ConditionPathExists=!/etc/bazzite/hardware_setup_done
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Runs the hardware script every time the version of the script increments and every time the image is rebased (useful for transitions from main to Nvidia or Nvidia to main). Also disables Deck services on generic devices

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
