### PR TITLE
chore(ci): fix possible empty version meta on image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,13 +183,19 @@ jobs:
 
       - name: Get Current Fedora Version
         id: labels
+        shell: bash
         run: |
+          set -eo pipefail
           if [[ "${{ matrix.base_name }}" == "bazzite-nvidia" ]]; then
               ver=$(skopeo inspect docker://ghcr.io/ublue-os/bazzite-${{ env.IMAGE_FLAVOR }}:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
           elif [[ "${{ env.IMAGE_FLAVOR}}" == "main" ]]; then
               ver=$(skopeo inspect docker://ghcr.io/ublue-os/${{ matrix.base_image_name }}:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
           else
               ver=$(skopeo inspect docker://ghcr.io/ublue-os/${{ matrix.base_image_name }}-${{ env.IMAGE_FLAVOR }}:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
+          fi
+          if [ -z "$ver" ] || [ "null" = "$ver" ]; then
+            echo "inspected image version must not be empty or null"
+            exit 1
           fi
           echo "VERSION=$ver" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This ensures that when inspecting upstream image, if an error occurs, or the resulting value is empty or 'null', we fail our build instead of propegating a bogus version downstream.

Relates: https://github.com/ublue-os/main/issues/487