### PR TITLE
Enable virtualization

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -279,29 +279,34 @@ enable-virtualization:
 enable-vfio:
   #!/usr/bin/env bash
   echo "Enabling VFIO..."
-  virt_test=$(rpm-ostree kargs)
-  cpu_vendor=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
-  vendor_karg="amd_iommu=on"
-  if [[ ${virt_test} == *kvm.report_ignored_msrs* ]]; then
+  VIRT_TEST=$(rpm-ostree kargs)
+  CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
+  VENDOR_KARG="unset"
+  if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
     rpm-ostree initramfs \
       --enable \
       --arg="--add-drivers" \
       --arg="vfio vfio_iommu_type1 vfio-pci"
-    if [[ ${cpu_vendor} == "AuthenticAMD" ]]; then
-      vendor_karg="amd_iommu=on"
-    elif [[ ${cpu_vendor} == "GenuineIntel" ]]; then
-      vendor_karg="intel_iommu=on"  
+    if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
+      VENDOR_KARG="amd_iommu=on"
+    elif [[ ${CPU_VENDOR} == "GenuineIntel" ]]; then
+      VENDOR_KARG="intel_iommu=on"  
     fi
-    rpm-ostree kargs \
-      --append-if-missing="${vendor_karg}" \
-      --append-if-missing="iommu=pt" \
-      --append-if-missing="rd.driver.pre=vfio_pci" \
-      --append-if-missing="vfio.pci.disable_vga=1"
-    echo "VFIO enabled, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
-    echo "Please understand that since this is such a niche use case, support will be very limited!"
-    echo "To add your unused/second GPU device ids to the vfio driver by running"
-    echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
-    echo "NOTE: Your second GPU will not be usable by the host after you do this!"
+    if [[ ${VENDOR_KARG} == "unset" ]]; then
+      echo "Failed to get CPU vendor, exiting..."
+      exit 1
+    else
+      rpm-ostree kargs \
+        --append-if-missing="${VENDOR_KARG}" \
+        --append-if-missing="iommu=pt" \
+        --append-if-missing="rd.driver.pre=vfio_pci" \
+        --append-if-missing="vfio.pci.disable_vga=1"
+      echo "VFIO enabled, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
+      echo "Please understand that since this is such a niche use case, support will be very limited!"
+      echo "To add your unused/second GPU device ids to the vfio driver by running"
+      echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
+      echo "NOTE: Your second GPU will not be usable by the host after you do this!"
+    fi
   else
     echo "Enable virtualization with just enable-virtualization before running just enable-vfio."
   fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -280,7 +280,7 @@ enable-vfio:
   #!/usr/bin/env bash
   echo "Enabling VFIO..."
   virt_test=$(rpm-ostree kargs)
-  cpu_vendor=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ $print $2 }')
+  cpu_vendor=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
   vendor_karg="amd_iommu=on"
   if [[ ${virt_test} == *kvm.report_ignored_msrs* ]]; then
     rpm-ostree initramfs \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Ran just enable-vfio on a new system and noticed awk command failed compared to the test system, saw that `print` had been replaced with `$print` at some point when writing and i have fixed that mistype.
Command has been tested on 2 systems now and it works each time (amd and intel check)
Also changed the script so that it will fail and exit if a cpu vendor for some reason is unknown or not detected, this will avoid situations where vfio will get "half enabled"
