### PR TITLE
chore: Install split gamescope session plus and steam packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -496,7 +496,8 @@ RUN rpm-ostree install \
         libFAudio \
         gamescope.x86_64 \
         gamescope.i686 \
-        gamescope-session \
+        gamescope-session-plus \
+        gamescope-session-steam \
         wine-core \
         winetricks \
         protontricks && \


### PR DESCRIPTION
The core for gamescope session was recently split away from Steam's session allowing it to be used for other sessions such as OpenGamepadUI's session independent of Steam's components.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
