### PR TITLE
fix(deck): Correct rotation for Lenovo p14s gen2 in the deck image

### DIFF
--- a/system_files/desktop/shared/usr/libexec/hardware/rotation-fix-hardware
+++ b/system_files/desktop/shared/usr/libexec/hardware/rotation-fix-hardware
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Returns true for hardware that needs a rotation fix in KDE
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
-if [[ ":ROG Ally RC71L_RC71L:ROG Ally RC71L:83E1:Loki Max:G1618-04:" =~ ":$SYS_ID:" ]]; then
+if [[ ":ROG Ally RC71L_RC71L:ROG Ally RC71L:83E1:Loki Max:G1618-04:21A0007TUK:" =~ ":$SYS_ID:" ]]; then
 	exit 0
 else
 	exit 1


### PR DESCRIPTION
For some reason the desktop gets rotated to the right on this laptop when on the deck image, this laptop has a landscape display and does not match any of our checks. Meaning it gets rotated by valve by accident?
This will correct it back to normal rotation.

reported by Crush in discord.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
