### PR TITLE
feat(gnome): Add File Roller Archive Manager

### DIFF
--- a/system_files/desktop/silverblue/usr/share/ublue-os/bazzite/flatpak/install
+++ b/system_files/desktop/silverblue/usr/share/ublue-os/bazzite/flatpak/install
@@ -12,6 +12,7 @@ org.gnome.Calendar
 org.gnome.Characters
 org.gnome.Contacts
 org.gnome.Evince
+org.gnome.FileRoller
 org.gnome.Logs
 org.gnome.Loupe
 org.gnome.Maps


### PR DESCRIPTION
 [File Roller](https://wiki.gnome.org/Apps/FileRoller) would give to feature parity with KDE images because KDE ships [Ark](https://apps.kde.org/ark/).

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
