### PR TITLE
Add rclone to the bazzite image for mounting cloud storage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -243,6 +243,7 @@ RUN rpm-ostree install \
         rmlint \
         compsize \
         input-remapper \
+        rclone \
         system76-scheduler \
         tuned \
         tuned-ppd \


### PR DESCRIPTION
This will allow users to mount storage, for instance:

rcloud mount onedrive:/ /mnt/OneDrive

This does not work in distrobox or docker as you can't do a FUSE mount from within a container.