### PR TITLE
chore: move 10-looking-glass.conf into just

### DIFF
--- a/system_files/desktop/shared/usr/etc/tmpfiles.d/10-looking-glass.conf
+++ b/system_files/desktop/shared/usr/etc/tmpfiles.d/10-looking-glass.conf
@@ -1,2 +1,0 @@
-# Type Path               Mode UID  GID Age Argument
-f /dev/shm/looking-glass 0660 1000 qemu -

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -329,11 +329,10 @@ install-opentabletdriver:
 
 # Add SELinux file context for default looking-glass shm file so that libvirt can create it when needed
 selinux-looking-glass:
-    cat << 'LOOKING_GLASS_TMP' > /tmp/10-looking-glass.conf
+    sudo tee << 'LOOKING_GLASS_TMP' > /etc/tmpfiles.d/10-looking-glass.conf
     # Type Path               Mode UID  GID Age Argument
     f /dev/shm/looking-glass 0660 1000 qemu -
     LOOKING_GLASS_TMP
-    sudo mv /tmp/10-looking-glass.conf /etc/tmpfiles.d/
     sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass
 
 # Add virtual audio channels/sinks named Game, Voice, Browser and Music which you can split audio to using qpwgraph, helvum, carla or other pipewire patchbays for use in OBS and other use cases

--- a/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/60-custom.just
@@ -329,6 +329,11 @@ install-opentabletdriver:
 
 # Add SELinux file context for default looking-glass shm file so that libvirt can create it when needed
 selinux-looking-glass:
+    cat << 'LOOKING_GLASS_TMP' > /tmp/10-looking-glass.conf
+    # Type Path               Mode UID  GID Age Argument
+    f /dev/shm/looking-glass 0660 1000 qemu -
+    LOOKING_GLASS_TMP
+    sudo mv /tmp/10-looking-glass.conf /etc/tmpfiles.d/
     sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass
 
 # Add virtual audio channels/sinks named Game, Voice, Browser and Music which you can split audio to using qpwgraph, helvum, carla or other pipewire patchbays for use in OBS and other use cases


### PR DESCRIPTION
Jilong on discord pointed out that the 10-looking-glass.conf file in /etc/tmpfiles.d will generate harmless but annoying log entries whenever qemu is not installed on the system.
This pull request moves the file into the selinux-looking-glass just recipe to avoid generating useless log entries about the lack of a qemu user.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
