### PR TITLE
fix(rtl8814au/rtl88xxau): package rtl8814au instead of rtl88xxau driver

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -93,7 +93,7 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
         /tmp/akmods-rpms/kmods/*ayn-platform*.rpm \
         /tmp/akmods-rpms/kmods/*bmi260*.rpm \
         /tmp/akmods-rpms/kmods/*bmi323*.rpm \
-        /tmp/akmods-rpms/kmods/*rtl88xxau*.rpm \
+        /tmp/akmods-rpms/kmods/*rtl8814au*.rpm \
         /tmp/akmods-rpms/kmods/*ryzen-smu*.rpm && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

closes #718 

This PR just adds the more stable rtl8814au driver back into the bazzite build instead of the unstable rtl88xxau driver. While this is removing driver capability for RTL8812AU/21AU cards, the driver has shown some instability with those as well. I'll take a look and see if there are some better options for those cards that we can include, for now if anyone needs them, there are old images, or it is easy to simply include both and install a modprobe blacklist which can be updated by the user.
