### PR TITLE
fix: correct bash if statement for dGPU detection

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -14,7 +14,7 @@ fi
 
 DGPU_OPTION=""
 # If we're running this on a dGPU, disable accelerated cef
-if [[ $(switcherooctl list | grep -o 'Device:' | wc -l) > 1 ]]; then
+if [[ $(switcherooctl list | grep -o 'Device:' | wc -l) -gt 1 ]]; then
   DGPU_OPTION="-cef-disable-gpu"
 fi
 


### PR DESCRIPTION
Using '>' instead of '-gt' always returns true (as '>' is not valid with 'test'), adding the flag '-cef-disable-gpu' regardless of the device using a dGPU.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
