### PR TITLE
feat(gnome): Enable num-lock by default

### DIFF
--- a/system_files/desktop/silverblue/usr/etc/dconf/db/local.d/02-bazzite-global
+++ b/system_files/desktop/silverblue/usr/etc/dconf/db/local.d/02-bazzite-global
@@ -4,6 +4,9 @@ switch-applications-backward = ['<Shift><Super>Tab']
 switch-windows = ['<Alt>Tab']
 switch-windows-backward = ['<Shift><Alt>Tab']
 
+[org/gnome/desktop/peripherals/keyboard]
+numlock-state=true
+
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true
 


### PR DESCRIPTION
It's a no-brainer to have this enabled out-of-the-box imo.

If someone knows how to apply this to KDE, let me know. I just learned that KDE doesn't have dconf equivalent.