### PR TITLE
fix(gamescope): add 3.13.16.9 splitgate crash fix

### DIFF
--- a/spec_files/gamescope/3.13.16.9-splitgate.patch
+++ b/spec_files/gamescope/3.13.16.9-splitgate.patch
@@ -1,0 +1,56 @@
+From 1345e658091848195ace5f94b8662deb49236a6b Mon Sep 17 00:00:00 2001
+From: Joshua Ashton <joshua@froggi.es>
+Date: Tue, 9 Apr 2024 23:46:35 +0100
+Subject: [PATCH 1/2] wlserver: use unordered_map for content_overrides
+
+---
+ src/wlserver.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/wlserver.hpp b/src/wlserver.hpp
+index 852a5a1..6854ebf 100644
+--- a/src/wlserver.hpp
++++ b/src/wlserver.hpp
+@@ -84,7 +84,7 @@ private:
+ 
+ 	struct wlr_output *output;
+ 
+-	std::map<uint32_t, wlserver_content_override *> content_overrides;
++	std::unordered_map<uint32_t, wlserver_content_override *> content_overrides;
+ 
+ 	bool xwayland_ready = false;
+ 	_XDisplay *dpy = NULL;
+-- 
+2.44.0
+
+From c59b09dbc0c100f604ae603c5f0026c42c62d49c Mon Sep 17 00:00:00 2001
+From: Joshua Ashton <joshua@froggi.es>
+Date: Wed, 10 Apr 2024 00:04:06 +0100
+Subject: [PATCH 2/2] wlserver: Clear x11_surface when content override is
+ destroyed
+
+---
+ src/wlserver.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/wlserver.cpp b/src/wlserver.cpp
+index 3fbc4ff..42d20e9 100644
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -532,6 +532,13 @@ static struct wl_listener new_surface_listener = { .notify = wlserver_new_surfac
+ 
+ void gamescope_xwayland_server_t::destroy_content_override( struct wlserver_content_override *co )
+ {
++	if ( co->surface )
++	{
++		wlserver_wl_surface_info *wl_surface_info = get_wl_surface_info( co->surface );
++		if ( wl_surface_info )
++			wl_surface_info->x11_surface = nullptr;
++	}
++
+ 	wl_list_remove( &co->surface_destroy_listener.link );
+ 	content_overrides.erase( co->x11_window );
+ 	free( co );
+-- 
+2.44.0
+

--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -17,6 +17,7 @@ Source5:        touch_gestures_env.patch
 Source6:        legion_go.patch
 Source7:	    loki.patch
 Source8:        0001-disable-steam-touch-click-atom.patch
+Source9:        3.13.16.9-splitgate.patch
 
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build
@@ -86,6 +87,7 @@ patch -Np1 < %{SOURCE5}
 patch -Np1 < %{SOURCE6}
 patch -Np1 < %{SOURCE7}
 patch -Np1 < %{SOURCE8}
+patch -Np1 < %{SOURCE9}
 
 %build
 cd gamescope


### PR DESCRIPTION
the 3.13.16.9 upstream gamescope tag contains a fix for Splitgate crash on exit. add these commits as a patch so that it doesn't do that and we're all happy again.
