### PR TITLE
fix(user-setup): Correct Fedora version check, prevents setup from ru…

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -15,7 +15,7 @@ USER_SETUP_FEDORA_VER_RAN=$(cat $USER_SETUP_FEDORA_VERSION)
 
 # Run script if updated
 if [[ -f $USER_SETUP_VER_FILE && $USER_SETUP_VER = $USER_SETUP_VER_RAN ]]; then
-  if [[ -f USER_SETUP_FEDORA_VER_FILE && $FEDORA_VERSION = $USER_SETUP_FEDORA_VER_RAN ]]; then
+  if [[ -f $USER_SETUP_FEDORA_VER_FILE && $FEDORA_VERSION = $USER_SETUP_FEDORA_VER_RAN ]]; then
     echo "User setup has already run. Exiting..."
     exit 0
   fi


### PR DESCRIPTION
…nning every boot

The file path for the last ran Fedora version wasn't being referenced causing the script to rerun every boot

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
