### PR TITLE
feat(just): add waydroid-related utilities

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -59,6 +59,14 @@ install-obs-studio-portable:
   distrobox-enter -n obs-studio-portable -- 'bash -c "distrobox-export --app obs"' && \
   echo 'Install complete'
 
+# Remove all waydroid-related files in your user folders
+reset-waydroid:
+  bash -c 'sudo rm -rf /var/lib/waydroid /home/.waydroid ~/waydroid ~/.share/waydroid ~/.local/share/applications/*aydroid* ~/.local/share/waydroid'
+
+# Quickly initialize a waydroid image
+init-waydroid:
+  sudo waydroid init -c 'https://ota.waydro.id/system' -v 'https://ota.waydro.id/vendor'
+
 # Launch Waydroid configuration helper
 configure-waydroid:
   #!/usr/bin/env bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -77,6 +77,14 @@ install-obs-studio-portable:
   distrobox-enter -n obs-studio-portable -- 'bash -c "distrobox-export --app obs"' && \
   echo 'Install complete'
 
+# Remove all waydroid-related files in your user folders
+reset-waydroid:
+  bash -c 'sudo rm -rf /var/lib/waydroid /home/.waydroid ~/waydroid ~/.share/waydroid ~/.local/share/applications/*aydroid* ~/.local/share/waydroid'
+
+# Quickly initialize a waydroid image
+init-waydroid:
+  sudo waydroid init -c 'https://ota.waydro.id/system' -v 'https://ota.waydro.id/vendor'
+
 # Launch Waydroid configuration helper
 configure-waydroid:
   #!/usr/bin/env bash


### PR DESCRIPTION
Hello! I was setting up waydroid in my laptop and I thought that adding these waydroid utilities in just could be a nice addition :)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
