### PR TITLE
fix(kde): Remove `QT_IM_MODULE` and `GTK_IM_MODULE` for IBus in wayland

### DIFF
--- a/spec_files/steamdeck-kde-presets/steamdeck-kde-presets.spec
+++ b/spec_files/steamdeck-kde-presets/steamdeck-kde-presets.spec
@@ -15,6 +15,7 @@ Patch0:         fedora.patch
 Patch1:         kdeglobals.patch
 Patch2:         bazzite_logo.patch
 Patch3:         ublue.patch
+Patch4:         wayland-remove-env.patch
 
 Requires:       kde-filesystem
 

--- a/spec_files/steamdeck-kde-presets/wayland-remove-env.patch
+++ b/spec_files/steamdeck-kde-presets/wayland-remove-env.patch
@@ -1,0 +1,8 @@
+diff --git a/etc/xdg/plasma-workspace/env/ibus.sh b/etc/xdg/plasma-workspace/env/ibus.sh
+index 36558e7..97f74e7 100644
+--- a/etc/xdg/plasma-workspace/env/ibus.sh
++++ b/etc/xdg/plasma-workspace/env/ibus.sh
+@@ -1,3 +1 @@
+-export QT_IM_MODULE=ibus
+-export GTK_IM_MODULE=ibus
+ export XMODIFIERS= @ im = ibus


### PR DESCRIPTION
To enable IBus in wayland session, it is necessary to remove environment variable  `QT_IM_MODULE` and `GTK_IM_MODULE`. The proper method to make ibus work is setting virtual keyboard to "IBus Wayland".