### PR TITLE
fix: correct mistype in remove virtual surround command

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -519,6 +519,6 @@ setup-virtual-surround-71:
 
 # Remove Virtual Surround 7.1 sink
 remove-virtual-surround-71:
-  rm ~/.conf/pipewire/pipewire.conf.d/virtual-surround-71.conf
-  rm ~/.conf/pipewire/hrir_hesuvi/Control_Room_1.wav
+  rm ~/.config/pipewire/pipewire.conf.d/virtual-surround-71.conf
+  rm ~/.config/pipewire/hrir_hesuvi/Control_Room_1.wav
   echo "Virtual Surround 7.1 removed, please reboot or restart pipewire for it to take effect."


### PR DESCRIPTION
There was a mistype in the remove-virtual-surround-71 command, this is corrected now.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
