### PR TITLE
fix: mangohud config folder typo

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager
+++ b/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager
@@ -62,7 +62,7 @@ flatpak override \
 
 # Allow MangoHUD config for Flatpaks
 flatpak override \
-  --filesystem=xdg-config/Mangohud:ro \
+  --filesystem=xdg-config/MangoHud:ro \
   --filesystem=xdg-config/vkBasalt:ro
 
 # Fix permissions for XIV Launcher


### PR DESCRIPTION
Mangohud flatpak did not load my config. I found the override here:
https://github.com/ublue-os/bazzite/blob/5e18df5aa69dd5d45a17281124cb348b66b8aaec/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager#L65

I thinks that's a typo because it should be `MangoHud` with a captital "H" and this should fix it. When I change it manually my MangoHud config is working again.