### PR TITLE
fix: Add Minimum-free ZRAM configuration

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-hardware-setup
@@ -35,6 +35,8 @@ fi
 # GLOBAL
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 GPU_ID=$(lspci -k | grep -A 3 -E "(VGA|3D)")
+MINIMUM_FREE_ZRAM=$(awk '/MemTotal/ {printf "%.0f", $2 * 0.01}' /proc/meminfo)
+CURRENT_FREE_ZRAM=$(sysctl vm.min_free_kbytes | awk '{print $3}')
 KARGS=$(rpm-ostree kargs)
 NEEDED_KARGS=()
 INITRAMFS=$(rpm-ostree initramfs)
@@ -141,6 +143,16 @@ if [[ $(grep "compress=zstd" /etc/fstab) ]]; then
   fi
 else
   echo "No fstab param adjustments needed"
+fi
+
+# ZRAM MINIMUM-FREE CONFIGURATION
+echo "Current minimum-free ZRAM value: $CURRENT_FREE_ZRAM"
+
+if ((MINIMUM_FREE_ZRAM > CURRENT_FREE_ZRAM)); then
+    sysctl -w "vm.min_free_kbytes=${MINIMUM_FREE_ZRAM}"
+    echo "Found needed minimum-free ZRAM changes, applying the following: ${MINIMUM_FREE_ZRAM}"
+else
+  echo "No minimum-free ZRAM changes needed"
 fi
 
 # HOSTNAME FIX


### PR DESCRIPTION
It assures that this value will get properly configured for systems with ≥6.75GBs of RAM.

As this article shows, too low of a value is not good, and too high of a value is not good.

https://linuxhint.com/vm_min_free_kbytes_sysctl/

It is the only remaining non-applied ZRAM tweak from Pop-OS, which they included in their zram service.

https://github.com/pop-os/default-settings/commit/7fcad35#diff-964fc7d24025670fb776c01ef2943c84e637a3675c164696aebae19d86c8d46eR62

This checks if minimum-free ZRAM value is 1% of the maximum RAM of the current system, hence why this must go to the hardware service compared to simple sysctl config change.