### PR TITLE
feat: Always layer Steam

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -162,7 +162,7 @@ RUN rpm-ostree install \
         vk_hdr_layer.x86_64 \
         vk_hdr_layer.i686 \
         gperftools-libs.i686 && \
-    if [[ "${IMAGE_FLAVOR}" != "surface-nvidia" ]]; then \
+    if [[ ! "${IMAGE_FLAVOR}" =~ "surface" ]]; then \
         rpm-ostree install \
             obs-vkcapture.x86_64 \
             obs-vkcapture.i686 \

--- a/Containerfile
+++ b/Containerfile
@@ -241,7 +241,8 @@ RUN rpm-ostree override replace \
         mesa-libgbm \
         mesa-libGL \
         mesa-libglapi \
-        mesa-vulkan-drivers
+        mesa-vulkan-drivers \
+        mesa-libOSMesa
 
 # Install Gamescope, ROCM, and Waydroid on non-Nvidia images
 RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \

--- a/Containerfile
+++ b/Containerfile
@@ -20,15 +20,13 @@ COPY system_files/desktop/shared system_files/desktop/${BASE_IMAGE_NAME} /
 COPY --from=ghcr.io/ublue-os/akmods:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     wget https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/negativo17-fedora-multimedia.repo && \
-    if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]]; then \
-        rpm-ostree install \
-            /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
-            /tmp/akmods-rpms/kmods/*xpad-noone*.rpm \
-            /tmp/akmods-rpms/kmods/*xone*.rpm \
-            /tmp/akmods-rpms/kmods/*openrazer*.rpm \
-            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
-            /tmp/akmods-rpms/kmods/*wl*.rpm \
-    ; fi && \
+    rpm-ostree install \
+        /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
+        /tmp/akmods-rpms/kmods/*xpad-noone*.rpm \
+        /tmp/akmods-rpms/kmods/*xone*.rpm \
+        /tmp/akmods-rpms/kmods/*openrazer*.rpm \
+        /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
+        /tmp/akmods-rpms/kmods/*wl*.rpm && \
     rpm-ostree install \
         /tmp/akmods-rpms/kmods/*gcadapter_oc*.rpm \
         /tmp/akmods-rpms/kmods/*nct6687*.rpm \
@@ -111,111 +109,8 @@ RUN rpm-ostree install \
     wget https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/systemd/system/btrfs-dedup@.service -O /usr/lib/systemd/system/btrfs-dedup@.service && \
     wget https://gitlab.com/popsulfr/steamos-btrfs/-/raw/main/files/usr/lib/systemd/system/btrfs-dedup@.timer -O /usr/lib/systemd/system/btrfs-dedup@.timer
 
-# Configure KDE & GNOME
-RUN if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
-    rpm-ostree override remove \
-        plasma-welcome \
-        qt5-qdbusviewer && \
-    rpm-ostree install \
-        steamdeck-kde-presets-desktop \
-        wallpaper-engine-kde-plugin \
-        kdeconnectd \
-        kdeplasma-addons \
-        rom-properties-kf5 && \
-    if [[ "${FEDORA_MAJOR_VERSION}" -lt "39" ]]; then \
-        rpm-ostree override replace \
-        --experimental \
-        --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
-            xorg-x11-server-Xwayland \
-    ; fi && \
-    if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
-        rpm-ostree install colord-kde \
-    ; fi && \
-    git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration && \
-    git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin && \
-    kpackagetool5 --type=KWin/Script --global --install /tmp/kwin-system76-scheduler-integration && \
-    kpackagetool5 --type=Plasma/Wallpaper --global --install /tmp/wallpaper-engine-kde-plugin/plugin && \
-    rm -rf /tmp/kwin-system76-scheduler-integration && \
-    rm -rf /tmp/wallpaper-engine-kde-plugin \
-; else \
-    if [[ "${FEDORA_MAJOR_VERSION}" -lt "39" ]]; then \
-        rpm-ostree override replace \
-        --experimental \
-        --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
-            mutter \
-            mutter-common \
-            gnome-control-center \
-            gnome-control-center-filesystem \
-            xorg-x11-server-Xwayland && \
-        rpm-ostree install \
-            gnome-shell-extension-tailscale-status \
-    ; else \
-        rpm-ostree override replace \
-        --experimental \
-        --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
-            mutter \
-            mutter-common \
-            gnome-control-center \
-            gnome-control-center-filesystem && \
-        rpm-ostree install \
-            gnome-shell-extension-tailscale-gnome-qs \
-    ; fi && \
-    rpm-ostree install \
-        xwaylandvideobridge \
-        steamdeck-backgrounds \
-        gnome-randr-rust \
-        gnome-shell-extension-user-theme \
-        gnome-shell-extension-gsconnect \
-        nautilus-gsconnect \
-        gnome-shell-extension-system76-scheduler \
-        gnome-shell-extension-compiz-windows-effect \
-        gnome-shell-extension-just-perfection \
-        gnome-shell-extension-blur-my-shell \
-        gnome-shell-extension-hanabi \
-        gnome-shell-extension-gamerzilla \
-        rom-properties-gtk3 \
-        openssh-askpass && \
-    rpm-ostree override remove \
-        gnome-classic-session \
-        gnome-tour \
-        gnome-extensions-app \
-        gnome-initial-setup \
-; fi
-
-# Install gamescope-limiter patched Mesa
-RUN if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]]; then \
-        rpm-ostree override replace \
-            --experimental \
-            --from repo=copr:copr.fedorainfracloud.org:kylegospo:bazzite-multilib \
-                mesa-filesystem \
-                mesa-dri-drivers \
-                mesa-libEGL \
-                mesa-libEGL-devel \
-                mesa-libgbm \
-                mesa-libGL \
-                mesa-libglapi \
-                mesa-vulkan-drivers \
-    ; fi
-
-# Install ROCM and Waydroid on non-Nvidia images
-# Install Steam & Lutris on Nvidia images (Avoids numerous driver issues under Distrobox)
-RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
-    rpm-ostree install \
-        rocm-hip \
-        rocm-opencl \
-        rocm-clinfo \
-        waydroid \
-        weston && \
-    sed -i~ -E 's/=.\$\(command -v (nft|ip6?tables-legacy).*/=/g' /usr/lib/waydroid/data/scripts/waydroid-net.sh && \
-    rm -f /usr/etc/modprobe.d/nvidia.conf \
-; else \
-    rm -f /usr/etc/modprobe.d/amdgpu.conf && \
-    if [[ "${FEDORA_MAJOR_VERSION}" -lt "39" ]]; then \
-        rpm-ostree install \
-            mesa-libGL.i686 \
-            mesa-libEGL.i686 \
-    ; fi && \
-    rpm-ostree install \
+# Install Steam & Lutris, plus supporting packages
+RUN rpm-ostree install \
         vulkan-loader.i686 \
         alsa-lib.i686 \
         fontconfig.i686 \
