### PR TITLE
fix(just): Fixed source1 patch 60-custom.just

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/60-custom.just
@@ -125,6 +125,7 @@ get-boilr:
 
 # Patch a bug in some 32-bit Source 1.x titles that causes them to crash at startup
 patch-source1-tcmalloc:
+    #!/usr/bin/env bash
     echo 'Add the following as a launch option in Steam:'
     echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
     echo "Delete libtcmalloc_minimal.so.x in the game's bin folder if present."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -80,6 +80,7 @@ enable-supergfxctl:
 
 # Patch a bug in some 32-bit Source 1.x titles that causes them to crash at startup
 patch-source1-tcmalloc:
+    #!/usr/bin/env bash
     echo 'Add the following as a launch option in Steam:'
     echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
     echo "Delete libtcmalloc_minimal.so.x in the game's bin folder if present."


### PR DESCRIPTION
The output of `ujust patch-source1-tcmalloc` gave this

```
echo 'Add the following as a launch option in Steam:'
Add the following as a launch option in Steam:
echo 'LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%'
LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%
echo "Delete libtcmalloc_minimal.so.x in the game's bin folder if present."
Delete libtcmalloc_minimal.so.x in the game's bin folder if present.
```

This should remove the echo part of the output so it just prints the message cleanly like this


```
Add the following as a launch option in Steam:
LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4 %command%
Delete libtcmalloc_minimal.so.x in the game's bin folder if present.
```

