### PR TITLE
Mini Pro rotation fix.  Same as Loki max and AIR

### DIFF
--- a/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
+++ b/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
@@ -38,7 +38,7 @@ fi
 echo $(date '+%Y-%m-%d %H:%M:%S') Fixing desktop orientation... | tee -a /tmp/bazrotfix.log
 if [[ ! -z "$IS_GAMEMODE" ]]; then
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log
-elif [[ ":83E1:Loki Max:AIR Plus:Loki MiniPro" =~ ":$SYS_ID:" ]]; then
+elif [[ ":83E1:Loki Max:AIR Plus:Loki MiniPro:" =~ ":$SYS_ID:" ]]; then
 	kscreen-doctor output.1.rotation.left 2>&1 | tee -a /tmp/bazrotfix.log
 else
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log

--- a/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
+++ b/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
@@ -38,7 +38,7 @@ fi
 echo $(date '+%Y-%m-%d %H:%M:%S') Fixing desktop orientation... | tee -a /tmp/bazrotfix.log
 if [[ ! -z "$IS_GAMEMODE" ]]; then
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log
-elif [[ ":83E1:Loki Max:AIR Plus:" =~ ":$SYS_ID:" ]]; then
+elif [[ ":83E1:Loki Max:AIR Plus:Loki MiniPro" =~ ":$SYS_ID:" ]]; then
 	kscreen-doctor output.1.rotation.left 2>&1 | tee -a /tmp/bazrotfix.log
 else
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log


### PR DESCRIPTION

![this one](https://github.com/ublue-os/bazzite/assets/121328689/506497fc-1f1d-4118-bf22-aec0187b4be4)


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
