### PR TITLE
feat: add virtual audio channels for special use cases

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -325,3 +325,79 @@ disable-watchdog:
 # Add SELinux file context for default looking-glass shm file so that libvirt can create it when needed
 selinux-looking-glass:
   sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass
+
+setup-virtual-channels:
+  #!/bin/bash
+  mkdir -p ~/.config/pipewire/pipewire.conf.d
+  cat << 'EOL' > ~/.config/pipewire/pipewire.conf.d/virtual-channels.conf
+  context.modules = [
+      { name = libpipewire-module-loopback
+          args = {
+              node.description = "Game"
+              capture.props = {
+                  node.name      = "game_output"
+                  media.class    = "Audio/Sink"
+                  audio.position = [ FL FR ]
+              }
+              playback.props = {
+                  node.name      = "playback.game_output"
+                  audio.position = [ FL FR ]
+                  node.passive   = true
+              }
+          }
+      }
+      { name = libpipewire-module-loopback
+          args = {
+              node.description = "Voice"
+              capture.props = {
+                  node.name      = "voice_output"
+                  media.class    = "Audio/Sink"
+                  audio.position = [ FL FR ]
+              }
+              playback.props = {
+                  node.name      = "playback.voice_output"
+                  audio.position = [ FL FR ]
+                  node.passive   = true
+              }
+          }
+      }
+      { name = libpipewire-module-loopback
+          args = {
+              node.description = "Browser"
+              capture.props = {
+                  node.name      = "browser_output"
+                  media.class    = "Audio/Sink"
+                  audio.position = [ FL FR ]
+              }
+              playback.props = {
+                  node.name      = "playback.browser_output"
+                  audio.position = [ FL FR ]
+                  node.passive   = true
+              }
+          }
+      }
+      { name = libpipewire-module-loopback
+          args = {
+              node.description = "Music"
+              capture.props = {
+                  node.name      = "music_output"
+                  media.class    = "Audio/Sink"
+                  audio.position = [ FL FR ]
+              }
+              playback.props = {
+                  node.name      = "playback.music_output"
+                  audio.position = [ FL FR ]
+                  node.passive   = true
+              }
+          }
+      }
+  ]
+  EOL
+  echo "Next time you log in, you will have audio channels for Game, Voice, Browser, Music that you can route game audio to"
+  echo "using programs like qpwgraph, helvum or carla."
+  echo "You can also add these channels to OBS audio mixer for separate audio control for yourself and your viewers."
+  echo "NOTE: It is recommended to mute the virtual channels so you do not have to listen to them twice if you are not exclusively routing the audio through said channel instead of splitting audio to them."
+
+remove-virtual-channels:
+  rm ~/.config/pipewire/pipewire.conf.d/virtual-channels.conf
+  echo "Virtual audio channels config removed, the channels will be removed next time you login."


### PR DESCRIPTION
This adds a just command for enabling virtual audio channels for Game, Voice, Browser and Music.
This is useful for special use cases where you where you would want 2 separate controls for the audio (for example streaming, game audio control for you and game audio control for viewers/stream)
This can easily be achieved by splitting the audio off to one of these channels using something like qpwgraph, helvum or carla.
![Screenshot_20231018_002004](https://github.com/ublue-os/bazzite/assets/2557889/1566e3f4-cb0a-48e9-aed7-15b9a7a6163b)
![Screenshot_20231018_012358](https://github.com/ublue-os/bazzite/assets/2557889/d5792235-6374-4d0b-8964-722b7e8f5de0)
Users will still have to manually add the `Audio Output Capture` source in OBS to make use of this.

I found no way to replicate this using the obs-pipewire-audio-capture plugin from obs-studio-portable, if this is actually possible with that plugin then this PR can be ignored for that use case.

I also use this to listen to podcasts while streaming without sending the podcast audio to the viewers (this i saw i could replicate using the obs-pipewire-audio-capture plugin) too or to play audio at lower volume to my friends on discord than for myself.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
