### PR TITLE
Added `nix-store --optimise` to `clean-system`

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -13,6 +13,7 @@ clean-system:
   rpm-ostree cleanup -bm
   if [ -x "$(command -v nix-store)" ]; then
     nix-store --gc
+    nix-store --optimise
   fi
 
 # Boot into this device's BIOS/UEFI screen

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -13,6 +13,7 @@ clean-system:
   rpm-ostree cleanup -bm
   if [ -x "$(command -v nix-store)" ]; then
     nix-store --gc
+    nix-store --optimise
   fi
 
 # Boot into this device's BIOS/UEFI screen


### PR DESCRIPTION
For both deck and desktop, I've added `nix-store --optimse` to `clean-system` in the justfile

`nix-store --optimise` hardlinks identical files in the nix store. Here is some more information about what `nix-store --optimise` does: https://nixos.org/manual/nix/unstable/command-ref/nix-store/optimise.html

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
