### PR TITLE
fix(ds-inhibit): autoload hid-playstation to avoid hook conflicts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -252,8 +252,7 @@ RUN rpm-ostree override remove \
         pipewire-jack-audio-connection-kit-libs \
         pipewire-libs \
         pipewire-pulseaudio \
-        pipewire-utils \
-        xorg-x11-server-Xwayland && \
+        pipewire-utils && \
     rpm-ostree install \
         mesa-va-drivers-freeworld \
         mesa-vdpau-drivers-freeworld.x86_64 && \

--- a/Containerfile
+++ b/Containerfile
@@ -279,7 +279,6 @@ RUN rpm-ostree override remove \
 
 # Install new packages
 RUN rpm-ostree install \
-        clevis-dracut \
         discover-overlay \
         python3-pip \
         libadwaita \

--- a/spec_files/ds-inhibit/10-modprobe-ds.conf
+++ b/spec_files/ds-inhibit/10-modprobe-ds.conf
@@ -1,0 +1,2 @@
+# autoload hid-playstation so ds-inhibit works correctly
+hid-playstation

--- a/spec_files/ds-inhibit/ds-inhibit.spec
+++ b/spec_files/ds-inhibit/ds-inhibit.spec
@@ -5,7 +5,8 @@ Summary:        DualShock 4/DualSense mouse inhibitor
 License:        BSD-2-Clause
 URL:            https://github.com/ublue-os/bazzite
 
-Source:         https://gitlab.com/evlaV/%{name}/-/archive/main/%{name}-main.tar.gz
+Source0:         https://gitlab.com/evlaV/%{name}/-/archive/main/%{name}-main.tar.gz
+Source1:        10-modprobe-ds.conf
 BuildArch:      noarch
 
 Patch0:         fedora.patch
@@ -31,8 +32,10 @@ chmod +x ds_inhibit.py
 %install
 mkdir -p %{buildroot}%{_bindir}/
 mkdir -p %{buildroot}%{_unitdir}/
+mkdir -p %{buildroot}%{_sysconfdir}/modules-load.d
 cp -v ds_inhibit.py %{buildroot}%{_bindir}/ds-inhibit
 cp -v systemd.service %{buildroot}%{_unitdir}/ds-inhibit.service
+cp %{SOURCE1} %{buildroot}%{_sysconfdir}/modules-load.d
 
 # Do post-installation
 %post
@@ -52,6 +55,7 @@ cp -v systemd.service %{buildroot}%{_unitdir}/ds-inhibit.service
 %license LICENSE
 %{_bindir}/ds-inhibit
 %{_unitdir}/ds-inhibit.service
+%{_sysconfdir}/modules-load.d/10-modprobe-ds.conf
 
 # Finally, changes from the latest release of your application are generated from
 # your project's Git history. It will be empty until you make first annotated Git tag.

--- a/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
+++ b/system_files/deck/kinoite/usr/libexec/bazzite-rotation-fix
@@ -36,7 +36,7 @@ if /usr/libexec/hardware/valve-hardware; then
 	kscreen-doctor output.1.scale.1.00 2>&1 | tee -a /tmp/bazrotfix.log
 elif [[ ! -z "$IS_GAMEMODE" ]]; then
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log
-elif [[ ":83E1:Loki Max:AIR Plus:" =~ ":$SYS_ID:" ]]; then
+elif [[ ":83E1:Loki Max:AIR Plus:SLIDE:" =~ ":$SYS_ID:" ]]; then
 	kscreen-doctor output.1.rotation.left 2>&1 | tee -a /tmp/bazrotfix.log
 else
 	kscreen-doctor output.1.rotation.normal 2>&1 | tee -a /tmp/bazrotfix.log

--- a/system_files/desktop/shared/usr/lib/dracut/dracut.conf.d/90-ublue.conf
+++ b/system_files/desktop/shared/usr/lib/dracut/dracut.conf.d/90-ublue.conf
@@ -1,1 +1,1 @@
-add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc clevis "
+add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc "

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -17,6 +17,19 @@ restore-original-terminal:
         echo "Done. Change your default Terminal in System Settings to complete the swap."
     fi
 
