### PR TITLE
feat(waydroid): add automount of shared waydroid directory to waydroid-launcher

### DIFF
--- a/system_files/desktop/shared/usr/bin/waydroid-launcher
+++ b/system_files/desktop/shared/usr/bin/waydroid-launcher
@@ -25,6 +25,11 @@ done
 sleep 10
 pkexec /usr/libexec/waydroid-fix-controllers
 
+mkdir -p /var/home/$USER/WaydroidShare
+
+# mount must happen after container is already running
+pkexec /usr/libexec/waydroid-mount-shared-folder $USER
+
 # Waydroid is now live!
 # Wait for exit and then clean up
 while [ -n "$(pgrep cage)" ]; do
@@ -32,3 +37,5 @@ while [ -n "$(pgrep cage)" ]; do
 done
 
 pkexec /usr/libexec/waydroid-container-stop
+
+pkexec /usr/libexec/waydroid-unmount-shared-folder $USER

--- a/system_files/desktop/shared/usr/libexec/waydroid-mount-shared-folder
+++ b/system_files/desktop/shared/usr/libexec/waydroid-mount-shared-folder
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+WAYDROID_USER=$1
+WAYDROID_SHARE_PATH=/var/home/$WAYDROID_USER/.local/share/waydroid/data/media/0/WaydroidShare
+
+sudo mkdir -p $WAYDROID_SHARE_PATH
+
+sudo mount --bind /var/home/$WAYDROID_USER/WaydroidShare $WAYDROID_SHARE_PATH

--- a/system_files/desktop/shared/usr/libexec/waydroid-unmount-shared-folder
+++ b/system_files/desktop/shared/usr/libexec/waydroid-unmount-shared-folder
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+WAYDROID_USER=$1
+
+sudo umount /var/home/$WAYDROID_USER/.local/share/waydroid/data/media/0/WaydroidShare

--- a/system_files/desktop/shared/usr/share/polkit-1/actions/org.bazzite.waydroid.policy
+++ b/system_files/desktop/shared/usr/share/polkit-1/actions/org.bazzite.waydroid.policy
@@ -38,4 +38,26 @@
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/waydroid-fix-controllers</annotate>
   </action>
+
+  <action id="org.bazzite.policykit.waydroid.mount.shared.folder">
+    <description>Mount Shared Folder in Waydroid</description>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/waydroid-mount-shared-folder</annotate>
+  </action>
+
+  <action id="org.bazzite.policykit.waydroid.unmount.shared.folder">
+    <description>Unmount Shared Folder in Waydroid</description>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/waydroid-unmount-shared-folder</annotate>
+  </action>
 </policyconfig>


### PR DESCRIPTION
Updates waydroid-launcher to create a `WaydroidShare` folder in the home directory and mounts it in waydroid.

This lets you share files directly  with waydroid without copying over the entire file.

Note that waydroid itself will see the shared folder as read-only, it will not be able to write to the directory.

waydroid documentation for setting up a shared folder:

https://docs.waydro.id/faq/setting-up-a-shared-folder