### PR TITLE
fix(image info): use proper prefix in IMAGE_REF

### DIFF
--- a/system_files/shared/tmp/image-info.sh
+++ b/system_files/shared/tmp/image-info.sh
@@ -3,7 +3,7 @@
 set -oue pipefail
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-IMAGE_REF="docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
+IMAGE_REF="ostree-image-signed:docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
 
 case $FEDORA_MAJOR_VERSION in
   38)


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Explained over in https://github.com/ublue-os/bluefin/pull/518, but basically the system update script fails because it can't rebase without the prefix (`ostree-image-signed`)