### PR TITLE
revert: "fix(hardware-setup): REVERT ME, disable desktop-autologin if…

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -2,7 +2,7 @@
 source /etc/default/bazzite
 
 # SCRIPT VERSION
-HWS_VER=2
+HWS_VER=1
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VERSION_FILE)
 
@@ -82,13 +82,6 @@ elif [[ $IMAGE_NAME =~ "deck"  ]]; then
   systemctl disable --now ryzenadj.service
   systemctl disable --now batterylimit.service
   systemctl --global disable --now sdgyrodsu.service
-fi
-
-# REVERT ME, disable desktop-autologin if gamescope-autologin is enabled
-if [[ $IMAGE_NAME =~ "deck"  ]]; then
-  if systemctl is-enabled --quiet gamescope-autologin; then
-    systemctl disable --now desktop-autologin
-  fi
 fi
 
 if grep -qz "Kernel driver in use: radeon" <<< $GPU_ID; then


### PR DESCRIPTION
… gamescope-autologin is enabled"

Not needed after consolidating to bazzite-autologin

This reverts commit 38c95fcfe3c4bbd2427bdff90774258fe7af640a.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
