### PR TITLE
feat(just): add option to add user to libvirt group

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -23,6 +23,7 @@ setup-virtualization ACTION="":
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'enable' to select Enable Virtualization"
       echo "  Use 'disable' to select Disable Virtualization"
+      echo "  Use 'group' to select Add $USER to libvirt group"
       echo "  Use 'vfio-on' to select Enable VFIO drivers"
       echo "  Use 'vfio-off' to select Disable VFIO drivers"
       echo "  Use 'shm' to select Autocreate Looking-Glass shm"
@@ -31,7 +32,14 @@ setup-virtualization ACTION="":
       echo "${bold}Virtualization Setup${normal}"
       echo "NOTE: Enabling Virtualization will layer virt-manager and qemu"
       echo "      this will slow down system updates by a lot."
-      OPTION=$(Choose "Enable Virtualization" "Disable Virtualization" "Enable VFIO drivers" "Disable VFIO drivers" "Autocreate Looking-Glass shm")
+      OPTION=$(Choose \
+        "Enable Virtualization" \
+        "Disable Virtualization" \
+        "Add $USER to libvirt group" \
+        "Enable VFIO drivers" \
+        "Disable VFIO drivers" \
+        "Autocreate Looking-Glass shm" \
+      )
     fi
     if [[ "${OPTION,,}" =~ ^enable[[:space:]]virt ]]; then
       virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
@@ -121,4 +129,6 @@ setup-virtualization ACTION="":
       LOOKING_GLASS_TMP"
       echo "Adding SELinux context record for /dev/shm/looking-glass"
       sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass
+    elif [[ "${OPTION,,}" =~ group ]]; then
+      sudo usermod -aG libvirt $USER
     fi


### PR DESCRIPTION
Added the option to add the user to the libvirt group so they do not have to provide the sudo password to use virt-manager

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
