### PR TITLE
feat(deck): Add discover overlay

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -251,6 +251,7 @@ COPY system_files/deck/${BASE_IMAGE_NAME} /
 
 # Setup Copr repos
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/LatencyFleX/repo/fedora-$(rpm -E %fedora)/kylegospo-LatencyFleX-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-latencyflex.repo && \
+    wget https://copr.fedorainfracloud.org/coprs/mavit/discover-overlay/repo/fedora-$(rpm -E %fedora)/mavit-discover-overlay-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_mavit_discover.repo && \
     sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_kylegospo-bazzite.repo && \
     sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_kylegospo-bazzite-multilib.repo && \
@@ -316,6 +317,7 @@ RUN rpm-ostree install \
     vkBasalt \
     mangohud \
     sdgyrodsu \
+    discover-overlay \
     sddm-sugar-steamOS \
     ibus-pinyin \
     ibus-table-chinese-cangjie \
@@ -365,6 +367,7 @@ RUN rpm-ostree install \
 
 # Cleanup & Finalize
 RUN rm /usr/share/applications/wine*.desktop && \
+    rm /usr/share/applications/discover_overlay.desktop && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-info && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-notice && \
     ln -s /usr/bin/steamos-logger /usr/bin/steamos-warning && \
@@ -385,6 +388,7 @@ RUN rm /usr/share/applications/wine*.desktop && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-obs-vkcapture.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-wallpaper-engine-kde-plugin.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_mavit_discover.repo && \
     if grep -q "silverblue" <<< "${BASE_IMAGE_NAME}"; then \
         systemctl mask power-profiles-daemon.service && \
         systemctl disable gdm.service && \

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Variant designed for usage as an alternative to SteamOS on the Steam Deck, and f
 - Built in support for Windows dual-boot thanks to Fedora's installation of GRUB being left intact.
 - Update break something? Easily roll back to the previous version of Bazzite thanks to `rpm-ostree`'s rollback functionality. You can even select previous images at boot.
 - Steam and Lutris preinstalled on the image as layered packages.
+- [Discover Overlay](https://github.com/trigg/Discover) for Discord pre-installed and automatically launches in both Gamemode and on the Desktop if Discord is installed.
 - Exclusively uses ZRAM by default with the option to switch back to a swap file and set a custom size if desired. <sub><sup>(1GB by default)</sup></sub>
 - BFQ I/O scheduler to prevent I/O starvation when installing games or during background `duperemove` and `rmlint` processes.
 - TLS/SSL secured DNS and NTP by default. <sup><sub>(This is a handheld PC you're likely to use on random public networks after all)</sub></sup>

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Additionally, the following packages are used from other Copr repos:
 
 |Package|Status|
 |---|---|
+|[discover-overlay](https://github.com/trigg/Discover)-git|![Build Status](https://copr.fedorainfracloud.org/coprs/mavit/discover-overlay/package/discover-overlay/status_image/last_build.png?)|
 |[distrobox](https://github.com/89luca89/distrobox)-git|![Build Status](https://copr.fedorainfracloud.org/coprs/ublue-os/distrobox-git/package/distrobox-git/status_image/last_build.png?)|
 |[gcadapter_oc-kmod](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/)|![Build Status](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/gcadapter_oc-kmod/status_image/last_build.png?)|
 |[gnome-vrr](https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/package/mutter/status_image/last_build.png?)|

--- a/system_files/deck/shared/usr/bin/bazzite-discover-overlay
+++ b/system_files/deck/shared/usr/bin/bazzite-discover-overlay
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Run discover-overlay if discord is installed and we aren't using Wayland.
+if grep -q "com.discordapp.Discord" <<< $(flatpak list); then
+  if [[ "$XDG_SESSION_TYPE" != "wayland" ]]; then
+    /usr/bin/discover-overlay
+  fi
+fi

--- a/system_files/deck/shared/usr/etc/xdg/autostart/discover_overlay.desktop
+++ b/system_files/deck/shared/usr/etc/xdg/autostart/discover_overlay.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Discover Overlay
+Comment=Voice chat overlay
+Exec=/usr/bin/bazzite-discover-overlay
+Terminal=false
+Type=Application
+Actions=close


### PR DESCRIPTION
Auto launches discover-overlay on desktop and gamemode if Wayland isn't in use  on the desktop and the Discord flatpak is installed.


Supporting change in gamescope-session: https://github.com/KyleGospo/gamescope-session/commit/3337d1a9a4c24f42bc95515358375ca164ff3751