### PR TITLE
chore: Remove documentation link in Bazzite Portal

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -259,9 +259,7 @@ screens:
       links:
       - "Install More Applications":
           run: /usr/bin/plasma-discover
-      - "Documentation":
-          run: /usr/bin/xdg-open https://universal-blue.discourse.group/docs?category=5
-      - "Forums":
+      - "Forums & Documentation":
           run: /usr/bin/xdg-open https://universal-blue.discourse.group/c/bazzite/5
       - "Join the Discord Community":
           run: /usr/bin/xdg-open https://discord.gg/XjG48C7VHx

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -234,9 +234,7 @@ screens:
       links:
       - "Install More Applications":
           run: /usr/bin/plasma-discover
-      - "Documentation":
-          run: /usr/bin/xdg-open https://universal-blue.discourse.group/docs?category=5
-      - "Forums":
+      - "Forums & Documentation":
           run: /usr/bin/xdg-open https://universal-blue.discourse.group/c/bazzite/5
       - "Join the Discord Community":
           run: /usr/bin/xdg-open https://discord.gg/XjG48C7VHx


### PR DESCRIPTION
The Forums already contain the documentation.  The user no longer has to scroll down to click the button that reboots their device.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
