### PR TITLE
fix: Typo in bazzite-flatpak-manager

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-flatpak-manager
+++ b/system_files/desktop/shared/usr/bin/bazzite-flatpak-manager
@@ -20,7 +20,7 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
 fi
 
 # Lists of flatpaks
-FLATPAK_LIST=$(flatpak list --column=application)
+FLATPAK_LIST=$(flatpak list --columns=application)
 INSTALL_LIST=$(cat /usr/etc/flatpak/install)
 REMOVE_LIST=$(cat /usr/etc/flatpak/remove)
 


### PR DESCRIPTION
Per `flatpak list --help`, `--column` should be `--columns`

```
--columns=FIELD,…         What information to show
```