### PR TITLE
fix: added glibc-headers and glibc-devel to override list

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -174,6 +174,12 @@ RUN rpm-ostree override replace \
         || true && \
     rpm-ostree override replace \
     --experimental \
+    --from repo=updates-archive \
+        glibc-headers \
+        glibc-devel \
+        || true && \
+    rpm-ostree override replace \
+    --experimental \
     --from repo=updates \
         glibc \
         glibc-common \


### PR DESCRIPTION
This is to fix build issues I found this morning where glibc-headers and glibc-devel have dependency conflicts. I found this issue in my custom image which shares most of Bazzite’s Containerfile (minus a few things: https://github.com/noelmiller/isengard/actions/runs/7739690630/job/21103077663#step:6:1425)