@@ -280,7 +175,86 @@ RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
     wget https://raw.githubusercontent.com/Shringe/LatencyFleX-Installer/main/install.sh -O /usr/bin/latencyflex && \
     sed -i 's@/usr/lib/wine/@/usr/lib64/wine/@g' /usr/bin/latencyflex && \
     sed -i 's@"dxvk.conf"@"/usr/share/latencyflex/dxvk.conf"@g' /usr/bin/latencyflex && \
-    chmod +x /usr/bin/latencyflex \
+    chmod +x /usr/bin/latencyflex
+
+# Configure KDE & GNOME
+RUN if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
+    rpm-ostree override remove \
+        plasma-welcome \
+        qt5-qdbusviewer && \
+    rpm-ostree install \
+        steamdeck-kde-presets-desktop \
+        wallpaper-engine-kde-plugin \
+        kdeconnectd \
+        kdeplasma-addons \
+        rom-properties-kf5 && \
+    if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
+        rpm-ostree install colord-kde \
+    ; fi && \
+    git clone https://github.com/maxiberta/kwin-system76-scheduler-integration.git --depth 1 /tmp/kwin-system76-scheduler-integration && \
+    git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 /tmp/wallpaper-engine-kde-plugin && \
+    kpackagetool5 --type=KWin/Script --global --install /tmp/kwin-system76-scheduler-integration && \
+    kpackagetool5 --type=Plasma/Wallpaper --global --install /tmp/wallpaper-engine-kde-plugin/plugin && \
+    rm -rf /tmp/kwin-system76-scheduler-integration && \
+    rm -rf /tmp/wallpaper-engine-kde-plugin \
+; else \
+    rpm-ostree override replace \
+    --experimental \
+    --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr \
+        mutter \
+        mutter-common \
+        gnome-control-center \
+        gnome-control-center-filesystem && \
+    rpm-ostree install \
+        gnome-shell-extension-tailscale-gnome-qs \
+        xwaylandvideobridge \
+        steamdeck-backgrounds \
+        gnome-randr-rust \
+        gnome-shell-extension-user-theme \
+        gnome-shell-extension-gsconnect \
+        nautilus-gsconnect \
+        gnome-shell-extension-system76-scheduler \
+        gnome-shell-extension-compiz-windows-effect \
+        gnome-shell-extension-just-perfection \
+        gnome-shell-extension-blur-my-shell \
+        gnome-shell-extension-hanabi \
+        gnome-shell-extension-gamerzilla \
+        rom-properties-gtk3 \
+        openssh-askpass && \
+    rpm-ostree override remove \
+        gnome-classic-session \
+        gnome-tour \
+        gnome-extensions-app \
+        gnome-initial-setup \
+; fi
+
+# Install gamescope-limiter patched Mesa
+rpm-ostree override replace \
+    --experimental \
+    --from repo=copr:copr.fedorainfracloud.org:kylegospo:bazzite-multilib \
+        mesa-filesystem \
+        mesa-dri-drivers \
+        mesa-libEGL \
+        mesa-libEGL-devel \
+        mesa-libgbm \
+        mesa-libGL \
+        mesa-libglapi \
+        mesa-vulkan-drivers
+
+# Install Gamescope, ROCM, and Waydroid on non-Nvidia images
+RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
+    rpm-ostree install \
+        gamescope.x86_64 \
+        gamescope.i686 \
+        rocm-hip \
+        rocm-opencl \
+        rocm-clinfo \
+        waydroid \
+        weston && \
+    sed -i~ -E 's/=.\$\(command -v (nft|ip6?tables-legacy).*/=/g' /usr/lib/waydroid/data/scripts/waydroid-net.sh && \
+    rm -f /usr/etc/modprobe.d/nvidia.conf \
+; else \
+    rm -f /usr/etc/modprobe.d/amdgpu.conf \
 ; fi
 
 # Cleanup & Finalize
