### PR TITLE
feat(just,yafti): webapp manager + openrazer and oversteer in distrobox

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -86,6 +86,11 @@ screens:
           default: false
           packages:
           - Install OpenRazer: just --unstable install-openrazer
+        Webapp Manager:
+          description: A utility for managing your webapps 
+          default: false
+          packages:
+          - Setup Webapp Manager: just --unstable setup-webapp-manager
         SteamCMD:
           description: Installs SteamCMD
           default: true

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -59,6 +59,19 @@ install-obs-studio-portable:
   distrobox-enter -n obs-studio-portable -- 'bash -c "distrobox-export --app obs"' && \
   echo 'Install complete'
 
+# Setup the Webapp manager
+setup-webapp-manager:
+  distrobox-create -i fedora:latest -n webapps
+  distrobox-enter -n webapps -- sudo sh -c "sudo dnf update -y && \
+    dnf install -y 'dnf-command(copr)' git && \
+    dnf copr enable -y kylegospo/webapp-manager && \
+    dnf install -y webapp-manager && \
+    /usr/bin/distrobox-host-exec &>/dev/null && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/xdg-open && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/flatpak && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/firefox && \
+    distrobox-export --app webapp-manager"
+
 # Remove all waydroid-related files in your user folders
 reset-waydroid:
   bash -c 'sudo rm -rf /var/lib/waydroid /home/.waydroid ~/waydroid ~/.share/waydroid ~/.local/share/applications/*aydroid* ~/.local/share/waydroid'

--- a/system_files/deck/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/custom.just
@@ -117,16 +117,12 @@ get-steamcmd:
   rm /tmp/steamcmd.tar.gz
 
 # Install Oversteer for Logitech steering wheels
-install-oversteer:
-  sudo wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-oversteer.repo
-  ublue-update --wait
-  rpm-ostree install oversteer
+install-oversteer: _setup-utilities-toolbox
+  distrobox enter -n utilities-toolbox -- bash -c 'sudo dnf copr enable -y kylegospo/oversteer && sudo dnf install python3-evdev oversteer'
 
 # Install OpenRazer (https://openrazer.github.io)
-install-openrazer:
-  sudo wget https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo -O /etc/yum.repos.d/hardware:razer.repo
-  ublue-update --wait
-  rpm-ostree install openrazer-meta
+install-openrazer: _setup-utilities-toolbox
+  distrobox-enter -n utilities-toolbox -- bash -c 'sudo wget https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo -O /etc/yum.repos.d/hardware:razer.repo && sudo dnf install openrazer-meta'
 
 # Install Nix with the Determinate Nix Installer
 install-nix:
@@ -522,3 +518,10 @@ _get-image:
     url = protocol + url
 
   print(url)
+
+_setup-utilities-toolbox:
+  #!/usr/bin/env bash
+  if ! podman container exists utilities-toolbox ; then 
+    distrobox create -i fedora:latest -n utilities-toolbox 
+    distrobox enter -n utilities-toolbox -- sudo sh -c "dnf update -y && dnf install -y 'dnf-command(copr)' git"
+  fi

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -67,6 +67,11 @@ screens:
           default: false
           packages:
           - Install OpenRazer: just --unstable install-openrazer
+        Webapp Manager:
+          description: A utility for managing your webapps 
+          default: false
+          packages:
+          - Setup Webapp Manager: just --unstable setup-webapp-manager
   amd-additions:
     source: yafti.screen.package
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -78,11 +78,8 @@ install-obs-studio-portable:
   echo 'Install complete'
 
 # Setup the Webapp manager
-setup-webapp-manager:
-  distrobox-create -i fedora:latest -n webapps
-  distrobox-enter -n webapps -- sudo sh -c "sudo dnf update -y && \
-    dnf install -y 'dnf-command(copr)' git && \
-    dnf copr enable -y kylegospo/webapp-manager && \
+setup-webapp-manager: _setup-utilities-toolbox
+  distrobox-enter -n utilities-toolbox -- sudo sh -c "dnf copr enable -y kylegospo/webapp-manager && \
     dnf install -y webapp-manager && \
     /usr/bin/distrobox-host-exec &>/dev/null && \
     ln -s /usr/bin/distrobox-host-exec /usr/bin/xdg-open && \
@@ -118,16 +115,12 @@ install-corectrl:
   rpm-ostree kargs --append="amdgpu.ppfeaturemask=0xffffffff"
 
 # Install Oversteer for Logitech steering wheels
-install-oversteer:
-  sudo wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-oversteer.repo
-  ublue-update --wait
-  rpm-ostree install oversteer
+install-oversteer: _setup-utilities-toolbox
+  distrobox enter -n utilities-toolbox -- bash -c 'sudo dnf copr enable -y kylegospo/oversteer && sudo dnf install python3-evdev oversteer'
 
 # Install OpenRazer (https://openrazer.github.io)
-install-openrazer:
-  sudo wget https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo -O /etc/yum.repos.d/hardware:razer.repo
-  ublue-update --wait
-  rpm-ostree install openrazer-meta
+install-openrazer: _setup-utilities-toolbox
+  distrobox-enter -n utilities-toolbox -- bash -c 'sudo wget https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo -O /etc/yum.repos.d/hardware:razer.repo && sudo dnf install openrazer-meta'
 
 # Install Nix with the Determinate Nix Installer
 install-nix:
@@ -360,3 +353,10 @@ _get-image:
     url = protocol + url
 
   print(url)
+
+_setup-utilities-toolbox:
+  #!/usr/bin/env bash
+  if ! podman container exists utilities-toolbox ; then 
+    distrobox create -i fedora:latest -n utilities-toolbox 
+    distrobox enter -n utilities-toolbox -- sudo sh -c "dnf update -y && dnf install -y 'dnf-command(copr)' git"
+  fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/custom.just
@@ -77,6 +77,19 @@ install-obs-studio-portable:
   distrobox-enter -n obs-studio-portable -- 'bash -c "distrobox-export --app obs"' && \
   echo 'Install complete'
 
+# Setup the Webapp manager
+setup-webapp-manager:
+  distrobox-create -i fedora:latest -n webapps
+  distrobox-enter -n webapps -- sudo sh -c "sudo dnf update -y && \
+    dnf install -y 'dnf-command(copr)' git && \
+    dnf copr enable -y kylegospo/webapp-manager && \
+    dnf install -y webapp-manager && \
+    /usr/bin/distrobox-host-exec &>/dev/null && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/xdg-open && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/flatpak && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/firefox && \
+    distrobox-export --app webapp-manager"
+
 # Remove all waydroid-related files in your user folders
 reset-waydroid:
   bash -c 'sudo rm -rf /var/lib/waydroid /home/.waydroid ~/waydroid ~/.share/waydroid ~/.local/share/applications/*aydroid* ~/.local/share/waydroid'


### PR DESCRIPTION
This PR adds the LinuxMint desktop manager to Yafti and the justfiles! These actions should set it up properly (i've tested them in my machine and they seem fine!)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
