### PR TITLE
chore: Revert "Mini Pro rotation fix.  Same as Loki max and AIR"

### DIFF
--- a/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
+++ b/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
@@ -38,7 +38,7 @@ fi
 echo $(date '+%Y-%m-%d %H:%M:%S') Fixing desktop orientation... | tee -a /tmp/bazrotfix.log
 if [[ ! -z "$IS_GAMEMODE" ]]; then
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log
-elif [[ ":83E1:Loki Max:AIR Plus:Loki MiniPro:" =~ ":$SYS_ID:" ]]; then
+elif [[ ":83E1:Loki Max:AIR Plus:" =~ ":$SYS_ID:" ]]; then
 	kscreen-doctor output.1.rotation.left 2>&1 | tee -a /tmp/bazrotfix.log
 else
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log


### PR DESCRIPTION
Reverts ublue-os/bazzite#962

Didn't seem to work in the `:testing` channel for one user.   Lower priority anyways as the handheld has no internal audio functioning. 