### PR TITLE
chore: update initramfs args example with link to documentation

### DIFF
--- a/system_files/desktop/shared/etc/bazzite/initramfs/args.d/00-example.conf
+++ b/system_files/desktop/shared/etc/bazzite/initramfs/args.d/00-example.conf
@@ -7,6 +7,12 @@
 # config files for dracut into /etc/dracut.conf.d/ and trigger an initramfs
 # rebuild using "sudo touch /etc/bazzite/initramfs/rebuild" which
 # will rebuild the initramfs on next boot using bazzite-hardware-setup.
+# Documentation: https://universal-blue.discourse.group/docs?topic=399
+#
+# NOTE: If you need to add files to initramfs (like modprobe files),
+# please add them to a .conf file in /etc/dracut.conf.d/
+# with the line (spaces before and after paths are important!)
+# install_items+=" /path/to/file1 /path/to/file2 "
 #
 # Multiline Example:
 #--arg="--add-drivers"


### PR DESCRIPTION
Update the initramfs args example with link to documentation and information about using dracut conf files for including files in initramfs due to rpm-ostree limitation of only allowing the `--arg="-I /path/to/file"` argument only once.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
