### PR TITLE
chore: Fix Misc. Documentation link from cutting off in the terminal

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/motd/tips/20-bazzite.md
+++ b/system_files/desktop/shared/usr/share/ublue-os/motd/tips/20-bazzite.md
@@ -8,5 +8,5 @@ Discover Overlay is preinstalled, allowing Discord to overlay your games during 
 Bazzite uses ZSTD compression in BTRFS by default, and deduplicates files across your entire drive. **More space for your games!**
 *Have a large library of ROMs to manage?* ROM Properties Page shell extension is installed by default and makes it much easier, with thumbnails and additional info for all of your files.
 *Need more control over your Flatpaks?* Check out the Warehouse and Flatseal applications to manage them.
-*Want more tips and tricks?* - [View the Miscellaneous Documentation](https://universal-blue.discourse.group/docs?topic=287)
+*Want more tips and tricks?* - [View Documentation](https://universal-blue.discourse.group/docs?topic=287)
 *Desktop users:  Want a to easily customize MangoHud and vkBasalt?* Use the GOverlay application as a graphical user interface to adjust settings.


### PR DESCRIPTION
This shortens the link so it doesn't get cut off in Prompt on KDE (and maybe GNOME)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
