### PR TITLE
fix(desktop): sqlite column error in btrfs-dedup service

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/btrfs-dedup@.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/btrfs-dedup@.service
@@ -10,7 +10,7 @@ ExecCondition=sh -c '[ "$(stat -f -c "%%T" "$1")" = btrfs ]' _ %f/
 ExecStartPre=-find %f/ -mindepth 1 -maxdepth 1 -mtime +14 -name .duperemove.hash -exec rm -f '{}' \;
 ExecStartPre=-cp -a %f/.duperemove.hash duperemove.hash
 ExecStartPre=-compsize %f/
-ExecStart=-sh -c '[ "$(sqlite3 -readonly duperemove.hash "SELECT keyval FROM config where keyname=''version_major''")" -ge 4 ] || rm -f duperemove.hash'
+ExecStart=sh -c "[ $(sqlite3 -readonly duperemove.hash \"SELECT keyval FROM config where keyname == 'version_major'\") -ge 4 ] || rm -f duperemove.hash"
 ExecStart=duperemove -r -d -h -q --hashfile=duperemove.hash --skip-zeroes --exclude="%f/.duperemove.hash" --exclude="%f/@swapfile/swapfile" %f/
 ExecStartPost=-compsize %f/
 ExecStopPost=-cp -a duperemove.hash %f/.duperemove.hash

--- a/system_files/desktop/shared/usr/lib/systemd/system/btrfs-dedup@.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/btrfs-dedup@.service
@@ -10,7 +10,7 @@ ExecCondition=sh -c '[ "$(stat -f -c "%%T" "$1")" = btrfs ]' _ %f/
 ExecStartPre=-find %f/ -mindepth 1 -maxdepth 1 -mtime +14 -name .duperemove.hash -exec rm -f '{}' \;
 ExecStartPre=-cp -a %f/.duperemove.hash duperemove.hash
 ExecStartPre=-compsize %f/
-ExecStart=sh -c "[ $(sqlite3 -readonly duperemove.hash \"SELECT keyval FROM config where keyname == 'version_major'\") -ge 4 ] || rm -f duperemove.hash"
+ExecStart=-sh -c "[ $(sqlite3 -readonly duperemove.hash \"SELECT keyval FROM config where keyname == 'version_major'\") -ge 4 ] || rm -f duperemove.hash"
 ExecStart=duperemove -r -d -h -q --hashfile=duperemove.hash --skip-zeroes --exclude="%f/.duperemove.hash" --exclude="%f/@swapfile/swapfile" %f/
 ExecStartPost=-compsize %f/
 ExecStopPost=-cp -a duperemove.hash %f/.duperemove.hash


### PR DESCRIPTION
I think since I reported #959 `sqlite` still errors in the `btrfs-dedup@.service`:

https://github.com/ublue-os/bazzite/blob/b5f4b6d179993d39c5f607958a91f2a330aa3ac6/system_files/desktop/shared/usr/lib/systemd/system/btrfs-dedup%40.service#L13

```sh
ei 09 13:39:31 desktop-bazzite systemd[1]: Starting btrfs-dedup@var-home.service - Btrfs deduplication on /var/home...
mei 09 13:39:59 desktop-bazzite compsize[18933]: Processed 725459 files, 4077370 regular extents (4581627 refs), 322845 inline.
mei 09 13:39:59 desktop-bazzite compsize[18933]: Type       Perc     Disk Usage   Uncompressed Referenced
mei 09 13:39:59 desktop-bazzite compsize[18933]: TOTAL       85%      727G         847G         895G
mei 09 13:39:59 desktop-bazzite compsize[18933]: none       100%      573G         573G         579G
mei 09 13:39:59 desktop-bazzite compsize[18933]: zstd        56%      154G         274G         315G
mei 09 13:39:59 desktop-bazzite compsize[18933]: prealloc   100%      288M         288M          82M
mei 09 13:39:59 desktop-bazzite sh[19131]: Error: in prepare, no such column: version_major
mei 09 13:39:59 desktop-bazzite sh[19131]:   SELECT keyval FROM config where keyname=version_major
mei 09 13:39:59 desktop-bazzite sh[19131]:                             error here ---^
mei 09 13:39:59 desktop-bazzite sh[19130]: sh: line 1: [: : integer expression expected
mei 09 13:39:59 desktop-bazzite duperemove[19134]: Adding exclude pattern: /var/home/.duperemove.hash
mei 09 13:39:59 desktop-bazzite duperemove[19134]: Adding exclude pattern: /var/home/@swapfile/swapfile
mei 09 13:39:59 desktop-bazzite duperemove[19134]: process_extents: unable to get extent
mei 09 13:39:59 desktop-bazzite duperemove[19134]: file /var/home/pimv/.config/Code/GPUCache/data_0 changed
mei 09 13:39:59 desktop-bazzite duperemove[19134]: process_extents: unable to get extent
```
This result in removal of the hash file for `duperemove` and it starts from scratch every time and this takes about 4 hours on my main system. After applying this fix, it does it in about 3-5 minutes on a second run.

I tested a bit in the terminal with different shell commands that should do the same and found it behaves differently when it runs in the service. I don't know why this is... If anyone knows I would like to know.

Anyways, I found that `'version_major'` would loose its surrounding `'` in any case when also using `'` to capture the `sh -c` command so `"` has to be used for this. I also found that when using `sh -c` in a service, a nested `"` has to be escaped with `\`.

I tested the command in the service by increasing the `-ge 4` expression and `||` echoing some string. The expression works fine with this fix.