### PR TITLE
chore(readme): Added "Misc. Doc" and Ublue Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Read the [FAQ](https://universal-blue.discourse.group/docs?topic=33) for details
 - [Updates, Rollbacks, and Rebasing](https://universal-blue.discourse.group/docs?topic=36)
 - [Gaming Guide](https://universal-blue.discourse.group/docs?topic=31)
 - [Dual Booting Guide](https://universal-blue.discourse.group/t/dual-booting-guide/129)
+- [Miscellaneous Documentation](https://universal-blue.discourse.group/t/bazzite-miscellaneous-documentation/287)
 
 Find additional documentation surrounding the project [here](https://universal-blue.discourse.group/docs).
 
@@ -312,4 +313,6 @@ We also ship a config for the popular [pull app](https://github.com/apps/pull) i
 
 ## Join The Community
 
-You can find us on the [Universal Blue Discord](https://discord.gg/f8MUghG5PB) and also discuss Bazzite on our [Discourse forums](https://universal-blue.discourse.group/c/bazzite/5).
+You can find us on the [Universal Blue Discord](https://discord.gg/f8MUghG5PB) and also discuss Bazzite on our [Discourse forums](https://universal-blue.discourse.group/c/bazzite/5).  
+
+Follow Universal Blue on [Mastodon](https://fosstodon.org/@UniversalBlue).


### PR DESCRIPTION
I consolidated the other Bazzite documentation into 1 page so that most of the documentation is now linked in the README. 

For now, it's called "Miscellaneous Documentation" for lack of a better term right now.  It's a little disorganized and lengthy, so I might fix that eventually.

I also added a link to Universal Blue's [Mastodon account](https://fosstodon.org/@UniversalBlue) so that reinforces to the general public that this is a Universal Blue image even more.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