@@ -379,26 +353,6 @@ RUN rpm-ostree install \
     /etc/akmods-rpms/steamdeck.rpm && \
     rm -rf /etc/akmods-rpms
 
-RUN if [[ "${FEDORA_MAJOR_VERSION}" -lt "39" ]]; then \
-        rpm-ostree override replace \
-            --experimental \
-            --from repo=copr:copr.fedorainfracloud.org:kylegospo:bazzite-multilib \
-                mesa-filesystem \
-                mesa-dri-drivers \
-                mesa-libEGL \
-                mesa-libEGL-devel \
-                mesa-libgbm \
-                mesa-libGL \
-                mesa-libglapi \
-                mesa-vulkan-drivers && \
-        rpm-ostree override replace \
-            --experimental \
-            --from repo=copr:copr.fedorainfracloud.org:kylegospo:bazzite \
-                udisks2 \
-                libudisks2 \
-                udisks2-btrfs \
-    ; fi
-
 # Configure KDE & GNOME
 RUN if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
     rpm-ostree override remove \
@@ -426,13 +380,6 @@ RUN rpm-ostree install \
     ds-inhibit \
     steam_notif_daemon \
     ryzenadj \
-    latencyflex-vulkan-layer \
-    vkBasalt.x86_64 \
-    vkBasalt.i686 \
-    mangohud.x86_64 \
-    mangohud.i686 \
-    obs-vkcapture.x86_64 \
-    obs-vkcapture.i686 \
     sdgyrodsu \
     sddm-sugar-steamOS \
     ibus-pinyin \
