### PR TITLE
chore(f39): Restore kmods removed from main

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,8 +19,19 @@ COPY --from=ghcr.io/ublue-os/akmods:main-${FEDORA_MAJOR_VERSION} /rpms /tmp/akmo
 RUN if [[ "${IMAGE_FLAVOR}" = "main" || "${IMAGE_NAME}" = "nvidia" ]]; then \
     sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     wget https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/negativo17-fedora-multimedia.repo && \
+    if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]]; then \
+        rpm-ostree install \
+            /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
+            /tmp/akmods-rpms/kmods/*xpad-noone*.rpm \
+            /tmp/akmods-rpms/kmods/*xone*.rpm \
+            /tmp/akmods-rpms/kmods/*openrazer*.rpm \
+            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
+            /tmp/akmods-rpms/kmods/*wl*.rpm \
+    ; else \
+        rpm-ostree install \
+            /tmp/akmods-rpms/kmods/*evdi*.rpm \
+    ; fi && \
     rpm-ostree install \
-        /tmp/akmods-rpms/kmods/*evdi*.rpm \
         /tmp/akmods-rpms/kmods/*gcadapter_oc*.rpm \
         /tmp/akmods-rpms/kmods/*nct6687*.rpm \
         /tmp/akmods-rpms/kmods/*openrgb*.rpm \


### PR DESCRIPTION
This restores kmods removed from Fedora 39

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
