### PR TITLE
feat(just): add warning message for looking-glass shm creation.

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -136,6 +136,16 @@ setup-virtualization ACTION="":
         echo "IOMMU is not supported on Steam Deck"
         exit 0
       fi
+      echo "Bazzite currently uses a deprecated implementation of the Looking Glass shm."
+      echo "This implementation will not be supported in the future and we are in the process"
+      echo "of moving over to the KVMFR kernel module."
+      echo "Until this is done please open any Looking Glass issues you have in Bazzite"
+      echo "in the $(Urllink "https://discord.bazzite.gg/" "Bazzite Discord") or the $(Urllink "https://github.com/ublue-os/bazzite/issues" "Bazzite Github issue tracker")"
+      echo "~ @HikariKnight"
+      CONFIRM=$(Choose Ok Cancel)
+      if [ "$CONFIRM" == "Cancel" ]; then
+        exit 0
+      fi
       echo "Creating tmpfile definition for shm file in /etc/tmpfiles.d/"
       sudo bash -c "tee << LOOKING_GLASS_TMP > /etc/tmpfiles.d/10-looking-glass.conf
       # Type Path               Mode UID  GID Age Argument


### PR DESCRIPTION
Until we move over to the KVMFR kernel module which gnif has confirmed is not picky with which version of Looking Glass the user is using , this warning message should be shown.
Once we have the kernel module included, we will change the option to add the config based on
https://looking-glass.io/docs/B7-rc1/ivshmem_kvmfr/

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
