### PR TITLE
feat(waydroid): pass arguments for waydroid-launcher through to waydroid

### DIFF
--- a/system_files/desktop/shared/usr/bin/waydroid-launcher
+++ b/system_files/desktop/shared/usr/bin/waydroid-launcher
@@ -19,10 +19,18 @@ if grep -qz 'not initialized' <<< $(/usr/bin/waydroid status); then
 	/usr/bin/ujust init-waydroid
 fi
 
+launch_waydroid() {
+        wlr-randr --output X11-1 --custom-mode "$1"
+        sleep 1
+        shift
+        exec waydroid "$@" &> /dev/null
+}
+export -f launch_waydroid
+
 # Launch Cage & Waydroid
 pkexec /usr/libexec/waydroid-container-start
 if [ -z "$(pgrep wlr-randr)" ]; then
-    cage -- bash -uxc 'wlr-randr --output X11-1 --custom-mode "$1"; sleep 1; shift; waydroid "$@" &> /dev/null' _ "${WAYDROID_WIDTH:-1280}x${WAYDROID_HEIGHT:-800}" "$@" &
+    cage -- bash -uxc 'launch_waydroid "$@"' _ "${WAYDROID_WIDTH:-1280}x${WAYDROID_HEIGHT:-800}" "$@" &
 fi
 
 # Fix controllers, we know Waydroid has started because surfaceflinger is running

--- a/system_files/desktop/shared/usr/bin/waydroid-launcher
+++ b/system_files/desktop/shared/usr/bin/waydroid-launcher
@@ -1,6 +1,13 @@
 #!/usr/bin/bash
 
+set -eux
+
 source /etc/default/waydroid-launcher
+
+# for backwards compatibility, default to show-full-ui
+if (($# == 0)); then
+	set -- show-full-ui
+fi
 
 # Kill any previous remnants
 if [ "$(systemctl is-active waydroid-container.service)" == 'active' ]; then
@@ -15,7 +22,7 @@ fi
 # Launch Cage & Waydroid
 pkexec /usr/libexec/waydroid-container-start
 if [ -z "$(pgrep wlr-randr)" ]; then
-	cage -- bash -c "wlr-randr --output X11-1 --custom-mode ${WAYDROID_WIDTH:-1280}x${WAYDROID_HEIGHT:-800}; sleep 1; waydroid show-full-ui &> /dev/null &" &
+    cage -- bash -uxc 'wlr-randr --output X11-1 --custom-mode "$1"; sleep 1; shift; waydroid "$@" &> /dev/null' _ "${WAYDROID_WIDTH:-1280}x${WAYDROID_HEIGHT:-800}" "$@" &
 fi
 
 # Fix controllers, we know Waydroid has started because surfaceflinger is running

--- a/system_files/desktop/shared/usr/libexec/waydroid-fix-controllers
+++ b/system_files/desktop/shared/usr/libexec/waydroid-fix-controllers
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-sudo /usr/bin/bash -c 'echo add > /sys/devices/virtual/input/input*/event*/uevent'
+echo add | exec sudo tee /sys/devices/virtual/input/input*/event*/uevent


### PR DESCRIPTION
This PR ensures waydroid-launcher is able to pass through the arguments given to `waydroid-launcher`. This means waydroid-launcher can be used for more than just launching the full UI, such as running a single app. Thus, this means additional desktop entries could be created running individual apps, which can then be added to Game Mode.

This also fixes a small bug in `waydroid-fix-controller`. The globbing for some reason doesn't work properly, thus it doesn't seem to work well. This uses `tee` instead to pipe the output using sudo.