### PR TITLE
Start Solaar minimized by default on login

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/30-distrobox.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/30-distrobox.just
@@ -83,7 +83,8 @@ install-solaar:
     distrobox-export --app solaar' && \
   mkdir -p ~/.config/autostart && \
   rm -f ~/.config/autostart/fedora-solaar.desktop && \
-  cp ~/.local/share/applications/fedora-solaar.desktop ~/.config/autostart/fedora-solaar.desktop
+  cp ~/.local/share/applications/fedora-solaar.desktop ~/.config/autostart/fedora-solaar.desktop && \
+  sed -i 's/fedora --   solaar/fedora --   solaar --window=hide/g' ~/.config/autostart/fedora-solaar.desktop
 
 # Install Resilio Sync, a file synchronization utility powered by BitTorrent
 install-resilio-sync:


### PR DESCRIPTION
This forces Solaar to start in the background instead of opening each time the interface forcing people to close it each time.
