### PR TITLE
feat: Warehouse as preinstalled Flatpak.

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -234,6 +234,7 @@ screens:
           - PinApp: io.github.fabrialberio.pinapp
           - qBittorrent: org.qbittorrent.qBittorrent
           - Resources: net.nokyan.Resources
+          - SaveDesktop: io.github.vikdevelop.SaveDesktop
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
   theme:

--- a/system_files/desktop/kinoite/usr/share/ublue-os/bazzite/flatpak/install
+++ b/system_files/desktop/kinoite/usr/share/ublue-os/bazzite/flatpak/install
@@ -1,7 +1,6 @@
 org.mozilla.firefox
 it.mijorus.gearlever
 com.github.tchx84.Flatseal
-io.github.vikdevelop.SaveDesktop
 io.github.flattool.Warehouse
 net.davidotek.pupgui2
 org.freedesktop.Platform.VulkanLayer.MangoHud//23.08

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -223,6 +223,7 @@ screens:
           - PinApp: io.github.fabrialberio.pinapp
           - qBittorrent: org.qbittorrent.qBittorrent
           - Resources: net.nokyan.Resources
+          - SaveDesktop: io.github.vikdevelop.SaveDesktop
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
   theme:

--- a/system_files/desktop/silverblue/usr/share/ublue-os/bazzite/flatpak/install
+++ b/system_files/desktop/silverblue/usr/share/ublue-os/bazzite/flatpak/install
@@ -3,7 +3,6 @@ com.github.GradienceTeam.Gradience
 com.mattjakeman.ExtensionManager
 it.mijorus.gearlever
 com.github.tchx84.Flatseal
-io.github.vikdevelop.SaveDesktop
 io.github.flattool.Warehouse
 io.missioncenter.MissionCenter
 com.vysp3r.ProtonPlus


### PR DESCRIPTION
chore: Remove Warehouse and SaveDesktop from Bazzite Portal.
feat: Added Added [Resources](https://flathub.org/apps/net.nokyan.Resources) to Bazzite Portal.
feat: Added [Pika Backup](https://flathub.org/apps/org.gnome.World.PikaBackup) to Bazzite Portal.
fix: Removed System Applications in Bazzite Portal so users will not have to scroll anymore
chore: Moved PinApp and Save Desktop back to Utilities.
chore: Renamed Utilities to Utilities and System Tools in Bazzite Portal.

Since AppImages have a utility like Gear Lever, then there should be a utility for Flatpaks besides Flatseal preinstalled.