### PR TITLE
feat(hardware-setup): Enable amdgpu on supported systems

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -25,6 +25,7 @@ fi
 
 # GLOBAL
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
+GPU_ID=$(lspci -k | grep -A 3 -E "(VGA|3D)")
 KARGS=$(rpm-ostree kargs)
 NEEDED_KARGS=""
 echo "Current kargs: $KARGS"
@@ -83,7 +84,7 @@ elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   systemctl --global disable --now sdgyrodsu.service
 fi
 
-if grep -qz "Kernel driver in use: radeon" <<< $(lspci -k | grep -A 3 -E "(VGA|3D)"); then
+if grep -qz "Kernel driver in use: radeon" <<< $GPU_ID; then
   if [[ ! $KARGS =~ "radeon.si_support" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --append=radeon.si_support=0"
   fi
@@ -99,7 +100,7 @@ if grep -qz "Kernel driver in use: radeon" <<< $(lspci -k | grep -A 3 -E "(VGA|3
   if [[ ! $KARGS =~ "amdgpu.cik_support" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --append=amdgpu.cik_support=1"
   fi
-elif grep -qvz "Kernel driver in use: amdgpu" <<< $(lspci -k | grep -A 3 -E "(VGA|3D)"); then
+elif grep -qvz "Kernel driver in use: amdgpu" <<< $GPU_ID; then
   if [[ $KARGS =~ "radeon.si_support" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --delete=radeon.si_support=0"
   fi

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -100,22 +100,6 @@ if grep -qz "Kernel driver in use: radeon" <<< $GPU_ID; then
   if [[ ! $KARGS =~ "amdgpu.cik_support" ]]; then
     NEEDED_KARGS="$NEEDED_KARGS --append=amdgpu.cik_support=1"
   fi
-elif grep -qvz "Kernel driver in use: amdgpu" <<< $GPU_ID; then
-  if [[ $KARGS =~ "radeon.si_support" ]]; then
-    NEEDED_KARGS="$NEEDED_KARGS --delete=radeon.si_support=0"
-  fi
-
-  if [[ $KARGS =~ "radeon.cik_support" ]]; then
-    NEEDED_KARGS="$NEEDED_KARGS --delete=radeon.cik_support=0"
-  fi
-
-  if [[ $KARGS =~ "amdgpu.si_support" ]]; then
-    NEEDED_KARGS="$NEEDED_KARGS --delete=amdgpu.si_support=1"
-  fi
-
-  if [[ $KARGS =~ "amdgpu.cik_support" ]]; then
-    NEEDED_KARGS="$NEEDED_KARGS --delete=amdgpu.cik_support=1"
-  fi
 fi
 
 if [[ $IMAGE_FLAVOR = "nvidia"  ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -83,6 +83,40 @@ elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   systemctl --global disable --now sdgyrodsu.service
 fi
 
+if grep -qz "Kernel driver in use: radeon" <<< $(lspci -k | grep -A 3 -E "(VGA|3D)"); then
+  if [[ ! $KARGS =~ "radeon.si_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --append=radeon.si_support=0"
+  fi
+
+  if [[ ! $KARGS =~ "radeon.cik_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --append=radeon.cik_support=0"
+  fi
+
+  if [[ ! $KARGS =~ "amdgpu.si_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --append=amdgpu.si_support=1"
+  fi
+
+  if [[ ! $KARGS =~ "amdgpu.cik_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --append=amdgpu.cik_support=1"
+  fi
+elif grep -qvz "Kernel driver in use: amdgpu" <<< $(lspci -k | grep -A 3 -E "(VGA|3D)"); then
+  if [[ $KARGS =~ "radeon.si_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=radeon.si_support=0"
+  fi
+
+  if [[ $KARGS =~ "radeon.cik_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=radeon.cik_support=0"
+  fi
+
+  if [[ $KARGS =~ "amdgpu.si_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=amdgpu.si_support=1"
+  fi
+
+  if [[ $KARGS =~ "amdgpu.cik_support" ]]; then
+    NEEDED_KARGS="$NEEDED_KARGS --delete=amdgpu.cik_support=1"
+  fi
+fi
+
 if [[ $IMAGE_FLAVOR = "nvidia"  ]]; then
   echo "Checking for needed karg changes (Nvidia)"
 


### PR DESCRIPTION
Enable amdgpu on systems using the radeon driver. The arguments for Southern Islands and Sea Islands do not conflict so just enable both

Do not block this based on image flavor as some people may be using mixed GPU systems that have both an AMD and Nvidia card

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
