### PR TITLE
fix(ujust): sync arch packages before installing opentabletdriver

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -135,7 +135,7 @@ install-opentabletdriver:
     if grep -qvz "arch" <<< $(distrobox list); then \
       Assemble noconfirmcreate "" "arch"; \
     fi && \
-    distrobox enter -n arch -- bash -c 'paru -S opentabletdriver --noconfirm' && \
+    distrobox enter -n arch -- bash -c 'paru -Syu --noconfirm && paru -S opentabletdriver --noconfirm' && \
     mkdir -p ~/.config/systemd/user/ && \
     rm -f ~/.config/systemd/user/arch-opentabletdriver.service && \
     wget https://raw.githubusercontent.com/ublue-os/bazzite/main/post_install_files/OpenTabletDriver/opentabletdriver.service -O ~/.config/systemd/user/arch-opentabletdriver.service && \


### PR DESCRIPTION
Currently, running `ujust install-opentabletdriver` when you don't already have an Arch distrobox will create one and try to install opentabletdriver. This will fail because the repos are out of sync and it can't locate the files needed. This should fix that by running `paru -Syu --noconfirm` before trying to install opentabletdriver.