### PR TITLE
feat: Enable libvirtd service if virt-manager layered

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -203,11 +203,19 @@ add-user-to-input-group:
 
 # Enable Virtualization and add workaround for a specific windows VM crash
 enable-virtualization:
-    echo "Installing QEMU and virt-manager..."
-    rpm-ostree install virt-manager edk2-ovmf qemu
-    rpm-ostree kargs \
-    --append-if-missing="kvm.ignore_msrs=1" \
-    --append-if-missing="kvm.report_ignored_msrs=0"
+    virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
+    if [[ -z ${virt_test} ]]; then
+      echo "Installing QEMU and virt-manager..."
+      rpm-ostree install virt-manager edk2-ovmf qemu
+      rpm-ostree kargs \
+      --append-if-missing="kvm.ignore_msrs=1" \
+      --append-if-missing="kvm.report_ignored_msrs=0"
+      echo 'Please re-run "ujust enable-virtualization" after the reboot to finish setup'
+    else
+      echo "Enabling libvirtd service"
+      sudo systemctl enable --now libvirtd
+      echo "libvirtd enabled! If virt-manager says libvirtd.sock is not available after a big update, re-run this command."
+    fi
 
 # Enable VFIO on the system if virtualization is enabled
 enable-vfio:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -225,8 +225,8 @@ enable-vfio:
     CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
     VENDOR_KARG="unset"
     if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
-        echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
-        sudo touch /etc/bazzite/initramfs/rebuild
+      echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
+      sudo touch /etc/bazzite/initramfs/rebuild
       if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
         VENDOR_KARG="amd_iommu=on"
       elif [[ ${CPU_VENDOR} == "GenuineIntel" ]]; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -203,6 +203,7 @@ add-user-to-input-group:
 
 # Enable Virtualization and add workaround for a specific windows VM crash
 enable-virtualization:
+    #!/usr/bin/env bash
     virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
     if [[ -z ${virt_test} ]]; then
       echo "Installing QEMU and virt-manager..."


### PR DESCRIPTION
`ujust enable-virtualization` will now tell the user to re-run the command after reboot to enable the libvirtd service.

the script now runs `rpm-ostree status | grep -A 4 "●" | grep "virt-manager"` to check if virt-manager is layered in the currently booted image and will run `sudo systemctl enable --now libvirtd` if virt-manager is layered.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
