### PR TITLE
feat: Add Warehouse to Bazzite Portal on Deck images

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -233,6 +233,7 @@ screens:
           - qBittorrent: org.qbittorrent.qBittorrent
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
+          - Warehouse: io.github.flattool.Warehouse
   theme:
     source: yafti.screen.title
     values:


### PR DESCRIPTION
Flatpak Manager
Link: https://flathub.org/apps/io.github.flattool.Warehouse

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
