### PR TITLE
chore(ci): install using apt since no longer using a container

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -163,7 +163,8 @@ jobs:
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           SOURCE_DIR: ${{ steps.upload-directory.outputs.iso-upload-dir }}
         run: |
-          dnf install -y rclone
+          sudo apt-get update
+          sudo apt-get install -y rclone
           rclone copy $SOURCE_DIR R2:bazzite
 
       - name: Upload ISOs to archive.org


### PR DESCRIPTION
was an oversight when updating action
