### PR TITLE
chore(gnome): remove MUTTER_DEBUG_FORCE_KMS_MODE

### DIFF
--- a/system_files/deck/silverblue/usr/etc/environment
+++ b/system_files/deck/silverblue/usr/etc/environment
@@ -2,8 +2,5 @@
 # Nvidia users must additionally have nvidia-drm.modeset=1 in their kargs
 OBS_USE_EGL=1
 
-# Required for GNOME VRR MR
-MUTTER_DEBUG_FORCE_KMS_MODE=simple
-
 # VIM is more usable on deck due to control scheme
 EDITOR=/usr/bin/vim

--- a/system_files/desktop/silverblue/usr/etc/environment
+++ b/system_files/desktop/silverblue/usr/etc/environment
@@ -2,8 +2,5 @@
 # Nvidia users must additionally have nvidia-drm.modeset=1 in their kargs
 OBS_USE_EGL=1
 
-# Required for GNOME VRR MR
-MUTTER_DEBUG_FORCE_KMS_MODE=simple
-
 # https://gitlab.gnome.org/GNOME/mutter/-/issues/3037
 MUTTER_DEBUG_KMS_THREAD_TYPE=user


### PR DESCRIPTION
This is no longer needed for VRR in v40+ and it breaks direct scanout.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
