### PR TITLE
chore(desktop): Delete bazzite-arch if it already exists in just command

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -39,6 +39,10 @@ setup-firefox-vaapi-nvidia:
 # Set up Bazzite-Arch Distrobox container
 install-bazzite-arch:
   source /etc/default/bazzite && \
+  if grep -qz "bazzite-arch" <<< $(distrobox list); then \
+    echo 'Removing existing Bazzite Arch install...' && \
+    distrobox rm bazzite-arch --force; \
+  fi && \
   echo 'Installing Bazzite Arch...' && \
   if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then \
     distrobox create --name bazzite-arch --image ghcr.io/ublue-os/bazzite-arch --nvidia --yes --volume /usr/lib/extest/libextest.so:/usr/lib/extest/libextest.so:ro --volume /usr/share/icons:/usr/share/icons:ro --volume /usr/share/themes:/usr/share/themes:ro; \


### PR DESCRIPTION
Allows just install-bazzite-arch to be used as a quick refresh for existing installs

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
