### PR TITLE
fix(sunshine): fix systemd file for missing closing quote

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/sunshine-workaround.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/sunshine-workaround.service
@@ -8,7 +8,7 @@ Type=oneshot
 # Copy if it doesn't exist
 ExecStartPre=/usr/bin/bash -c "[ -x /usr/local/bin/.sunshine ] || /usr/bin/cp /usr/bin/sunshine /usr/local/bin/.sunshine"
 # This is faster than using .mount unit. Also allows for the previous line/cleanup
-ExecStartPre=/usr/bin/bash -c "/usr/bin/mount --bind /usr/local/bin/.sunshine /usr/bin/sunshine
+ExecStartPre=/usr/bin/bash -c "/usr/bin/mount --bind /usr/local/bin/.sunshine /usr/bin/sunshine"
 # Fix caps
 ExecStart=/usr/sbin/setcap 'cap_sys_admin+p' /usr/bin/sunshine
 # Clean-up after ourselves


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

fix(sunshine): sunshine-workaround missing closing quote in ExecStartPre line preventing proper execution. See #1204 