### PR TITLE
chore(boot_menu): Add entry for HTPCs

### DIFF
--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -24,6 +24,11 @@ ublue_variants:
     flavors:
       - label: bazzite-deck
         info: Bazzite (Steam Deck Edition)
+  - label: ublue-os/bazzite-deck
+    ks: /kickstart/ublue-os.ks
+    flavors:
+      - label: bazzite-deck
+        info: Bazzite (Steam Deck Edition for HTPCs)
   - label: ublue-os/bazzite-gnome
     ks: /kickstart/ublue-os.ks
     flavors:
@@ -49,3 +54,8 @@ ublue_variants:
     flavors:
       - label: bazzite-deck-gnome
         info: Bazzite GNOME (Steam Deck Edition)
+  - label: ublue-os/bazzite-deck-gnome
+    ks: /kickstart/ublue-os.ks
+    flavors:
+      - label: bazzite-deck-gnome
+        info: Bazzite GNOME (Steam Deck Edition for HTPCs)


### PR DESCRIPTION
The only difference being that these use the standard kickstart file and exclude the resolution change from the installer

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
