### PR TITLE
feat: Package and ship xwiimote-ng

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -160,6 +160,7 @@ RUN rpm-ostree install \
         vulkan-tools \
         glibc.i686 \
         extest.i686 \
+        xwiimote-ng \
         twitter-twemoji-fonts \
         google-noto-sans-cjk-fonts \
         lato-fonts \

--- a/spec_files/xwiimote-ng/xwiimote-ng.spec
+++ b/spec_files/xwiimote-ng/xwiimote-ng.spec
@@ -1,0 +1,50 @@
+Name:          xwiimote-ng
+Summary:       An open-source device driver for Nintendo Wii / Wii U remotes.
+
+Version:       3.0.1
+Release:       1%{?dist}
+
+License:       XWiimote License
+URL:           https://github.com/dev-0x7C6/xwiimote-ng
+Source:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+ExclusiveArch: x86_64
+
+BuildRequires: cmake
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: systemd-devel
+
+Requires:      ncurses
+Requires:      systemd-udev
+
+%description
+An open-source device driver for Nintendo Wii / Wii U remotes.
+
+%prep
+%autosetup -p1 -n %{name}-%{version}
+
+%build
+%cmake -DCMAKE_INSTALL_PREFIX=/usr -B . .
+%make_build
+
+%install
+mkdir -p %{buildroot}%{_libdir}
+mkdir -p %{buildroot}%{_includedir}
+mkdir -p %{buildroot}%{_datadir}/pkgconfig
+install -D -m 755 lib%{name}.so.3.0.1 %{buildroot}%{_libdir}/lib%{name}.so.3.0.1
+install -D -m 755 lib%{name}.so.3 %{buildroot}%{_libdir}/lib%{name}.so.3
+install -D -m 755 lib%{name}.so %{buildroot}%{_libdir}/lib%{name}.so
+install -D -m 755 lib/%{name}.h %{buildroot}%{_includedir}/%{name}.h
+install -D -m 755 lib%{name}.pc %{buildroot}%{_datadir}/pkgconfig/lib%{name}.pc
+
+%files
+%license LICENSE
+%{_libdir}/lib%{name}.so.3.0.1
+%{_libdir}/lib%{name}.so.3
+%{_libdir}/lib%{name}.so
+%{_includedir}/%{name}.h
+%{_datadir}/pkgconfig/lib%{name}.pc
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Extends hid-wiimote, providing tools and libraries that support the Wii Remote as well as the Wii Balance Board, Wii U Pro Controller, and other accessories.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
