### PR TITLE
chore: Restore nokmods images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_flavor: [main, nvidia, asus, asus-nvidia, framework, surface, surface-nvidia]
+        image_flavor: [main, nokmods, nvidia, asus, asus-nvidia, framework, surface, surface-nvidia]
         base_name: [bazzite, bazzite-deck]
         base_image_name: [kinoite, silverblue]
         major_version: [39]
@@ -95,6 +95,11 @@ jobs:
               echo "AKMODS_FLAVOR=surface" >> $GITHUB_ENV
           else
               echo "AKMODS_FLAVOR=main" >> $GITHUB_ENV
+          fi
+          if [[ "${{ matrix.image_flavor }}" =~ "nokmods" ]]; then
+              echo "SOURCE_FLAVOR=main" >> $GITHUB_ENV
+          else
+              echo "SOURCE_FLAVOR=${{ matrix.image_flavor }}" >> $GITHUB_ENV
           fi
 
       - name: Generate tags
@@ -187,6 +192,7 @@ jobs:
             IMAGE_VENDOR=${{ github.repository_owner }}
             BASE_IMAGE_NAME=${{ matrix.base_image_name }}
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
+            SOURCE_FLAVOR=${{ env.SOURCE_FLAVOR }}
             AKMODS_FLAVOR=${{ env.AKMODS_FLAVOR }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false


### PR DESCRIPTION
These were disabled after hwcompat was implemented however, these could still be useful for people working on images based off of Bazzite that want to use a custom kernel or have greater control over what kmods they want to utilize

Works around 39s exclusion of nokmods nomenclature by introducing SOURCE_FLAVOR
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
