### PR TITLE
feat: Restore discover overlay support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -233,7 +233,6 @@ COPY system_files/shared system_files/deck/shared system_files/deck/${BASE_IMAGE
 
 # Setup Copr repos
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/LatencyFleX/repo/fedora-$(rpm -E %fedora)/kylegospo-LatencyFleX-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo-latencyflex.repo && \
-    wget https://copr.fedorainfracloud.org/coprs/mavit/discover-overlay/repo/fedora-$(rpm -E %fedora)/mavit-discover-overlay-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_mavit_discover.repo && \
     if grep -qv "nokmods" <<< ${IMAGE_FLAVOR}; then \
         sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo \
     ; fi && \
@@ -420,7 +419,6 @@ RUN /tmp/image-info.sh && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-obs-vkcapture.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_kylegospo-wallpaper-engine-kde-plugin.repo && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ycollet-audinux.repo && \
-    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_mavit_discover.repo && \
     if grep -q "silverblue" <<< "${BASE_IMAGE_NAME}"; then \
         systemctl mask power-profiles-daemon.service && \
         systemctl disable gdm.service && \

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Variant designed for usage as an alternative to SteamOS on the Steam Deck, and f
 - Built in support for Windows dual-boot thanks to Fedora's installation of GRUB being left intact.
 - Update break something? Easily roll back to the previous version of Bazzite thanks to `rpm-ostree`'s rollback functionality. You can even select previous images at boot.
 - Steam and Lutris preinstalled on the image as layered packages.
-- [Discover Overlay](https://github.com/trigg/Discover) for Discord pre-installed and automatically launches in both Gamemode and on the Desktop if Discord is installed and feature is enabled. See `/etc/default/discover-overlay` to enable automatic launching.
+- [Discover Overlay](https://github.com/trigg/Discover) for Discord pre-installed and automatically launches in both Gamemode and on the Desktop if Discord is installed.
 - Exclusively uses ZRAM by default with the option to switch back to a swap file and set a custom size if desired. <sub><sup>(1GB by default)</sup></sub>
 - BFQ I/O scheduler to prevent I/O starvation when installing games or during background `duperemove` and `rmlint` processes.
 - TLS/SSL secured DNS and NTP by default. <sup><sub>(This is a handheld PC you're likely to use on random public networks after all)</sub></sup>
@@ -189,6 +189,7 @@ Ported SteamOS and ChimeraOS packages, among others used by Bazzite, are built o
 
 |Package|Status|
 |---|---|
+|[discover-overlay](https://github.com/trigg/Discover)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/discover-overlay/status_image/last_build.png?)|
 |ds-inhibit|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/ds-inhibit/status_image/last_build.png?)|
 |duperemove|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/package/duperemove/status_image/last_build.png?)|
 |[extest](https://github.com/Supreeeme/extest)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite-multilib/package/extest/status_image/last_build.png?)|
@@ -220,7 +221,6 @@ Additionally, the following packages are used from other Copr repos:
 
 |Package|Status|
 |---|---|
-|[discover-overlay](https://github.com/trigg/Discover)|![Build Status](https://copr.fedorainfracloud.org/coprs/mavit/discover-overlay/package/discover-overlay/status_image/last_build.png?)|
 |[distrobox](https://github.com/89luca89/distrobox)-git|![Build Status](https://copr.fedorainfracloud.org/coprs/ublue-os/distrobox-git/package/distrobox-git/status_image/last_build.png?)|
 |[gcadapter_oc-kmod](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/)|![Build Status](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/gcadapter_oc-kmod/status_image/last_build.png?)|
 |[gnome-vrr](https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/)|![Build Status](https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/package/mutter/status_image/last_build.png?)|

--- a/system_files/deck/shared/usr/bin/bazzite-discover-overlay
+++ b/system_files/deck/shared/usr/bin/bazzite-discover-overlay
@@ -4,7 +4,7 @@ source /etc/default/discover-overlay
 
 # Run discover-overlay if discord is installed and we aren't using Wayland.
 if [[ ${AUTO_LAUNCH_DISCOVER_OVERLAY} == 1 ]]; then
-  if grep -q "com.discordapp.Discord" <<< $(flatpak list); then
+  if grep -q "com.discordapp.Discord\|xyz.armcord.ArmCord\|de.shorsh.discord-screenaudio\|io.github.spacingbat3.webcord" <<< $(flatpak list); then
     if [[ "$XDG_SESSION_TYPE" != "wayland" ]]; then
       /usr/bin/discover-overlay
     fi

--- a/system_files/deck/shared/usr/etc/default/discover-overlay
+++ b/system_files/deck/shared/usr/etc/default/discover-overlay
@@ -1,2 +1,1 @@
-# Default disabled due to discover-overlay breaking mangohud in gamemode.
-AUTO_LAUNCH_DISCOVER_OVERLAY=0
+AUTO_LAUNCH_DISCOVER_OVERLAY=1


### PR DESCRIPTION
Only merge me once [this copr](https://copr.fedorainfracloud.org/coprs/mavit/discover-overlay/) has shipped [0.6.7](https://github.com/trigg/Discover/releases/tag/v0.6.7).