### PR TITLE
feat: Added an easy way for users to use `distrobox-git` and revert back as well

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
@@ -66,6 +66,16 @@ install-openrazer:
   sudo usermod -a -G plugdev $USER && \
   echo "Please reboot to apply needed changes."
 
+# Upgrade Distrobox to the latest git version
+distrobox-git:
+  echo 'Installing latest git snapshot of Distrobox...'
+  curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
+
+# Downgrades Distrobox to the Fedora version
+remove-distrobox-git:
+  echo 'Uninstalling latest git snapshot of Distrobox...'
+  curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/uninstall | sh -s -- --prefix ~/.local
+
 # Install Nix with the Determinate Nix Installer
 install-nix:
   #!/usr/bin/env bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -219,6 +219,16 @@ install-adwaita-for-steam:
     echo "This is only supported under GNOME."
   fi
 
+# Upgrade Distrobox to the latest git version
+distrobox-git:
+  echo 'Installing latest git snapshot of Distrobox...'
+  curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
+
+# Downgrades Distrobox to the Fedora version
+remove-distrobox-git:
+  echo 'Uninstalling latest git snapshot of Distrobox...'
+  curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/uninstall | sh -s -- --prefix ~/.local
+
 # Set system to boot without showing the grub screen with options
 hide-grub:
   #!/usr/bin/env bash


### PR DESCRIPTION
got this one from Bluefin

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
