### PR TITLE
fix: make gamescope 720p patch use env_to_bool to allow user binary s…

### DIFF
--- a/spec_files/gamescope/add_720p_var.patch
+++ b/spec_files/gamescope/add_720p_var.patch
@@ -1,24 +1,35 @@
-From dab64a97b336c13c4d48a14550b72508f98cc1d4 Mon Sep 17 00:00:00 2001
+From 19c6635d5e20dd429cb23b4a7c728afa306fae0a Mon Sep 17 00:00:00 2001
 From: Sterophonick <sterophonick@gmail.com>
-Date: Wed, 17 Jan 2024 12:00:44 -0700
+Date: Sat, 10 Feb 2024 22:00:36 -0700
 Subject: [PATCH] steamcompmgr: add env var to enable/disable 720p restriction
 
 ---
- src/steamcompmgr.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/steamcompmgr.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index e50265c..22e9345 100644
+index 00c00e9..795898c 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
-@@ -5822,7 +5822,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
+@@ -137,6 +137,9 @@ extern float g_flInternalDisplayBrightnessNits;
+ extern float g_flHDRItmSdrNits;
+ extern float g_flHDRItmTargetNits;
+
++// define env_to_bool to point to the function in drm: remove in later patches pl0x
++extern bool env_to_bool(const char *env);
++
+ uint64_t g_lastWinSeq = 0;
+
+ static std::shared_ptr<wlserver_ctm> s_scRGB709To2020Matrix;
+@@ -5657,7 +5660,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
  			int width = xwayland_mode_ctl[ 1 ];
  			int height = xwayland_mode_ctl[ 2 ];
 
 -			if ( g_nOutputWidth != 1280 && width == 1280 )
-+			if ( ( g_nOutputWidth != 1280 && width == 1280 ) && !getenv("GAMESCOPE_ENABLE_720P_RESTRICT") )
++			if ( g_nOutputWidth != 1280 && width == 1280 && !env_to_bool( getenv("GAMESCOPE_ENABLE_720P_RESTRICT") ) )
  			{
  				width = g_nOutputWidth;
  				height = g_nOutputHeight;
 --
 2.43.0
+


### PR DESCRIPTION
adds a `env_to_bool` to allow for binary settings when using the variable. allows for script in Kyle's fork of `gamescope-session` to work as intended