### PR TITLE
fix(ci): build Release ISO condition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
     name: Generate and Release ISOs
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.releases_created
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     container:
       image: fedora:39
       options: --privileged


### PR DESCRIPTION
Boolean output becomes a `string`, so needs to be checked against string value.
This should fix the :x: invalid merges to `main`.