### PR TITLE
feat: Preinstall GOverlay

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -163,6 +163,7 @@ RUN rpm-ostree install \
         vk_hdr_layer.x86_64 \
         vk_hdr_layer.i686 \
         gperftools-libs.i686 && \
+        goverlay \
     if [[ ! "${IMAGE_FLAVOR}" =~ "surface" ]]; then \
         rpm-ostree install \
             obs-vkcapture.x86_64 \


### PR DESCRIPTION
GOverlay (https://github.com/benjamimgois/goverlay)

It's a nice GUI for MangoHud, vkBasalt, and ReplaySorcery though.  In my testing in layering it to Bazzite, it complains MangoHud is missing, but it worked in my testing so I'm not sure why it does that. 
**EDIT:** Known issue in the latest stable.

It could also be placed in the Bazzite Portal as well instead of being preinstalled, and I can make a new PR for that.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
