### PR TITLE
chore: Use direct paths to bluez rpms due to rpm-ostree issue

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -242,7 +242,12 @@ RUN rpm-ostree override replace \
         mesa-libGL \
         mesa-libglapi \
         mesa-vulkan-drivers \
-        mesa-libOSMesa
+        mesa-libOSMesa \
+        https://download.copr.fedorainfracloud.org/results/kylegospo/bazzite-multilib/fedora-39-x86_64/06620403-bluez/bluez-5.70-1.fc39.bazzite.0.0.git.1708.6d2818cf.x86_64.rpm \
+        https://download.copr.fedorainfracloud.org/results/kylegospo/bazzite-multilib/fedora-39-x86_64/06620403-bluez/bluez-cups-5.70-1.fc39.bazzite.0.0.git.1708.6d2818cf.x86_64.rpm \
+        https://download.copr.fedorainfracloud.org/results/kylegospo/bazzite-multilib/fedora-39-x86_64/06620403-bluez/bluez-libs-5.70-1.fc39.bazzite.0.0.git.1708.6d2818cf.x86_64.rpm \
+        https://download.copr.fedorainfracloud.org/results/kylegospo/bazzite-multilib/fedora-39-x86_64/06620403-bluez/bluez-obexd-5.70-1.fc39.bazzite.0.0.git.1708.6d2818cf.x86_64.rpm \
+        https://download.copr.fedorainfracloud.org/results/kylegospo/bazzite-multilib/fedora-39-i386/06620403-bluez/bluez-libs-5.70-1.fc39.bazzite.0.0.git.1708.6d2818cf.i686.rpm
 
 # Install Gamescope, ROCM, and Waydroid on non-Nvidia images
 RUN if grep -qv "nvidia" <<< "${IMAGE_NAME}"; then \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