@@ -459,84 +406,18 @@ RUN rpm-ostree install \
     mv -vf /tmp/linux-firmware-neptune/* /usr/lib/firmware/cirrus/ && \
     rm -rf /tmp/linux-firmware-neptune && \
     wget $(jq -r '.assets[].browser_download_url | select(endswith("steam-patch"))' <<< $(curl -s 'https://api.github.com/repos/KyleGospo/steam-patch/releases' | jq -r "first(.[] | select(.prerelease == "false"))")) -O /usr/bin/steam-patch && \
-    chmod +x /usr/bin/steam-patch && \
-    if [[ "${FEDORA_MAJOR_VERSION}" -lt "39" ]]; then \
-        rpm-ostree install \
-           mesa-va-drivers \ 
-    ; fi
+    chmod +x /usr/bin/steam-patch
 
-# Install Steam and Lutris into their own OCI layer
+# Install Gamescope Session & Supporting changes
 # Add bootstraplinux_ubuntu12_32.tar.xz used by gamescope-session (Thanks ChimeraOS! - https://chimeraos.org/)
-RUN rpm-ostree install \
-        vulkan-loader.i686 \
-        alsa-lib.i686 \
-        fontconfig.i686 \
-        gtk2.i686 \
-        libICE.i686 \
-        libnsl.i686 \
-        libxcrypt-compat.i686 \
-        libpng12.i686 \
-        libXext.i686 \
-        libXinerama.i686 \
-        libXtst.i686 \
-        libXScrnSaver.i686 \
-        NetworkManager-libnm.i686 \
-        nss.i686 \
-        pulseaudio-libs.i686 \
-        libcurl.i686 \
-        systemd-libs.i686 \
-        libva.i686 \
-        libvdpau.i686 \
-        libdbusmenu-gtk3.i686 \
-        libatomic.i686 \
-        pipewire-alsa.i686 && \
-    if [[ "${FEDORA_MAJOR_VERSION}" -lt "39" ]]; then \
-        rpm-ostree install \
-            mesa-dri-drivers.i686 \
-            mesa-vulkan-drivers.i686 \
-            mesa-libGL.i686 \
-            mesa-libEGL.i686 \
-    ; fi && \
-    sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/rpmfusion-nonfree-steam.repo && \
-    sed -i '0,/enabled=1/s//enabled=0/' /etc/yum.repos.d/rpmfusion-nonfree.repo && \
-    sed -i '0,/enabled=1/s//enabled=0/' /etc/yum.repos.d/rpmfusion-nonfree-updates.repo && \
-    sed -i '0,/enabled=1/s//enabled=0/' /etc/yum.repos.d/fedora-updates.repo && \
-    rpm-ostree install \
-        steam && \
-    sed -i '0,/enabled=1/s//enabled=0/' /etc/yum.repos.d/rpmfusion-nonfree-steam.repo && \
-    sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/rpmfusion-nonfree.repo && \
-    sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/rpmfusion-nonfree-updates.repo && \
-    sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/fedora-updates.repo && \
-    wget https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steam-jupiter-stable-1.0.0.76-1-x86_64.pkg.tar.zst -O /tmp/steam-jupiter.pkg.tar.zst && \
+# Remove Feral gamemode, System76-Scheduler supersedes this
+RUN wget https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steam-jupiter-stable-1.0.0.76-1-x86_64.pkg.tar.zst -O /tmp/steam-jupiter.pkg.tar.zst && \
     mkdir -p /usr/etc/first-boot && \
     tar -I zstd -xvf /tmp/steam-jupiter.pkg.tar.zst usr/lib/steam/bootstraplinux_ubuntu12_32.tar.xz -O > /usr/etc/first-boot/bootstraplinux_ubuntu12_32.tar.xz && \
     rm -f /tmp/steam-jupiter.pkg.tar.zst && \
     rpm-ostree install \
-        lutris \
-        wxGTK \
-        libFAudio \
-        gamescope.x86_64 \
-        gamescope.i686 \
         gamescope-session-plus \
-        gamescope-session-steam \
-        wine-core.x86_64 \
-        wine-core.i686 \
-        wine-pulseaudio.x86_64 \
-        wine-pulseaudio.i686 \
-        winetricks \
-        protontricks \
-        gperftools-libs.i686 && \
-    ln -s /usr/bin/wine64 /usr/bin/wine && \
-    wget $(curl https://api.github.com/repos/ishitatsuyuki/LatencyFleX/releases/latest | jq -r '.assets[] | select(.name| test(".*.tar.xz$")).browser_download_url') -O /tmp/latencyflex.tar.xz && \
-    mkdir -p /tmp/latencyflex && \
-    tar --strip-components 1 -xvf /tmp/latencyflex.tar.xz -C /tmp/latencyflex && \
-    rm -f /tmp/latencyflex.tar.xz && \
-    cp -r /tmp/latencyflex/wine/usr/lib/wine/* /usr/lib64/wine/ && \
-    rm -rf /tmp/latencyflex && \
-    wget https://raw.githubusercontent.com/Shringe/LatencyFleX-Installer/main/install.sh -O /usr/bin/latencyflex && \
-    sed -i 's@/usr/lib/wine/@/usr/lib64/wine/@g' /usr/bin/latencyflex && \
-    sed -i 's@"dxvk.conf"@"/usr/share/latencyflex/dxvk.conf"@g' /usr/bin/latencyflex && \
-    chmod +x /usr/bin/latencyflex && \
+        gamescope-session-steam && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
         rpm-ostree override remove \
             gamemode \

--- a/Containerfile
+++ b/Containerfile
@@ -159,6 +159,8 @@ RUN rpm-ostree install \
         vkBasalt.i686 \
         mangohud.x86_64 \
         mangohud.i686 \
+        vk_hdr_layer.x86_64 \
+        vk_hdr_layer.i686 \
         gperftools-libs.i686 && \
     if [[ "${IMAGE_FLAVOR}" != "surface-nvidia" ]]; then \
         rpm-ostree install \

--- a/Containerfile
+++ b/Containerfile
@@ -263,6 +263,10 @@ RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \
 # Cleanup & Finalize
 COPY system_files/shared /
 RUN /tmp/image-info.sh && \
+    sed -i 's@/usr/bin/steam@/usr/bin/bazzite-steam@g' /usr/share/applications/steam.desktop && \
+    mkdir -p "/usr/etc/xdg/autostart" && \
+    cp "/usr/share/applications/steam.desktop" "/usr/etc/xdg/autostart/steam.desktop" && \
+    sed -i 's@/usr/bin/bazzite-steam %U@/usr/bin/bazzite-steam -silent %U@g' /usr/etc/xdg/autostart/steam.desktop && \
     rm /usr/share/applications/shredder.desktop && \
     rm /usr/share/vulkan/icd.d/lvp_icd.*.json && \
     mkdir -p "/usr/etc/profile.d/" && \
@@ -440,10 +444,6 @@ RUN /tmp/image-info.sh && \
     sed -i 's/870/817/' /usr/share/alsa/ucm2/AMD/acp5x/acp5x.conf && \
     sed -i 's/252/207/' /usr/share/alsa/ucm2/AMD/acp5x/acp5x.conf && \
     sed -i 's/192/207/' /usr/share/alsa/ucm2/AMD/acp5x/acp5x.conf && \
-    sed -i 's@/usr/bin/steam@/usr/bin/bazzite-steam@g' /usr/share/applications/steam.desktop && \
-    mkdir -p "/usr/etc/xdg/autostart" && \
-    cp "/usr/share/applications/steam.desktop" "/usr/etc/xdg/autostart/steam.desktop" && \
-    sed -i 's@/usr/bin/bazzite-steam %U@/usr/bin/bazzite-steam -silent %U@g' /usr/etc/xdg/autostart/steam.desktop && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
         sed -i 's/Exec=.*/Exec=systemctl start return-to-gamemode.service/' /etc/skel.d/Desktop/Return.desktop \
     ; fi && \

--- a/Containerfile
+++ b/Containerfile
@@ -231,7 +231,7 @@ RUN if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
 ; fi
 
 # Install gamescope-limiter patched Mesa