+# Install System Flatpaks (Support for Rebasing)
+_install-system-flatpaks:
+    #!/usr/bin/bash
+    IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+    BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
+    if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
+        FLATPAKS="gnome_flatpaks/flatpaks"
+    else
+        FLATPAKS="kde_flatpaks/flatpaks"
+    fi
+    FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/bazzite/main/scripts/${FLATPAKS} | tr '\n' ' ')"
+    flatpak --system -y install ${FLATPAK_LIST}
+
 # Install Bazzite's Steam Game Mode Startup Video
 install-gamemode-video:
     mkdir -p $HOME/.local/share/Steam/config/uioverrides/movies

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -20,8 +20,8 @@ setup-virtualization ACTION="":
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust configure-grub <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
-      echo "  Use 'enable' to select Enable Virtualization"
-      echo "  Use 'disable' to select Disable Virtualization"
+      echo "  Use 'virt-on' to select Enable Virtualization"
+      echo "  Use 'virt-off' to select Disable Virtualization"
       echo "  Use 'group' to select Add $USER to libvirt group"
       echo "  Use 'vfio-on' to select Enable VFIO drivers"
       echo "  Use 'vfio-off' to select Disable VFIO drivers"
@@ -40,7 +40,7 @@ setup-virtualization ACTION="":
         "Autocreate Looking-Glass shm" \
       )
     fi
-    if [[ "${OPTION,,}" =~ ^enable(|[[:space:]]virtualization) ]]; then
+    if [[ "${OPTION,,}" =~ (^enable[[:space:]]virtualization|virt-on) ]]; then
       virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
       if [[ -z ${virt_test} ]]; then
         echo "Installing QEMU and virt-manager..."
@@ -50,7 +50,7 @@ setup-virtualization ACTION="":
         --append-if-missing="kvm.report_ignored_msrs=0"
         echo 'Please re-run "ujust setup-virtualization" after the reboot to enable libvirtd service'
       fi
-    elif [[ "${OPTION,,}" =~ ^disable(|[[:space:]]virtualization) ]]; then
+    elif [[ "${OPTION,,}" =~ (^disable[[:space:]]virtualization|virt-off) ]]; then
       virt_test=$(rpm-ostree status | grep -A 4 "●" | grep "virt-manager")
       if [[ ${virt_test} ]]; then
         if [ "$(systemctl is-enabled libvirtd.service)" == "enabled" ]; then
@@ -76,7 +76,7 @@ setup-virtualization ACTION="":
       VENDOR_KARG="unset"
       if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
         echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
-        sudo touch /etc/bazzite/initramfs/rebuild
+        rpm-ostree initramfs --enable
         if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
           VENDOR_KARG="amd_iommu=on"
         elif [[ ${CPU_VENDOR} == "GenuineIntel" ]]; then
@@ -118,8 +118,7 @@ setup-virtualization ACTION="":
         fi
         echo "Removing dracut modules"
         sudo rm /etc/dracut.conf.d/vfio.conf
-        echo "Issuing initramfs rebuild for next boot"
-        sudo touch /etc/bazzite/initramfs/rebuild
+        rpm-ostree initramfs --enable
         rpm-ostree kargs \
         --delete-if-present="iommu=pt" \
         --delete-if-present="iommu=on" \
@@ -147,10 +146,10 @@ setup-virtualization ACTION="":
         exit 0
       fi
       echo "Creating tmpfile definition for shm file in /etc/tmpfiles.d/"
-      sudo bash -c "tee << LOOKING_GLASS_TMP > /etc/tmpfiles.d/10-looking-glass.conf
-      # Type Path               Mode UID  GID Age Argument
-      f /dev/shm/looking-glass 0660 1000 qemu -
-      LOOKING_GLASS_TMP"
+      sudo bash -c "cat << LOOKING_GLASS_TMP > /etc/tmpfiles.d/10-looking-glass.conf
+    # Type Path               Mode UID  GID Age Argument
+    f /dev/shm/looking-glass 0660 1000 qemu -
+    LOOKING_GLASS_TMP"
       echo "Adding SELinux context record for /dev/shm/looking-glass"
       sudo semanage fcontext -a -t svirt_tmpfs_t /dev/shm/looking-glass
     elif [[ "${OPTION,,}" =~ group ]]; then


### PR DESCRIPTION
ds-inhibit on upstream has issues with the first connect of PlayStation controllers, where the touchpads are not hooked correctly and therefore don't correctly interact with steam input. work around by using `modules-load.d` to autoload `hid-playstation` on boot.