### PR TITLE
feat(gamescope): add env var for 720p patch

### DIFF
--- a/spec_files/gamescope/add_720p_var.patch
+++ b/spec_files/gamescope/add_720p_var.patch
@@ -1,0 +1,24 @@
+From dab64a97b336c13c4d48a14550b72508f98cc1d4 Mon Sep 17 00:00:00 2001
+From: Sterophonick <sterophonick@gmail.com>
+Date: Wed, 17 Jan 2024 12:00:44 -0700
+Subject: [PATCH] steamcompmgr: add env var to enable/disable 720p restriction
+
+---
+ src/steamcompmgr.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index e50265c..22e9345 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -5822,7 +5822,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
+ 			int width = xwayland_mode_ctl[ 1 ];
+ 			int height = xwayland_mode_ctl[ 2 ];
+
+-			if ( g_nOutputWidth != 1280 && width == 1280 )
++			if ( ( g_nOutputWidth != 1280 && width == 1280 ) && !getenv("GAMESCOPE_ENABLE_720P_RESTRICT") )
+ 			{
+ 				width = g_nOutputWidth;
+ 				height = g_nOutputHeight;
+--
+2.43.0

--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -12,6 +12,7 @@ URL:            https://github.com/ValveSoftware/gamescope
 Source1:        stb.pc
 Source2:        chimeraos.patch
 Source3:        crashfix.patch
+Source4:        add_720p_var.patch
 
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build
@@ -76,6 +77,7 @@ mkdir -p pkgconfig
 cp %{SOURCE1} pkgconfig/stb.pc
 patch -Np1 < %{SOURCE2}
 patch -Np1 < %{SOURCE3}
+patch -Np1 < %{SOURCE4}
 
 %build
 cd gamescope


### PR DESCRIPTION
This patch allows for an environment variable, `GAMESCOPE_ENABLE_720P_RESTRICT`, to be set to re-renable the 720p restriction that Steam sets, ideal for setups such as mine on Steam Deck that have scripts to auto-adjust game config files based on what's visible to `XWAYLAND1`, also for games like DOOM Eternal where setting `+r_mode -2` forces the resolution to the highest available. Disabled by default, can be set in `/etc/environment`.