### PR TITLE
feat: Trigger CEC onboot on Bluetooth device connection

### DIFF
--- a/system_files/desktop/shared/usr/lib/udev/rules.d/99-cec-bluetooth.rules
+++ b/system_files/desktop/shared/usr/lib/udev/rules.d/99-cec-bluetooth.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="bluetooth", RUN+="/usr/bin/cec-control onboot"


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Added a new udev rule which is triggered when a Bluetooth device is connected. It calls `/usr/bin/cec-control onboot`, same as `cec-onboot.service`, should set the TV's input source to Bazzite. Useful when you just grab the controller and turn it on to start gaming.