### PR TITLE
fix: correct brew directory.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -605,6 +605,7 @@ RUN /usr/libexec/containerbuild/build-initramfs && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /usr/lib/systemd/system.conf && \
     mkdir -p /usr/etc/flatpak/remotes.d && \
     curl -Lo /usr/etc/flatpak/remotes.d/flathub.flatpakrepo https://dl.flathub.org/repo/flathub.flatpakrepo && \
+    systemctl enable brew-dir-fix.service && \
     systemctl enable brew-setup.service && \
     systemctl enable brew-upgrade.timer && \
     systemctl enable brew-update.timer && \

--- a/system_files/desktop/shared/usr/lib/systemd/system/brew-dir-fix.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/brew-dir-fix.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Make sure brew is in correct location...
+After=local-fs.target
+ConditionPathExists=!/etc/.linuxbrew.check
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bash -c "if [[ -d /var/home/linuxbrew/Homebrew && ! -d /var/home/linuxbrew/.linuxbrew/Homebrew ]]; then mv /var/home/linuxbrew /tmp/linuxbrew.tmp && mkdir -p /var/home/linuxbrew/ && mv /tmp/linuxbrew.tmp/* /var/home/linuxbrew/.linuxbrew/ && rmdir /tmp/linuxbrew.tmp; fi"
+ExecStart=/usr/bin/touch /etc/.linuxbrew.check
+
+[Install]
+WantedBy=default.target multi-user.target

--- a/system_files/desktop/shared/usr/lib/systemd/system/brew-dir-fix.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/brew-dir-fix.service
@@ -5,7 +5,7 @@ ConditionPathExists=!/etc/.linuxbrew.check
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/bash -c "if [[ -d /var/home/linuxbrew/Homebrew && ! -d /var/home/linuxbrew/.linuxbrew/Homebrew ]]; then mv /var/home/linuxbrew /tmp/linuxbrew.tmp && mkdir -p /var/home/linuxbrew/ && mv /tmp/linuxbrew.tmp/* /var/home/linuxbrew/.linuxbrew/ && rmdir /tmp/linuxbrew.tmp; fi"
+ExecStart=/usr/bin/bash -c "if [[ -d /var/home/linuxbrew/Homebrew && ! -d /var/home/linuxbrew/.linuxbrew/Homebrew ]]; then mv /var/home/linuxbrew /tmp/linuxbrew.tmp && mkdir -p /var/home/linuxbrew/ && mv /tmp/linuxbrew.tmp /var/home/linuxbrew/.linuxbrew; fi"
 ExecStart=/usr/bin/touch /etc/.linuxbrew.check
 
 [Install]

--- a/system_files/desktop/shared/usr/lib/systemd/system/brew-update.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/brew-update.service
@@ -2,7 +2,7 @@
 Description=Auto update brew for mutable brew installs
 After=local-fs.target
 After=network-online.target
-ConditionPathExists=/home/linuxbrew/.linuxbrew/bin/brew
+ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
 
 [Service]
 # Override the user if different UID/User
@@ -11,5 +11,4 @@ Type=oneshot
 Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
 Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
 Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
-ExecStart=/home/linuxbrew/.linuxbrew/bin/brew update
-StandardOutput=journal
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew update"

--- a/system_files/desktop/shared/usr/lib/systemd/system/brew-update.timer
+++ b/system_files/desktop/shared/usr/lib/systemd/system/brew-update.timer
@@ -3,7 +3,7 @@ Description=Timer for brew update for mutable brew
 Wants=network-online.target
 
 [Timer]
-OnBootSec=20min
+OnBootSec=10min
 OnUnitInactiveSec=6h
 Persistent=true
 

--- a/system_files/desktop/shared/usr/lib/systemd/system/brew-upgrade.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/brew-upgrade.service
@@ -2,7 +2,7 @@
 Description=Upgrade Brew packages
 After=local-fs.target
 After=network-online.target
-ConditionPathExists=/home/linuxbrew/.linuxbrew/bin/brew
+ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
 
 [Service]
 # Override the user if different UID/User
@@ -11,5 +11,4 @@ Type=oneshot
 Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
 Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
 Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
-ExecStart=/home/linuxbrew/.linuxbrew/bin/brew upgrade
-StandardOutput=journal
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"

--- a/system_files/desktop/shared/usr/lib/systemd/system/brew-upgrade.timer
+++ b/system_files/desktop/shared/usr/lib/systemd/system/brew-upgrade.timer
@@ -3,8 +3,8 @@ Description=Timer for brew upgrade for on image brew
 Wants=network-online.target
 
 [Timer]
-OnBootSec=20min
-OnUnitInactiveSec=6h
+OnBootSec=30min
+OnUnitInactiveSec=8h
 Persistent=true
 
 [Install]

--- a/system_files/desktop/shared/usr/lib/tmpfiles.d/homebrew.conf
+++ b/system_files/desktop/shared/usr/lib/tmpfiles.d/homebrew.conf
@@ -1,0 +1,1 @@
+d /var/home/linuxbrew 0755 1000 1000 - -


### PR DESCRIPTION
Brew was being copied into the wrong directory. The directory `/var/home/linuxbrew` was missing and causing things to be copied to `/var/home/linuxbrew` and not `/var/home/linuxbrew/.linuxbrew`.

This makes sure it is in the correct spot. This is handled via a oneshot service. The service checks if `/var/home/linuxbrew/Homebrew` exists and if `/var/home/linuxbrew/.linuxbrew/Homebrew` doesn't exist. If that's the case, it mv's the dir to /tmp, makes the correct `/home/linuxbrew/.linuxbrew` directory and mv's everything back underneath the newly created dir.

The service is only needed for a few weeks and can then be removed. 
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
