### PR TITLE
chore: Add patch for Ayn Loki refresh rates in gamescope

### DIFF
--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -15,6 +15,7 @@ Source3:        crashfix.patch
 Source4:        add_720p_var.patch
 Source5:        touch_gestures_env.patch
 Source6:        legion_go.patch
+Source7:	loki.patch
 
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build
@@ -82,6 +83,7 @@ patch -Np1 < %{SOURCE3}
 patch -Np1 < %{SOURCE4}
 patch -Np1 < %{SOURCE5}
 patch -Np1 < %{SOURCE6}
+patch -Np1 < %{SOURCE7}
 
 %build
 cd gamescope

--- a/spec_files/gamescope/loki.patch
+++ b/spec_files/gamescope/loki.patch
@@ -1,0 +1,27 @@
+diff --git a/src/drm.cpp b/src/drm.cpp
+index 745965c..9f8315e 100644
+--- a/src/drm.cpp
++++ b/src/drm.cpp
+@@ -107,6 +107,13 @@ static uint32_t legion_go_display_rates[] =
+ 	144,
+ };
+ 
++static uint32_t loki_display_rates[] =
++{
++	40,
++	50,
++	60,
++};
++
+ static uint32_t get_conn_display_info_flags(struct drm_t *drm, struct connector *connector)
+ {
+ 	if (!connector)
+@@ -921,6 +928,8 @@ static void parse_edid( drm_t *drm, struct connector *conn)
+ 			conn->valid_display_rates = std::span(steam_deck_display_rates);
+ 		} else if ( strcmp(conn->make_pnp, "LEN") == 0 && strcmp(conn->model, "Go Display") == 0 ) {
+ 			conn->valid_display_rates = std::span(legion_go_display_rates);
++		} else if ( strcmp(conn->make_pnp, "AYN") == 0 && strcmp(conn->model, "LK-GOLDSPV58") == 0 ) {
++			conn->valid_display_rates = std::span(loki_display_rates);
+ 		}
+ 	}
+ 


### PR DESCRIPTION
This needs gamescope-session-plus edit in device-quirks to works, removing the panel being forced as external

If not it does nothing, so no harm done.