### PR TITLE
chore(ci): test main branch to fix extra boot params

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -111,7 +111,7 @@ jobs:
           docker rmi ${image}
 
       - name: Build ISOs
-        uses: jasonn3/build-container-installer@v1.1.1
+        uses: jasonn3/build-container-installer@main
         id: build
         with:
           arch: x86_64


### PR DESCRIPTION
This will test using the main branch to fix extra boot params issue when building ISO. I will ask Jason to do a release once I have tested this change in cosmic, bazzite, and bluefin.