### PR TITLE
feat(deck): add tdpfix for cards that has 15W TDP on boot due to writable sysfs on boot

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -762,6 +762,7 @@ RUN /tmp/image-info.sh && \
     systemctl enable cec-onboot.service && \
     systemctl enable cec-onpoweroff.service && \
     systemctl enable cec-onsleep.service && \
+    systemctl enable bazzite-tdpfix.service && \
     systemctl --global enable steam-web-debug-portforward.service && \
     systemctl --global disable sdgyrodsu.service && \
     systemctl disable input-remapper.service && \

--- a/spec_files/jupiter-hw-support/priv-write.patch
+++ b/spec_files/jupiter-hw-support/priv-write.patch
@@ -12,7 +12,7 @@ index e307823..45946ed 100755
  if [[ $EUID -ne 0 ]];
  then
      exec pkexec --disable-internal-agent "$0" "$@"
-@@ -12,21 +15,21 @@ WRITE_VALUE="$2"
+@@ -12,21 +15,21 @@
  
  function CommitWrite()
  {
@@ -37,12 +37,12 @@ index e307823..45946ed 100755
      exit 1
  }
  
-@@ -40,15 +43,35 @@ if [[ "$WRITE_PATH" == /dev/drm_dp_aux0 ]]; then
+@@ -40,15 +43,35 @@
  fi
  
  if [[ "$WRITE_PATH" == /sys/class/drm/card*/device/power_dpm_force_performance_level ]]; then
 -   CommitWrite
-+   if [[ /usr/libexec/hardware/valve-hardware || "$ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE" = 1 ]]; then
++   if /usr/libexec/hardware/valve-hardware || [[ "$ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE" = 1 ]]; then
 +      for i in $(ls /sys/class/drm/card*/device/power_dpm_force_performance_level)
 +      do
 +         WRITE_PATH="$i"
@@ -55,7 +55,7 @@ index e307823..45946ed 100755
  
  if [[ "$WRITE_PATH" == /sys/class/drm/card*/device/pp_od_clk_voltage ]]; then
 -   CommitWrite
-+   if [[ /usr/libexec/hardware/valve-hardware || "$ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE" = 1 ]]; then
++   if /usr/libexec/hardware/valve-hardware || [[ "$ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE" = 1 ]]; then
 +      for i in $(ls /sys/class/drm/card*/device/pp_od_clk_voltage)
 +      do
 +         WRITE_PATH="$i"
@@ -68,7 +68,7 @@ index e307823..45946ed 100755
  
  if [[ "$WRITE_PATH" == /sys/class/hwmon/hwmon*/power*_cap ]]; then
 -   CommitWrite
-+   if [[ /usr/libexec/hardware/valve-hardware || "$ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE" = 1 ]]; then
++   if /usr/libexec/hardware/valve-hardware || [[ "$ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE" = 1 ]]; then
 +      CommitWrite
 +   else
 +      echo "commit: Skipped $WRITE_VALUE -> $WRITE_PATH - see /etc/default/steam-hardware-control" | systemd-cat -t p-steamos-priv-write -p warning

--- a/system_files/deck/shared/usr/lib/systemd/system/bazzite-tdpfix.service
+++ b/system_files/deck/shared/usr/lib/systemd/system/bazzite-tdpfix.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Resets power1_cap permissions to 644 if it is 666 at boot
+After=multi-user.target rc-local.service systemd-user-sessions.service
+Wants=modprobe@amdgpu.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/bazzite-tdpfix
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/deck/shared/usr/libexec/bazzite-tdpfix
+++ b/system_files/deck/shared/usr/libexec/bazzite-tdpfix
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+# This is a workaround for cards that somehow has their sysfs power1_cap permission set to 666 on boot
+# Which in turn makes steam directly set the TDP to 15W
+POWER_CAP_PATH=$(find /sys/class/hwmon/*/ -name "power1_cap")
+
+# If the permissions are set to writable
+if [ "$(stat -c %a "$POWER_CAP_PATH")" == "666" ]; then
+    chmod 644 "$POWER_CAP_PATH"
+    echo "fix: Permissions reset to 644 on $POWER_CAP_PATH" | systemd-cat -t bazzite-tdpfix -p warning
+fi
+
+# If TDP is 15W and default TDP is higher than 45W, set card to use default TDP
+# This will then be handled by firmware or software afterwards as this is set once
+if [ "$(cat "$POWER_CAP_PATH")" == "15000000" ] && [ "$(cat "${POWER_CAP_PATH}_default")" -gt "45000000" ]; then
+    "$(cat "${POWER_CAP_PATH}_default")" > "$POWER_CAP_PATH"
+    echo "fix: TDP reset to default on $POWER_CAP_PATH" | systemd-cat -t bazzite-tdpfix -p warning
+fi


### PR DESCRIPTION
We do not know what causes a super small subset of GPUs to boot with sysfs writable on the deck images, but this will at least set the permissions back to 644 and reset the TDP at boot if it was messed with by gamescope-session and steam.

DNM before d3Xt3r tests and verifies that this works in `testing` as they have a system affected by this issue
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
