### PR TITLE
fix(surface-nvidia): Exclude OBS vkcapture

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -263,9 +263,12 @@ RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
         vkBasalt.i686 \
         mangohud.x86_64 \
         mangohud.i686 \
-        obs-vkcapture.x86_64 \
-        obs-vkcapture.i686 \
         gperftools-libs.i686 && \
+    if [[ "${IMAGE_FLAVOR}" != "surface-nvidia" ]]; then \
+        rpm-ostree install \
+            obs-vkcapture.x86_64 \
+            obs-vkcapture.i686 \
+    ; fi && \
     wget $(curl https://api.github.com/repos/ishitatsuyuki/LatencyFleX/releases/latest | jq -r '.assets[] | select(.name| test(".*.tar.xz$")).browser_download_url') -O /tmp/latencyflex.tar.xz && \
     mkdir -p /tmp/latencyflex && \
     tar --strip-components 1 -xvf /tmp/latencyflex.tar.xz -C /tmp/latencyflex && \


### PR DESCRIPTION
Dependencies pull in libwacom via libinput which conflicts with libwacom-surface

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
