### PR TITLE
feat(deck): Add service to return to gaming mode

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -376,6 +376,9 @@ RUN rm /usr/share/applications/wine*.desktop && \
     mkdir -p "/usr/etc/xdg/autostart" && \
     cp "/usr/share/applications/steam.desktop" "/usr/etc/xdg/autostart/steam.desktop" && \
     sed -i 's@/usr/bin/bazzite-steam %U@/usr/bin/bazzite-steam -silent %U@g' /usr/etc/xdg/autostart/steam.desktop && \
+    if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
+        sed -i 's/Exec=.*/Exec=systemctl start return-to-gamemode.service/' /etc/skel/Desktop/Return.desktop \
+    ; fi && \
     cp "/usr/share/applications/discover_overlay.desktop" "/usr/etc/xdg/autostart/discover_overlay.desktop" && \
     sed -i 's@Exec=discover-overlay@Exec=/usr/bin/bazzite-discover-overlay@g' /usr/etc/xdg/autostart/discover_overlay.desktop && \
     rm /usr/share/applications/discover_overlay.desktop && \

--- a/system_files/deck/shared/usr/bin/bazzite-autologin
+++ b/system_files/deck/shared/usr/bin/bazzite-autologin
@@ -7,15 +7,16 @@ USER=$(id -nu 1000)
 
 # SteamOS SDDM config
 SDDM_CONF='/etc/sddm.conf.d/steamos.conf'
-DESKTOP_AUTOLOGIN="/etc/bazzite/desktop_autologin"
+AUTOLOGIN_CONF='/etc/sddm.conf.d/zz-steamos-autologin.conf'
+DESKTOP_AUTOLOGIN='/etc/bazzite/desktop_autologin'
+
+# Avoid autologin conflict
+if [[ -f ${AUTOLOGIN_CONF} ]]; then
+  rm -f ${AUTOLOGIN_CONF}
+fi
 
 # Configure autologin if Steam has been updated
-if [[ ! -f $DESKTOP_AUTOLOGIN && -f /var/home/$USER/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
-  AUTOLOGIN_CONF='/etc/sddm.conf.d/zz-steamos-autologin.conf'
-  # Avoid autologin conflict
-  if [[ -f ${AUTOLOGIN_CONF} ]]; then
-    rm -f ${AUTOLOGIN_CONF}
-  fi
+if [[ ! -f ${DESKTOP_AUTOLOGIN} && -f /var/home/$USER/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
   sed -i 's/.*Session=.*/Session=gamescope-session.desktop/g' ${SDDM_CONF}
 elif [[ ${BASE_IMAGE_NAME} =~ "kinoite" ]]; then
   if ${DESKTOP_WAYLAND}; then

--- a/system_files/deck/shared/usr/bin/return-to-gamemode
+++ b/system_files/deck/shared/usr/bin/return-to-gamemode
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+source /etc/default/bazzite
+
+USER=$(id -nu 1000)
+
+# SteamOS autologin SDDM config
+AUTOLOGIN_CONF='/etc/sddm.conf.d/zz-steamos-autologin.conf'
+
+# Configure autologin if Steam has been updated
+if [[ -f /var/home/$USER/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
+  {
+    echo "[Autologin]"
+    echo "Session=gamescope-session.desktop"
+  } > "$AUTOLOGIN_CONF"
+fi
+
+if [[ $BASE_IMAGE_NAME = "kinoite" ]]; then
+  sudo -Eu $USER qdbus org.kde.Shutdown /Shutdown org.kde.Shutdown.logout
+elif [[ $BASE_IMAGE_NAME = "silverblue" ]]; then
+  sudo -Eu $USER gnome-session-quit --logout --no-prompt
+fi

--- a/system_files/deck/shared/usr/etc/polkit-1/rules.d/return-to-gamemode.rules
+++ b/system_files/deck/shared/usr/etc/polkit-1/rules.d/return-to-gamemode.rules
@@ -1,0 +1,8 @@
+polkit.addRule(function(action, subject) {
+    if (subject.isInGroup("wheel") &&
+        action.id == "org.freedesktop.systemd1.manage-units" &&
+        action.lookup("unit") == "return-to-gamemode.service")
+    {
+        return polkit.Result.YES;
+    }
+})

--- a/system_files/deck/shared/usr/lib/systemd/system/return-to-gamemode.service
+++ b/system_files/deck/shared/usr/lib/systemd/system/return-to-gamemode.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Return to Gaming Mode
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/return-to-gamemode


### PR DESCRIPTION
Fixes users not being to switch to gaming mode when they have desktop autologin toggled and should allow users to start gaming mode immediately after Steam has been updated instead of having to reboot after setup (although this should be done regardless)

Fixes: https://github.com/ublue-os/bazzite/issues/165

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
