### PR TITLE
fix(user-setup): Only enable steam-patch on the ROG Ally

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -129,7 +129,7 @@ fi
 
 # Steam Patch setup
 if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" || $IMAGE_NAME =~ "framegame" ]]; then
-  if [[ ! ":Jupiter:" =~ ":$SYS_ID:" ]]; then
+  if [[ ":ROG Ally RC71L_RC71L:" =~ ":$SYS_ID:"  ]]; then
     echo 'Enabling Steam-Patch'
     pkexec /usr/bin/bazzite-enable-steam-patch "$USER"
   fi


### PR DESCRIPTION
Results in a coredump on anything that can't use it (I.E. HTPCs)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
