### PR TITLE
chore: bump mesa to 24.1.1

### DIFF
--- a/spec_files/mesa/mesa.spec
+++ b/spec_files/mesa/mesa.spec
@@ -62,7 +62,7 @@
 
 Name:           mesa
 Summary:        Mesa graphics libraries
-%global ver 24.1.0
+%global ver 24.1.1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
 Release:        100.bazzite.{{{ git_dir_version }}}
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0


### PR DESCRIPTION
Bump to latest mesa patch release (24.1.1)

COPR build to validate: https://copr.fedorainfracloud.org/coprs/trouter/bazzite-multilib/build/7610825/

(Build is in progress at time of opening this PR; check it's green in COPR before merging)