### PR TITLE
feat(nvidia): Set Nvidia kernel arguments in Bazzite Portal

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -93,6 +93,7 @@ screens:
       show_terminal: true
       package_manager: yafti.plugin.run
       packages:
+        - Set Needed Kernel Arguments: ujust configure-nvidia kargs
         - GreenWithEnvy (GPU Overclocking): flatpak install --user --noninteractive com.leinardi.gwe
         - Supergfxctl (Hybrid GPU Switching): ujust enable-supergfxctl
   applications:


### PR DESCRIPTION
Allows setting necessary kernel arguments in the Bazzite Portal, since it's a necessary step to use Nvidia graphics.

Resolves ublue-os/bazzite#1114