### PR TITLE
feat: Enable Web UI for ISO Installer

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -128,6 +128,7 @@ jobs:
           flatpak_remote_refs_dir: ${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}
           enable_flatpak_dependencies: "false"
           extra_boot_params: ${{ steps.generate-extra-params.outputs.extra-boot-params }}
+          web_ui: "true"
 
       - name: Move ISOs to Upload Directory
         id: upload-directory
@@ -140,7 +141,7 @@ jobs:
           echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
 
       - name: Upload ISOs and Checksum to Job Artifacts
-        if: github.ref_name == 'testing'
+        #if: github.ref_name == 'testing'
         #if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Upon testing the web UI, it fixes the scaling issues on the Steam Deck  LCD. Rotation can be resolved in OLED if we can get a kernel patch into Fedora. 

**Current Blockers for using the Web UI:** 

- [ ] Kickstart Post Scripts currently do not run after installation
- [ ] Issues with how disks are managed (if we can hide advanced partitioning options, this would allow us to get around this)
