### PR TITLE
fix: Correct hide/unhide grub just command

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
@@ -339,10 +339,10 @@ hide-grub:
   sudo sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/g' /etc/default/grub
   echo 'GRUB_TIMEOUT_STYLE=hidden' | sudo tee -a /etc/default/grub 1>/dev/null
   echo 'GRUB_HIDDEN_TIMEOUT=3' | sudo tee -a /etc/default/grub 1>/dev/null
-  if [ -f '/boot/efi/EFI/fedora/grub.cfg' ]; then
-    sudo grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+  if [ -d /sys/firmware/efi ]; then
+    sudo grub2-mkconfig -o /etc/grub2-efi.cfg
   else
-    sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+    sudo grub2-mkconfig -o /etc/grub2.cfg
   fi
 
 # Set system to boot with the grub screen showing options (Default)
@@ -351,10 +351,10 @@ unhide-grub:
   sudo sed -i '/GRUB_HIDDEN_TIMEOUT=3/d' /etc/default/grub
   sudo sed -i '/GRUB_TIMEOUT_STYLE=hidden/d' /etc/default/grub
   sudo sed -i 's/GRUB_TIMEOUT=0/GRUB_TIMEOUT=5/g' /etc/default/grub
-  if [ -f '/boot/efi/EFI/fedora/grub.cfg' ]; then
-    sudo grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+  if [ -d /sys/firmware/efi ]; then
+    sudo grub2-mkconfig -o /etc/grub2-efi.cfg
   else
-    sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+    sudo grub2-mkconfig -o /etc/grub2.cfg
   fi
 
 # Enable BIOS & Firmware update services for the Steam Deck

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -187,10 +187,10 @@ hide-grub:
   sudo sed -i 's/GRUB_TIMEOUT=5/GRUB_TIMEOUT=0/g' /etc/default/grub
   echo 'GRUB_TIMEOUT_STYLE=hidden' | sudo tee -a /etc/default/grub 1>/dev/null
   echo 'GRUB_HIDDEN_TIMEOUT=1' | sudo tee -a /etc/default/grub 1>/dev/null
-  if [ -f '/boot/efi/EFI/fedora/grub.cfg' ]; then
-    sudo grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+  if [ -d /sys/firmware/efi ]; then
+    sudo grub2-mkconfig -o /etc/grub2-efi.cfg
   else
-    sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+    sudo grub2-mkconfig -o /etc/grub2.cfg
   fi
 
 # Set system to boot with the grub screen showing options (Default)
@@ -199,10 +199,10 @@ unhide-grub:
   sudo sed -i '/GRUB_HIDDEN_TIMEOUT=1/d' /etc/default/grub
   sudo sed -i '/GRUB_TIMEOUT_STYLE=hidden/d' /etc/default/grub
   sudo sed -i 's/GRUB_TIMEOUT=0/GRUB_TIMEOUT=5/g' /etc/default/grub
-  if [ -f '/boot/efi/EFI/fedora/grub.cfg' ]; then
-    sudo grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+  if [ -d /sys/firmware/efi ]; then
+    sudo grub2-mkconfig -o /etc/grub2-efi.cfg
   else
-    sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+    sudo grub2-mkconfig -o /etc/grub2.cfg
   fi
 
 # Enable Flatpak Theming


### PR DESCRIPTION
Use current grub paths instead of depreciated F33 paths.

Also simplify detection by looking if /sys/firmware/efi exists, as BIOS systems don't have this directory.