### PR TITLE
fix(autologin/return-to-gamemode): Don't assume path to home directory

### DIFF
--- a/system_files/deck/shared/usr/bin/bazzite-autologin
+++ b/system_files/deck/shared/usr/bin/bazzite-autologin
@@ -6,6 +6,7 @@ IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
 
 USER=$(id -nu 1000)
+HOME=$(getent passwd $USER | cut -d: -f6)
 
 # SteamOS SDDM config
 SDDM_CONF='/etc/sddm.conf.d/steamos.conf'
@@ -18,7 +19,7 @@ if [[ -f ${AUTOLOGIN_CONF} ]]; then
 fi
 
 # Configure autologin if Steam has been updated
-if [[ ! -f ${DESKTOP_AUTOLOGIN} && -f /var/home/$USER/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
+if [[ ! -f ${DESKTOP_AUTOLOGIN} && -f $HOME/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
   sed -i 's/.*Session=.*/Session=gamescope-session.desktop/g' ${SDDM_CONF}
 elif [[ ${BASE_IMAGE_NAME} =~ "kinoite" ]]; then
   if ${DESKTOP_WAYLAND}; then

--- a/system_files/deck/shared/usr/bin/return-to-gamemode
+++ b/system_files/deck/shared/usr/bin/return-to-gamemode
@@ -4,12 +4,13 @@ IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
 
 USER=$(id -nu 1000)
+HOME=$(getent passwd $USER | cut -d: -f6)
 
 # SteamOS autologin SDDM config
 AUTOLOGIN_CONF='/etc/sddm.conf.d/zz-steamos-autologin.conf'
 
 # Configure autologin if Steam has been updated
-if [[ -f /var/home/$USER/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
+if [[ -f $HOME/.local/share/Steam/ubuntu12_32/steamui.so ]]; then
   {
     echo "[Autologin]"
     echo "Session=gamescope-session.desktop"


### PR DESCRIPTION
In cases where the home directory path differs from the user name, it isn't enough to use a hard path that assumes the user's username is in it.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
