### PR TITLE
feat(desktop): Add option to enable virtualization and vfio

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -266,3 +266,42 @@ add-user-to-input-group:
     sudo bash -c 'grep "input" /lib/group >> /etc/group'
   fi
   sudo usermod -a -G input $USER
+
+# Enable Virtualization and add workaround for a specific windows VM crash
+enable-virtualization:
+  echo "Installing QEMU and virt-manager..."
+  rpm-ostree install virt-manager edk2-ovmf qemu
+  rpm-ostree kargs \
+  --append-if-missing="kvm.ignore_msrs=1" \
+  --append-if-missing="kvm.report_ignored_msrs=0"
+
+# Enable VFIO on the system if virtualization is enabled
+enable-vfio:
+  #!/usr/bin/env bash
+  echo "Enabling VFIO..."
+  virt_test=$(rpm-ostree kargs)
+  cpu_vendor=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ $print $2 }')
+  vendor_karg="amd_iommu=on"
+  if [[ ${virt_test} == *kvm.report_ignored_msrs* ]]; then
+    rpm-ostree initramfs \
+      --enable \
+      --arg="--add-drivers" \
+      --arg="vfio vfio_iommu_type1 vfio-pci"
+    if [[ ${cpu_vendor} == "AuthenticAMD" ]]; then
+      vendor_karg="amd_iommu=on"
+    elif [[ ${cpu_vendor} == "GenuineIntel" ]]; then
+      vendor_karg="intel_iommu=on"  
+    fi
+    rpm-ostree kargs \
+      --append-if-missing="${vendor_karg}" \
+      --append-if-missing="iommu=pt" \
+      --append-if-missing="rd.driver.pre=vfio_pci" \
+      --append-if-missing="vfio.pci.disable_vga=1"
+    echo "VFIO enabled, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
+    echo "Please understand that since this is such a niche use case, support will be very limited!"
+    echo "To add your unused/second GPU device ids to the vfio driver by running"
+    echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
+    echo "NOTE: Your second GPU will not be usable by the host after you do this!"
+  else
+    echo "Enable virtualization with just enable-virtualization before running just enable-vfio."
+  fi


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
This adds the option to enable virtualization and vfio on the desktop image.

Enabling virtualization will:
* Install virt-manager, edk-ovmf2 and qemu as layered packages (distrobox is not feasable for this during my testing)
* Add 2 kargs for kvm to prevent a specific bluescreen in windows and to also prevent log and tty spam caused by said workaround.
 
Enabling VFIO will:
* enable the vfio kernel modules
* enable iommu in the kernel using the kargs appropriate for each cpu vendor
* make sure the vfio driver is loaded before gpu drivers
* disable vga output on any device bound to the vfio driver (this only applies to the host)
* display a message that support in regards to vfio will be very limited (this can be removed if preferable, however i know there is an extremely small amount of people in the community doing gpu passthrough, hence the inclusion)