### PR TITLE
feat: Remove decky hhd plugin, replaced by built in hhd overlay

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -128,6 +128,13 @@ restore-input-remapper:
     cp /usr/share/applications/input-remapper-gtk.desktop ~/.local/share/applications/input-remapper-gtk.desktop && \
     sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop
 
+# Install hhd main branch locally until reboot, helpful for hhd testing and debugging. (rename to install-hhd-dev if we unhide)
+_hhd-dev:
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    echo "Installing ${b}Handheld Daemon${n} locally until next reboot."
+    curl -L https://raw.githubusercontent.com/hhd-dev/hhd/master/local_hhd.sh | bash
+
 _toggle-autologin:
     #!/usr/bin/bash
     DESKTOP_AUTOLOGIN="/etc/bazzite/desktop_autologin"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -155,7 +155,6 @@ setup-decky ACTION="":
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'install' to select Install Decky"
       echo "  Use 'simpledeckytdp' to select Get SimpleDeckyTDP"
-      echo "  Use 'hhd-decky' to select Get HHD-decky"
       exit 0
     elif [ "$OPTION" == "" ]; then
       echo "${bold}Setup Decky Loader${normal}"
@@ -165,8 +164,7 @@ setup-decky ACTION="":
       OPTION=$(
         Choose \
         "Install Decky" \
-        "Get $(Urllink "https://github.com/aarron-lee/SimpleDeckyTDP" SimpleDeckyTDP)${n}" \
-        "Get $(Urllink "https://github.com/hhd-dev/hhd-decky" HHD-Decky)${n}"
+        "Get $(Urllink "https://github.com/aarron-lee/SimpleDeckyTDP" SimpleDeckyTDP)${n}"
         )
     fi
     if [[ "${OPTION,,}" =~ install ]]; then
@@ -181,16 +179,6 @@ setup-decky ACTION="":
         rm /tmp/SimpleDeckyTDP.tar.gz
         sudo sed -i 's/ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE=0/ENABLE_HARDWARE_CONTROL_ON_NON_DECK_HARDWARE=1/g' /etc/default/steam-hardware-control
         echo 'Installed. Please reboot to apply needed changes.'
-      else
-        echo 'Please install Decky Loader by running "ujust setup-decky install" first.'
-      fi
-    elif [[ "${OPTION,,}" =~ hhd-decky ]]; then
-      if [[ -d $HOME/homebrew/plugins ]]; then
-        sudo rm -rf $HOME/homebrew/plugins/hhd-decky
-        curl -L $(curl -s https://api.github.com/repos/hhd-dev/hhd-decky/releases/latest | grep "browser_download_url" | cut -d '"' -f 4) -o /tmp/hhd-decky.tar.gz
-        sudo tar -xzf /tmp/hhd-decky.tar.gz -C $HOME/homebrew/plugins
-        rm /tmp/hhd-decky.tar.gz
-        echo 'Installed.'
       else
         echo 'Please install Decky Loader by running "ujust setup-decky install" first.'
       fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -157,13 +157,6 @@ install-opentabletdriver:
     systemctl enable --user --now arch-opentabletdriver.service && \
     distrobox enter -n arch -- bash -c 'distrobox-export --app otd-gui'
 
-# Install hhd main branch locally until reboot, helpful for hhd testing and debugging. (rename to install-hhd-dev if we unhide)
-_hhd-dev:
-    #!/usr/bin/bash
-    source /usr/lib/ujust/ujust.sh
-    echo "Installing ${b}Handheld Daemon${n} locally until next reboot."
-    curl -L https://raw.githubusercontent.com/hhd-dev/hhd/master/local_hhd.sh | bash
-
 # Create fedora distrobox if it doesn't exist
 [private]
 distrobox-check-fedora:


### PR DESCRIPTION
This is replaced by hhd overlay which is activated by double/triple pressing the QAM button (or holding it on handhelds that support the hold action)

This also moves the hidden `_hhd-dev` recipe to only be available in the deck image.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
