### PR TITLE
feat: enable auto mounting of hugepages with 1GB pagesize if karg exists

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -283,6 +283,7 @@ RUN /tmp/image-info.sh && \
     systemctl enable ublue-update.timer && \
     systemctl enable bazzite-hardware-setup.service && \
     systemctl enable tailscaled.service && \
+    systemctl enable dev-hugepages1G.mount && \
     systemctl --global enable bazzite-user-setup.service && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
         sed -i '/^PRETTY_NAME/s/Kinoite/Bazzite/' /usr/lib/os-release && \

--- a/system_files/desktop/shared/usr/lib/systemd/system/dev-hugepages1G.mount
+++ b/system_files/desktop/shared/usr/lib/systemd/system/dev-hugepages1G.mount
@@ -1,0 +1,31 @@
+#  This file is a modified version of dev-hugepages.mount from systemd.
+#
+#  With this unit file enabled you can set 1GB hugepages using kernel args
+#  and have them auto mounted, just as you would with 2MB hugepages.
+#
+#  For normal systems use "hugepagesz=1G hugepages=16"
+#  to allocate 16 hugepages with a pagesize of 1GB
+#  
+#  For systems with numa nodes use "hugepagesz=1G hugepages=0:16"
+#  to allocate 16 hugepages on numa node 0 with a pagesize of 1GB
+# 
+#  For more info, consult the kernel.org documentation linked in this file
+
+[Unit]
+Description=1GB Huge Pages File System
+Documentation=https://docs.kernel.org/admin-guide/mm/hugetlbpage.html
+Documentation=https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
+ConditionPathExists=/sys/kernel/mm/hugepages
+DefaultDependencies=no
+ConditionCapability=CAP_SYS_ADMIN
+ConditionVirtualization=!private-users
+ConditionKernelCommandLine=hugepagesz=1G
+
+[Install]
+WantedBy=multi-user.target
+
+[Mount]
+What=hugetlbfs
+Where=/dev/hugepages1G
+Type=hugetlbfs
+Options=pagesize=1G


### PR DESCRIPTION
This will enable auto mounting of hugepages with a pagesize of 1GB if the kernel argument `hugepagesz=1G` is present, which indicates the user has reserved hugepages with a pagesize of 1GB.

Hugepages with a pagesize of 1GB each is used for specialized VMs (like gaming VMs) to reduce latency due to memory page lookups for the VM, the default hugepages of 2MB each page has auto mounting enabled by default , however for special VMs like a gaming VM (should the user set one up), it would be favorable to auto mount it too as a pagesize of 2MB for a VM with 16GB ram would have `16777216` memory pages for the VM compared to the `16` you would get with 1GB hugepages.

Alternatively the we can set the feature disabled by default and instead be enabled with a just command, in which case i will change it.

Users can consult https://docs.kernel.org/admin-guide/mm/hugetlbpage.html which is referenced in the mount unit file for more info on how to use hugepages, the libvirt VMs that will use 1GB hugepages will need it specified in their xml, otherwise they will use the normal memory pages that the rest of the system uses

normal config with the kargs `hugepagesz=1G hugepages=16`
```xml
<memoryBacking>
  <hugepages>
    <page size="1048576" unit="KiB"/>
  </hugepages>
</memoryBacking>
```

config for hugepages on a specific numa node (must be reserved with the kargs `hugepagesz=1G hugepages=1:16` to reserve 16 pages on numa node 1, as the default on systems with numa nodes is to split the hugepages equally across the nodes, which will actually increase latency
```xml
<memoryBacking>
  <hugepages>
    <page size="1048576" unit="KiB" nodeset="1"/>
  </hugepages>
</memoryBacking>
``` 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
