### PR TITLE
feat(just): add recipe to restart proton

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -17,3 +17,11 @@ fix-gmod:
     chmod +x /tmp/patch-gmod/GModCEFCodecFix-Linux
     /tmp/patch-gmod/GModCEFCodecFix-Linux
     rm -rf /tmp/patch-gmod
+
+# Kills all processes related to wine and proton, and forces it to restart (you might still have to press STOP in steam to kill the game binary)
+fix-proton-hang:
+    #!/usr/bin/bash
+    PROTONCORE=(pv-bwrap pressure-vessel reaper explorer.exe rpcss.exe plugplay.exe services.exe svchost.exe winedevice.exe winedevice.exe wineserver)
+    for PROG in "${PROTONCORE[@]}"; do
+	    killall -9 "$PROG"
+    done


### PR DESCRIPTION
useful for when a game gets stuck at "launching" or "exiting"

Been playing around with this script since before i started using Bazzite, taken a long time to properly test as i needed to have a game that got stuck in a "launching" state, which is rare (game window never appears and it is not a crash so the button does not flip back to Play, and Steam gets stuck trying to Stop said game, or Stopping and Starting the game again results in a game window never appearing)

Also works to close games that sometimes get frozen in a similar state when exiting and the Steam `Stop` button again gets stuck trying to kill the game.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
