### PR TITLE
fix: prevent vfio initramfs args from conflicting with bazzite-hardware-setup

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -272,7 +272,6 @@ enable-vfio:
   INITRAMFS_ARGS=$(rpm-ostree status | grep -m 1 Initramfs | perl -pe "s/\s+(Initramfs: regenerate|Initramfs:)//" | perl -pe "s/ \'/ --arg='/")
   if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
       echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
-      echo $(($(cat /etc/bazzite/hws_version)-1)) | sudo tee /etc/bazzite/hws_version
       rpm-ostree initramfs --enable $INITRAMFS_ARGS
     if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
       VENDOR_KARG="amd_iommu=on"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -270,10 +270,9 @@ enable-vfio:
   CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
   VENDOR_KARG="unset"
   if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
-    rpm-ostree initramfs \
-      --enable \
-      --arg="--add-drivers" \
-      --arg="vfio vfio_iommu_type1 vfio-pci"
+      echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
+      echo $(($(cat /etc/bazzite/hws_version)-1)) | sudo tee /etc/bazzite/hws_version
+      rpm-ostree initramfs --enable $INITRAMFS_ARGS
     if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
       VENDOR_KARG="amd_iommu=on"
     elif [[ ${CPU_VENDOR} == "GenuineIntel" ]]; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -269,6 +269,7 @@ enable-vfio:
   VIRT_TEST=$(rpm-ostree kargs)
   CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
   VENDOR_KARG="unset"
+  INITRAMFS_ARGS=$(rpm-ostree status | grep -m 1 Initramfs | perl -pe "s/\s+(Initramfs: regenerate|Initramfs:)//" | perl -pe "s/ \'/ --arg='/")
   if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
       echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
       echo $(($(cat /etc/bazzite/hws_version)-1)) | sudo tee /etc/bazzite/hws_version


### PR DESCRIPTION
Noticed this morning that bazzite-hardware-setup nuked the vfio arguments from initramfs.
After some testing I found out that since `rpm-ostree initramfs --enable` is run, i could just add the vfio arguments to `/etc/dracut.conf.d/vfio.conf` and rebuild initramfs once, thereby preventing any future conflict.

However it will also reduce bazzite hw_version by 1 to re-trigger bazzite-hardware-setup so that it will re-add any missing initramfs arguments.

I initially had a variable where i used perl to check what the current initramfs args are and then include them in the `rpm-ostree initramfs --enable` command as this would avoid having to rebuild initramfs 2 times, however after some consideration i decided this might not be reliable down the line and instead opted to have initramfs rebuild 2 times instead as that would be a lot safer (and it would be a 1 time thing anyway)
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
