### PR TITLE
Looking glass shm OOB auto generation and support

### DIFF
--- a/system_files/desktop/shared/usr/etc/tmpfiles.d/10-looking-glass.conf
+++ b/system_files/desktop/shared/usr/etc/tmpfiles.d/10-looking-glass.conf
@@ -1,0 +1,2 @@
+# Type Path               Mode UID  GID Age Argument
+f /dev/shm/looking-glass 0660 1000 qemu -

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -326,3 +326,7 @@ disable-watchdog:
     WATCHDOG_KARGS="$WATCHDOG_KARGS --append-if-missing=modprobe.blacklist=sp5100_tco"
   fi
   rpm-ostree kargs $WATCHDOG_KARGS
+
+# Add SELinux file context for default looking-glass shm file
+selinux-looking-glass:
+  sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -327,6 +327,6 @@ disable-watchdog:
   fi
   rpm-ostree kargs $WATCHDOG_KARGS
 
-# Add SELinux file context for default looking-glass shm file
+# Add SELinux file context for default looking-glass shm file so that libvirt can create it when needed
 selinux-looking-glass:
   sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -292,7 +292,7 @@ enable-vfio:
         --append-if-missing="${VENDOR_KARG}" \
         --append-if-missing="iommu=pt" \
         --append-if-missing="rd.driver.pre=vfio_pci" \
-        --append-if-missing="vfio.pci.disable_vga=1"
+        --append-if-missing="vfio_pci.disable_vga=1"
       echo "VFIO enabled, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
       echo "Please understand that since this is such a niche use case, support will be very limited!"
       echo "To add your unused/second GPU device ids to the vfio driver by running"


### PR DESCRIPTION
This adds the config for systemd to to generate the looking-glass shm file if libvirt requests it and also provide a just command to set the correct selinux file context for `/dev/shm/looking-glass`.

this will result in any libvirt VM started with
```xml
<shmem name="looking-glass">
      <model type="ivshmem-plain"/>
      <size unit="M">X</size>
</shmem>
```
inside the xml to auto create /dev/shm/looking-glass when needed.
the user will just have to run `just selinux-looking-glass` once on their system to permanently enable it.

If you do not know about looking-glass it is a kvm framebuffer relay for gpu passthrough.
Users will still have to download and compile the client with the same release as the host they installed in the VM from https://looking-glass.io/ for it to work, this will have to be compiled in a fedora docker distrobox (the fedora toolbox distrobox does not work for this) and then copy the binary to the host `~/.local/bin` for now to avoid randomly breaking peoples looking-glass VMs whenever looking-glass updates (as the host application in the VM has no auto update function)
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
