### PR TITLE
fix: AOKZOE A1 Pro (AMD R愛zen 7840U) - Add device to simpledeckytdp-supported-hardware and hhd-supported-hardware, as well as add waydroid-launcher resolution

### DIFF
--- a/system_files/desktop/shared/usr/etc/default/waydroid-launcher
+++ b/system_files/desktop/shared/usr/etc/default/waydroid-launcher
@@ -13,7 +13,7 @@ case "$(cat /sys/devices/virtual/dmi/id/product_name)" in
 	"ROG Ally RC71L_RC71L" | "G1618-04" | "G1617-01" | "Loki Max")
 		WAYDROID_WIDTH=1920
 		WAYDROID_HEIGHT=1080 ;;
-	"AYANEO 2" | "AYANEO 2S" | "AOKZOE A1 AR07" | "G1619-04" | "AIR Plus")
+	"AYANEO 2" | "AYANEO 2S" | "AOKZOE A1 AR07" | "AOKZOE A1 Pro" | "G1619-04" | "AIR Plus")
 		WAYDROID_WIDTH=1920
 		WAYDROID_HEIGHT=1200 ;;
 	"83E1")

--- a/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Returns true for hardware that is supported by HHD
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
-if [[ ":ROG Ally RC71L_RC71L:ROG Ally RC71L:83E1:G1618-04:G1617-01:G1619-05:AIR Plus:AIR:AYANEO GEEK:AYANEO 2:AYANEO 2S:AOKZOE A1 AR07:G1619-04:Win600:Loki Max:Loki Zero:Loki MiniPro:" =~ ":$SYS_ID:" ]]; then
+if [[ ":ROG Ally RC71L_RC71L:ROG Ally RC71L:83E1:G1618-04:G1617-01:G1619-05:AIR Plus:AIR:AYANEO GEEK:AYANEO 2:AYANEO 2S:AOKZOE A1 AR07:AOKZOE A1 Pro:G1619-04:Win600:Loki Max:Loki Zero:Loki MiniPro:" =~ ":$SYS_ID:" ]]; then
 	exit 0
 fi
 

--- a/system_files/desktop/shared/usr/libexec/hwsupport/simpledeckytdp-supported-hardware
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/simpledeckytdp-supported-hardware
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Returns true for hardware that is supported by SimpleDeckyTDP
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
-if [[ ":ROG Ally RC71L_RC71L:ROG Ally RC71L:83E1:G1618-04:G1619-04:G1617-01:G1619-05:AIR Plus:AIR:SLIDE:V3:" =~ ":$SYS_ID:" ]]; then
+if [[ ":ROG Ally RC71L_RC71L:ROG Ally RC71L:83E1:G1618-04:G1619-04:G1617-01:G1619-05:AIR Plus:AIR:SLIDE:V3:AOKZOE A1 AR07:AOKZOE A1 Pro:" =~ ":$SYS_ID:" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
### **Fixes**:

- Add waydroid-launcher resolution for **AOKZOE A1 Pro**
- Add **AOKZOE A1 Pro** to both simpledeckytdp-supported-hardware and hdd-supported-hardware

The display specs of both the **[AOKZOE A1 Pro](https://aokzoestore.com/products/aokzoe-a1-pro)** and **AOKZOE A1 AR07** are _identical_. The only difference is that the A1 Pro has a 7840U APU.

### **Additional comments:**

『愛してるよ！ 愛だけに！』

![992097669m](https://github.com/ublue-os/bazzite/assets/78288795/7916802d-a8aa-424b-8b8c-befb08da90d8)

(you can ignore these.)


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
