### PR TITLE
hotfix: batteryservice on latest bioses

### DIFF
--- a/system_files/deck/shared/usr/lib/systemd/system/batterylimit.service
+++ b/system_files/deck/shared/usr/lib/systemd/system/batterylimit.service
@@ -7,4 +7,4 @@ EnvironmentFile=-/etc/default/%p
 ExecStart=/usr/bin/bash -c "echo ${MAX_BATTERY_CHARGE_LEVEL} > /sys/class/hwmon/hwmon*/max_battery_charge_level"
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target reboot.target hibernate.target hybrid-sleep.target sleep.target suspend-then-hibernate.target suspend.target


### PR DESCRIPTION
Based on my testing with my Deck LCD on 0131 it seems that it randomly loses the setting after sleep/reboot/shutdown.

Run this command after each possible systemd stage to force it to leave this applied correctly. Tested locally.
