### PR TITLE
chore: Remove dual boot documentation in MOTD

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/motd/tips/10-ublue.md
+++ b/system_files/desktop/shared/usr/share/ublue-os/motd/tips/10-ublue.md
@@ -2,7 +2,6 @@ It is **always** better to install packages with Distrobox rather than layer the
 Packages installed in Distrobox can be exported to appear like any other application~[View documentation](https://distrobox.it/usage/distrobox-export/)
 *Update break something?* You can roll back and pin the previous release or rebase by build date~[View our guide](https://universal-blue.discourse.group/docs?topic=36)
 *This isn't a distro*, this is a custom image built on  Fedora Atomic Desktop technology~[View our mission](https://ublue.it/mission/)
-*Looking to dual-boot with  Windows?*~[View dual booting guide](https://universal-blue.discourse.group/docs?topic=129)
 **Support the app store!**~[Donate to  Flatpak](https://opencollective.com/flatpak)
 **Support indie game preservation and OSS developers!**~[Join Hit Save!'s Patreon](https://patreon.com/hitsave)
 **H.264 hardware acceleration is supported out of the box.** No tweaks necessary!


### PR DESCRIPTION
I plan to merge the dual boot documentation with the installation guide and re-arrange some of it especially since handheld usage is becoming increasingly popular.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
