### PR TITLE
fix(ci): extract digest output from retry action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,7 +277,8 @@ jobs:
           containers: ${{ env.IMAGE_NAME }}
           registry-token: ${{ secrets.GITHUB_TOKEN }}
           signing-secret: ${{ secrets.SIGNING_SECRET }}
-          tags: ${{ steps.push.outputs.digest }}
+          tags: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
+
 
       - name: Echo outputs
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
fix use of cosign-action/sign breaking due to wrapping the push step in a retry action