### PR TITLE
fix(waydroid): fix waydroid-launcher script

### DIFF
--- a/system_files/desktop/shared/usr/bin/waydroid-launcher
+++ b/system_files/desktop/shared/usr/bin/waydroid-launcher
@@ -15,7 +15,7 @@ fi
 # Launch Cage & Waydroid
 pkexec /usr/libexec/waydroid-container-start
 if [ -z "$(pgrep wlr-randr)" ]; then
-	cage -- bash -c "wlr-randr --output X11-1 --custom-mode ${WAYDROID_WIDTH:-1280}x${WAYDROID_HEIGHT:-800}; sleep 1; waydroid show-full-ui &> /dev/null &"
+	cage -- bash -c "wlr-randr --output X11-1 --custom-mode ${WAYDROID_WIDTH:-1280}x${WAYDROID_HEIGHT:-800}; sleep 1; waydroid show-full-ui &> /dev/null &" &
 fi
 
 # Fix controllers, we know Waydroid has started because surfaceflinger is running


### PR DESCRIPTION
Currently the waydroid-launcher script never actually runs the `waydroid-fix-controllers` script while waydroid is running, only after waydroid is closed does it run