-rpm-ostree override replace \
+RUN rpm-ostree override replace \
     --experimental \
     --from repo=copr:copr.fedorainfracloud.org:kylegospo:bazzite-multilib \
         mesa-filesystem \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Bazzite is built from [ublue-os/main](https://github.com/ublue-os/main) and [ubl
 - Out of the box support for [Wooting](https://wooting.io/) keyboards.
 - Built in support for Southern Islands <sub><sup>(HD 7000)</sup></sub> and Sea Islands <sub><sup>(HD 8000)</sup></sub> AMD GPUs under the `amdgpu` driver.
 - A fix is available for [a 32-bit Source 1 engine game bug <sub><sup>(IE: TF2)</sup></sub>](https://github.com/ValveSoftware/Source-1-Games/issues/5043) that makes the game crash on launch - `ujust patch-source1-tcmalloc`
-- [XwaylandVideoBridge](https://invent.kde.org/system/xwaylandvideobridge) is available for Discord screensharing on Wayland. <sub><sup>(Only on KDE)</sup></sub>
+- [XwaylandVideoBridge](https://invent.kde.org/system/xwaylandvideobridge) is available for Discord screensharing on Wayland.
+
 ### Desktop
 
 Common variant available as `bazzite`, suitable for desktop computers.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 </p>
 
 [![build-bazzite](https://github.com/ublue-os/bazzite/actions/workflows/build.yml/badge.svg)](https://github.com/ublue-os/bazzite/actions/workflows/build.yml)
-[![build-bazzite-arch](https://github.com/ublue-os/bazzite-arch/actions/workflows/build.yml/badge.svg)](https://github.com/ublue-os/bazzite-arch/actions/workflows/build.yml)
 
 ---
 # Table of Contents
@@ -60,7 +59,6 @@ Bazzite is built from [ublue-os/main](https://github.com/ublue-os/main) and [ubl
 
 Common variant available as `bazzite`, suitable for desktop computers.
 
-- Runs Steam and Lutris in a [custom Arch Linux OCI](https://github.com/ublue-os/bazzite-arch/) via Distrobox. <sub><sup>(Except on Nvidia)</sup></sub>
 - Automatic updates for the OS, Flatpaks, Nix packages <sup><sub>(Via Fleek)</sub></sup>, and all Distrobox containers.
 
 > [!IMPORTANT]  

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Bazzite is built from [ublue-os/main](https://github.com/ublue-os/main) and [ubl
 - [Waydroid](https://waydro.id/) preinstalled for running Android apps. Future releases will offer to set this up for you through Bazzite Portal. <sub><sup>(Not available on Nvidia builds)</sup></sub>
 - Manage applications using [Flatseal](https://github.com/tchx84/Flatseal), [Warehouse](https://github.com/flattool/warehouse), and [Gear Lever](https://github.com/mijorus/gearlever).
 - [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB) i2c-piix4 and i2c-nct6775 drivers for controlling RGB on certain motherboards.
-- [OpenRazer](https://openrazer.github.io) drivers built in, Select OpenRazer in Bazzite Portal or run `just install-openrazer` in a terminal to begin using it.
-- [OpenTabletDriver](https://opentabletdriver.net/) udev rules built in, with the full software suite installable via Bazzite Portal or by running `just install-opentabletdriver` in a terminal.
+- [OpenRazer](https://openrazer.github.io) drivers built in, Select OpenRazer in Bazzite Portal or run `ujust install-openrazer` in a terminal to begin using it.
+- [OpenTabletDriver](https://opentabletdriver.net/) udev rules built in, with the full software suite installable via Bazzite Portal or by running `ujust install-opentabletdriver` in a terminal.
 - [GCAdapter_OC](https://github.com/hannesmann/gcadapter-oc-kmod) driver for overclocking Nintendo's Gamecube Controller Adapter to 1000hz polling.
 - Out of the box support for [Wooting](https://wooting.io/) keyboards.
 - Built in support for Southern Islands <sub><sup>(HD 7000)</sup></sub> and Sea Islands <sub><sup>(HD 8000)</sup></sub> AMD GPUs under the `amdgpu` driver.
-- A fix is available for [a TF2 bug](https://github.com/ValveSoftware/Source-1-Games/issues/5043) that makes the game crash on launch - `just patch-tf2-tcmalloc`
+- A fix is available for [a 32-bit Source 1 engine game bug <sub><sup>(IE: TF2)</sup></sub>](https://github.com/ValveSoftware/Source-1-Games/issues/5043) that makes the game crash on launch - `ujust patch-source1-tcmalloc`
 - [XwaylandVideoBridge](https://invent.kde.org/system/xwaylandvideobridge) is available for Discord screensharing on Wayland. <sub><sup>(Only on KDE)</sup></sub>
 ### Desktop
 
@@ -76,7 +76,7 @@ or for devices with Nvidia GPUs:
 rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-nvidia:latest
 ```
 
-**For users with Secure Boot enabled:** Run `just enroll-secure-boot-key` and enter the password `ublue-os` if prompted to enroll the required key.
+**For users with Secure Boot enabled:** Run `ujust enroll-secure-boot-key` and enter the password `ublue-os` if prompted to enroll the required key.
 
 ### Steam Deck/Home Theater PCs (HTPCs)
 > [!IMPORTANT]  
@@ -110,7 +110,7 @@ Variant designed for usage as an alternative to SteamOS on the Steam Deck, and f
     - Built in support for display overclocking. For example, add `GAMESCOPE_OVERRIDE_REFRESH_RATE=40,70` to `/etc/environment`.
     - Ability to enable Wayland on the desktop if desired by editing `/etc/default/desktop-wayland`.
     - 32GB RAM mod your Steam Deck? Enjoy double the maximum VRAM amount, automatically applied. <sup><sub>(Can you share your soldering skills?)</sub></sup>
-- Steam Deck hardware-specific services can be disabled by running `just disable-deck-services` in the terminal, useful for trying this image on other handhelds or for use on HTPCs.
+- Steam Deck hardware-specific services can be disabled by running `ujust disable-deck-services` in the terminal, useful for trying this image on other handhelds or for use on HTPCs.
 
 > [!WARNING]  
 > **Due to an upstream bug, Bazzite cannot be used on Steam Decks with 64GB eMMC storage at this time. Upgrading the storage resolves the issue.**
@@ -166,7 +166,7 @@ Bazzite started as a project to resolve some of the issues that plague SteamOS, 
 
 Despite this project also being image-based, you are able to install any Fedora package straight from the command line. These packages will persist across updates <sub><sup>(So go ahead and install that obscure VPN software you spent an hour trying to get working in SteamOS)</sup></sub>. Additionally, Bazzite is updated multiple times a week with packages from upstream Fedora, giving you the best possible performance and latest features - all on a stable base.
 
-Bazzite ships with the latest Linux kernel and SELinux enabled by default with full support for secure boot <sub><sup>(Run `just enroll-secure-boot-key` and enter the password `ublue-os` if prompted to enroll our key)</sup></sub> and disk encryption, making this a sensible solution for general computing. <sup><sub>(Yes, you can print from Bazzite)</sub></sup>
+Bazzite ships with the latest Linux kernel and SELinux enabled by default with full support for secure boot <sub><sup>(Run `ujust enroll-secure-boot-key` and enter the password `ublue-os` if prompted to enroll our key)</sup></sub> and disk encryption, making this a sensible solution for general computing. <sup><sub>(Yes, you can print from Bazzite)</sub></sup>
 
 Check out the [FAQ](https://universal-blue.org/images/bazzite/FAQ/) for other topics surrounding the project.
 

--- a/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
@@ -187,15 +187,8 @@ get-boilr:
 
 # Patch a bug in some 32-bit Source 1.x titles that causes them to crash at startup
 patch-source1-tcmalloc:
-  #!/usr/bin/env bash
-  IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-  IMAGE_FLAVOR=$(jq -r '."image-flavor"' < $IMAGE_INFO)
   echo 'Add the following as a launch option in Steam:'
-  if [[ ${IMAGE_FLAVOR} ~= 'nvidia' || ${IMAGE_FLAVOR} =~ "deck" || ${IMAGE_FLAVOR} =~ "ally" || ${IMAGE_FLAVOR} =~ "framegame" ]]; then
-    echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
-  else
-    echo 'LD_PRELOAD=/usr/lib32/libtcmalloc.so %command%'
-  fi
+  echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
   echo "Delete libtcmalloc_minimal.so.x in the game's bin folder if present."
 
 # Patch GMod's 64-bit beta to work properly on Linux (https://github.com/solsticegamestudios/GModCEFCodecFix)

--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
+IMAGE_NAME=$(jq -r '."image-name"' < $IMAGE_INFO)
 
 LAUNCH_OPTIONS=""
 
 # If Steam has been launched before we can safely launch with -steamdeck
 # to maintain the gamemode update branch
-if [ -f $HOME/.local/share/Steam/ubuntu12_32/steamui.so ]; then
-  LAUNCH_OPTIONS="-steamdeck"
+if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" || $IMAGE_NAME =~ "framegame" ]]; then
+  if [ -f $HOME/.local/share/Steam/ubuntu12_32/steamui.so ]; then
+    LAUNCH_OPTIONS="-steamdeck"
+  fi
 fi
 
 if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -137,6 +137,12 @@ if grep -qvz "bazzite-arch" <<< $(distrobox list); then
   if [[ -f "$HOME/.local/share/applications/bazzite-arch-steam.desktop" ]]; then
     distrobox stop bazzite-arch
     distrobox rm bazzite-arch --force
+    if [[ -f "$HOME/Desktop/bazzite-arch-steam.desktop" ]]; then
+      rm -f "$HOME/Desktop/bazzite-arch-steam.desktop"
+    fi
+    if [[ -f "$HOME/Desktop/bazzite-arch-net.lutris.Lutris.desktop" ]]; then
+      rm -f "$HOME/Desktop/bazzite-arch-net.lutris.Lutris.desktop"
+    fi
   fi
 fi
 

--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -7,7 +7,7 @@ FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 
 # SCRIPT VERSION
-USER_SETUP_VER=13
+USER_SETUP_VER=14
 USER_SETUP_VER_FILE="$HOME/.bazzite-configured"
 USER_SETUP_VER_RAN=$(cat $USER_SETUP_VER_FILE)
 USER_SETUP_FEDORA_VER_FILE="$HOME/.bazzite-configured-fedora-version"
@@ -128,6 +128,15 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" || $IMAGE_NAME =~ "framegam
   if [[ ! ":Jupiter:" =~ ":$SYS_ID:" ]]; then
     echo 'Enabling Steam-Patch'
     pkexec /usr/libexec/bazzite-enable-steam-patch "$USER"
+  fi
+fi
+
+# Previous images used Bazzite-Arch to run Steam on desktop images
+# If the exported bazzite-arch-steam file exists it's safe to assume this copy of bazzite-arch is no longer needed.
+if grep -qvz "bazzite-arch" <<< $(distrobox list); then
+  if [[ -f "$HOME/.local/share/applications/bazzite-arch-steam.desktop" ]]; then
+    distrobox stop bazzite-arch
+    distrobox rm bazzite-arch --force
   fi
 fi
 

--- a/system_files/desktop/shared/usr/bin/bazzite-user-setup
+++ b/system_files/desktop/shared/usr/bin/bazzite-user-setup
@@ -7,7 +7,7 @@ FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 
 # SCRIPT VERSION
-USER_SETUP_VER=12
+USER_SETUP_VER=13
 USER_SETUP_VER_FILE="$HOME/.bazzite-configured"
 USER_SETUP_VER_RAN=$(cat $USER_SETUP_VER_FILE)
 USER_SETUP_FEDORA_VER_FILE="$HOME/.bazzite-configured-fedora-version"
@@ -37,23 +37,19 @@ if [[ $BASE_IMAGE_NAME =~ "kinoite"  ]]; then
   echo 'Enabling System76-Scheduler KWin script'
   kwriteconfig5 --file kwinrc --group Plugins --key kwin-system76-scheduler-integrationEnabled true
 
-  if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" || $IMAGE_NAME =~ "framegame" ]]; then
-    echo 'Running setup for Kinoite on Steam Deck'
-
-    echo 'Creating Desktop shortcuts'
-    mkdir -p $HOME/Desktop/
-    if [[ ! -f "$HOME/Desktop/steam.desktop" ]]; then
-      cp /usr/share/applications/steam.desktop $HOME/Desktop/steam.desktop
-    fi
-    if [[ ! -f "$HOME/Desktop/Return.desktop" ]]; then
-      cp /etc/skel.d/Desktop/Return.desktop $HOME/Desktop/Return.desktop
-    fi
-    if [[ ! -f "$HOME/Desktop/net.lutris.Lutris.desktop" ]]; then
-      cp /usr/share/applications/net.lutris.Lutris.desktop $HOME/Desktop/net.lutris.Lutris.desktop
-    fi
-    if [[ ! -f "$HOME/Desktop/yafti.desktop" ]]; then
-      cp /usr/share/applications/yafti.desktop $HOME/Desktop/yafti.desktop
-    fi
+  echo 'Creating Desktop shortcuts'
+  mkdir -p $HOME/Desktop/
+  if [[ ! -f "$HOME/Desktop/steam.desktop" ]]; then
+    cp /usr/share/applications/steam.desktop $HOME/Desktop/steam.desktop
+  fi
+  if [[ ! -f "$HOME/Desktop/Return.desktop" ]]; then
+    cp /etc/skel.d/Desktop/Return.desktop $HOME/Desktop/Return.desktop
+  fi
+  if [[ ! -f "$HOME/Desktop/net.lutris.Lutris.desktop" ]]; then
+    cp /usr/share/applications/net.lutris.Lutris.desktop $HOME/Desktop/net.lutris.Lutris.desktop
+  fi
+  if [[ ! -f "$HOME/Desktop/yafti.desktop" ]]; then
+    cp /usr/share/applications/yafti.desktop $HOME/Desktop/yafti.desktop
   fi
 else
   echo 'Running setup for Silverblue'

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -10,20 +10,6 @@ screens:
       icon: "/usr/share/ublue-os/bazzite/logo.svg"
       description: |
         Configure your system to get started
-  configure-bazzite-arch:
-    source: yafti.screen.package
-    values:
-      title: Setting up Bazzite Arch (This can take a long time)
-      condition:
-        run: grep -qvz "bazzite-arch" <<< $(distrobox list) && grep -qv 'nvidia' <<< $(jq -r '."image-flavor"' < /usr/share/ublue-os/image-info.json)
-      show_terminal: true
-      package_manager: yafti.plugin.run
-      groups:
-        Install Bazzite Arch:
-          description: Sets up a custom Arch Linux OCI in Distrobox that Steam, Lutris, and other gaming workloads will be run inside of.
-          default: true
-          packages:
-          - Install Bazzite Arch: ujust install-bazzite-arch
   configure-bazzite:
     source: yafti.screen.package
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/30-distrobox.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/30-distrobox.just
@@ -41,47 +41,10 @@ install-obs-studio-portable:
   distrobox-enter -n obs-studio-portable -- 'bash -c "distrobox-export --app obs"' && \
   echo 'Install complete'
 
-# Set up Bazzite-Arch Distrobox container
-install-bazzite-arch:
-  IMAGE_INFO="/usr/share/ublue-os/image-info.json" && \
-  BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO) && \
-  if grep -qz "bazzite-arch" <<< $(distrobox list); then \
-    echo 'Removing existing Bazzite Arch install...' && \
-    distrobox rm bazzite-arch --force; \
-  fi && \
-  echo 'Installing Bazzite Arch...' && \
-  if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then \
-    distrobox-create --name bazzite-arch --image ghcr.io/ublue-os/bazzite-arch --unshare-netns --nvidia --yes; \
-  else \
-    distrobox-create --name bazzite-arch --image ghcr.io/ublue-os/bazzite-arch-gnome --unshare-netns --nvidia --yes; \
-  fi && \
-  echo 'Exporting applications...' && \
-  distrobox-enter -n bazzite-arch -- 'bash -c "sudo locale-gen && distrobox-export --app steam && distrobox-export --app lutris && distrobox-export --app protontricks && mkdir -p $HOME/.steam && distrobox-export --bin /usr/bin/steamcmd --export-path ~/.steam && mv $HOME/.steam/steamcmd $HOME/.steam/steamcmd.sh"' && \
-  echo 'Starting Steam...' && \
-  distrobox-enter -n bazzite-arch -- '  /usr/bin/steam-runtime --silent &>/dev/null &' && \
-  if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then \
-    echo 'Creating desktop shortcuts...' && \
-    cp ~/.local/share/applications/bazzite-arch-steam.desktop ~/Desktop/bazzite-arch-steam.desktop && \
-    sed -i 's@  (on bazzite-arch)@@g' ~/Desktop/bazzite-arch-steam.desktop && \
-    cp ~/.local/share/applications/bazzite-arch-net.lutris.Lutris.desktop ~/Desktop/bazzite-arch-net.lutris.Lutris.desktop && \
-    sed -i 's@  (on bazzite-arch)@@g' ~/Desktop/bazzite-arch-net.lutris.Lutris.desktop; \
-  fi && \
-  echo 'Finalizing...' && \
-  sleep 10 && \
-  rm -f ~/Desktop/steam.desktop
-
-# Remove container image for bazzite-arch and reinstall it
-reset-bazzite-arch:
-  IMAGE_INFO="/usr/share/ublue-os/image-info.json" && \
-  BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO) && \
-  distrobox stop bazzite-arch && \
-  distrobox rm bazzite-arch --force && \
-  if [[ ${BASE_IMAGE_NAME} == 'kinoite' ]]; then \
-    podman image rm bazzite-arch --force; \
-  else \
-    podman image rm bazzite-arch-gnome --force; \
-  fi && \
-  /usr/bin/ujust install-bazzite-arch
+# Set up Bazzite-Arch container
+distrobox-bazzite-arch:
+  echo 'Creating Bazzite-Arch distrobox ...'
+  distrobox-create --unshare-netns --nvidia --image ghcr.io/ublue-os/bazzite-arch -n bazzite-arch -Y
 
 # Install Webapp manager
 install-webapp-manager: distrobox-check-fedora

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -138,15 +138,8 @@ enable-supergfxctl:
 
 # Patch a bug in some 32-bit Source 1.x titles that causes them to crash at startup
 patch-source1-tcmalloc:
-  #!/usr/bin/env bash
-  IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-  IMAGE_FLAVOR=$(jq -r '."image-flavor"' < $IMAGE_INFO)
   echo 'Add the following as a launch option in Steam:'
-  if [[ ${IMAGE_FLAVOR} ~= 'nvidia' || ${IMAGE_FLAVOR} =~ "deck" || ${IMAGE_FLAVOR} =~ "ally" || ${IMAGE_FLAVOR} =~ "framegame" ]]; then
-    echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
-  else
-    echo 'LD_PRELOAD=/usr/lib32/libtcmalloc.so %command%'
-  fi
+  echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
   echo "Delete libtcmalloc_minimal.so.x in the game's bin folder if present."
 
 # Patch GMod's 64-bit beta to work properly on Linux (https://github.com/solsticegamestudios/GModCEFCodecFix)
@@ -160,11 +153,6 @@ patch-gmod:
   chmod +x /tmp/patch-gmod/GModCEFCodecFix-Linux
   /tmp/patch-gmod/GModCEFCodecFix-Linux
   rm -rf /tmp/patch-gmod
-
-# Fix an error that occurs after installing SteamVR in Bazzite-Arch
-patch-steam-vr:
-  #!/usr/bin/env bash
-  sudo setcap CAP_SYS_NICE+ep $HOME/.local/share/Steam/steamapps/common/SteamVR/bin/linux64/vrcompositor-launcher
 
 # Activate Valve-inspired Vapor theme on GNOME
 enable-vapor-theme:


### PR DESCRIPTION
Drops the `bazzite-arch` pattern in favor of all images having steam layered into them. A lot has changed since our 1.0 release and while bazzite-arch has it's place, I think this makes more sense for the majority of our users now.

Additionally opens us up to supporting HDR via gamescope and vk_hdr_layer on desktop images.

Note that we will continue to maintain bazzite-arch as it continues to be a useful tool for numerous other distros, and can still be optionally used on bazzite if desired - IE: Mesa git, AMDGPU-Pro. 