### PR TITLE
feat: provide script to detect known cards requiring drm workaround

### DIFF
--- a/system_files/desktop/shared/usr/libexec/hwsupport/gamescope-drm-workaround
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/gamescope-drm-workaround
@@ -12,10 +12,8 @@ FINAL_RE="$POLARIS_RE"
 # Get the users homedirs so we can check for export-gpu configs
 HOMES=$(grep "/home" /etc/passwd | awk -F ":" '{ print $6 }')
 
-# Use switcherooctl to find all GPUs and conveniently does not list gpus used by vfio-pci <3
-#VGA_CONTROLLERS=$(switcherooctl list | grep -a -A 1 -P 'Name:' | perl -pe 's/\n/;/')
+# Find all GPUs using lspci
 VGA_CONTROLLERS=$(lspci -nn | grep -P "(VGA compatible|3D) controller")
-VULKAN_GPU=""
 
 # Check inside users home if gamescope is configured to use a specific GPU
 # This at least does not break gamescope on systems where users have re-enabled the sddm login screen
@@ -43,7 +41,7 @@ do
     # If we match with a card that requires drm workaround
     if [[ "$GPU" =~ ($FINAL_RE) ]]; then
         # Write info to journal
-        echo "INFO: $(echo "$GPU" | awk -F ';' '{ print $1 }' | sed -E 's/\s+Name:\s+//') detected" | systemd-cat -t gamescope-drm-workaround -p info
+        echo "INFO: $GPU detected" | systemd-cat -t gamescope-drm-workaround -p info
         echo "INFO: DRM workaround will be applied." | systemd-cat -t gamescope-drm-workaround -p info
 
         # This gpu requires drm workaround, exit 0 (true)
@@ -53,7 +51,7 @@ done <<< "$VGA_CONTROLLERS"
 
 # Write info to journalctl
 echo "INFO: DRM workaround not required for this system" | systemd-cat -t gamescope-drm-workaround -p info
-echo 'INFO: If DRM workaround IS required for your card. Provide your "lspci -nn | grep '"'"'(VGA compatible|3D) controller'"'"'" to the developers.' | systemd-cat -t gamescope-drm-workaround -p info
+echo 'INFO: If DRM workaround IS required for your card. Provide your "lspci -nn | grep -P '"'"'(VGA compatible|3D) controller'"'"'" to the developers.' | systemd-cat -t gamescope-drm-workaround -p info
 
 # This GPU does not require drm workaround, exit 1 (false)
 exit 1

--- a/system_files/desktop/shared/usr/libexec/hwsupport/gamescope-drm-workaround
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/gamescope-drm-workaround
@@ -13,9 +13,9 @@ FINAL_RE="$POLARIS_RE"
 HOMES=$(grep "/home" /etc/passwd | awk -F ":" '{ print $6 }')
 
 # Use switcherooctl to find all GPUs and conveniently does not list gpus used by vfio-pci <3
-VGA_CONTROLLERS=$(switcherooctl list | grep -a -A 1 -P 'Name:' | perl -pe 's/\n/;/')
+#VGA_CONTROLLERS=$(switcherooctl list | grep -a -A 1 -P 'Name:' | perl -pe 's/\n/;/')
+VGA_CONTROLLERS=$(lspci -nn | grep -P "(VGA compatible|3D) controller")
 VULKAN_GPU=""
-IS_GAMESCOPE_GPU=""
 
 # Check inside users home if gamescope is configured to use a specific GPU
 # This at least does not break gamescope on systems where users have re-enabled the sddm login screen
@@ -33,7 +33,6 @@ do
         if [ -n "$VULKAN_GPU" ]; then
             # Replace list of VGA controllers with just this device
             VGA_CONTROLLERS=$(lspci -nn -d "$VULKAN_GPU")
-            IS_GAMESCOPE_GPU="yes"
         fi
     fi
 done <<< "$HOMES"
@@ -43,30 +42,18 @@ while IFS= read -r GPU
 do
     # If we match with a card that requires drm workaround
     if [[ "$GPU" =~ ($FINAL_RE) ]]; then
-        # If $IS_GAMESCOPE_GPU is empty
-        if [ -z "$IS_GAMESCOPE_GPU" ]; then
-            # Check if the GPU is the default GPU
-            IS_GAMESCOPE_GPU=$(echo "$GPU" | awk -F ';' '{ print $2 }' | sed -E 's/\s+Default:\s+//')
-        fi
+        # Write info to journal
+        echo "INFO: $(echo "$GPU" | awk -F ';' '{ print $1 }' | sed -E 's/\s+Name:\s+//') detected" | systemd-cat -t gamescope-drm-workaround -p info
+        echo "INFO: DRM workaround will be applied." | systemd-cat -t gamescope-drm-workaround -p info
 
-        # If this is the gpu used for gamescope session
-        if [ "$IS_GAMESCOPE_GPU" == "yes" ]; then
-            # Write info to journal
-            echo "INFO: $(echo "$GPU" | awk -F ';' '{ print $1 }' | sed -E 's/\s+Name:\s+//') is the GPU used for gamescope" | systemd-cat -t gamescope-drm-workaround -p info
-            echo "INFO: DRM workaround will be applied for this card" | systemd-cat -t gamescope-drm-workaround -p info
-            
-            # This gpu requires drm workaround, exit 0 (true)
-            exit 0
-        else
-            # Empty for next loop
-            IS_GAMESCOPE_GPU=""
-        fi
+        # This gpu requires drm workaround, exit 0 (true)
+        exit 0
     fi
 done <<< "$VGA_CONTROLLERS"
 
 # Write info to journalctl
 echo "INFO: DRM workaround not required for this system" | systemd-cat -t gamescope-drm-workaround -p info
-echo 'INFO: If DRM workaround IS required for your card, provide the bazzite team your "switcherooctl list"' | systemd-cat -t gamescope-drm-workaround -p info
+echo 'INFO: If DRM workaround IS required for your card. Provide your "lspci -nn | grep '"'"'(VGA compatible|3D) controller'"'"'" to the developers.' | systemd-cat -t gamescope-drm-workaround -p info
 
 # This GPU does not require drm workaround, exit 1 (false)
 exit 1

--- a/system_files/desktop/shared/usr/libexec/hwsupport/gamescope-drm-workaround
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/gamescope-drm-workaround
@@ -1,0 +1,72 @@
+#!/usr/bin/bash
+# Script returns true if a card requiring drm workaround is detected
+
+# Regexes for GPUs requiring workarounds
+# Can be used in regexes as $POLARIS_RE|$VEGA_RE etc for readability
+# Needed output for a regex can gathered from "switcherooctl list"
+POLARIS_RE="Ellesmere|Lexa PRO|RX 470/480/570/570X/580/580X/590|540/540X/550/550X|RX 540X/550/550X"
+
+# Used to combine all regex into 1 var ex: FINALE_RE="$POLARIS_RE|$VEGA_RE"
+FINAL_RE="$POLARIS_RE"
+
+# Get the users homedirs so we can check for export-gpu configs
+HOMES=$(grep "/home" /etc/passwd | awk -F ":" '{ print $6 }')
+
+# Use switcherooctl to find all GPUs and conveniently does not list gpus used by vfio-pci <3
+VGA_CONTROLLERS=$(switcherooctl list | grep -a -A 1 -P 'Name:' | perl -pe 's/\n/;/')
+VULKAN_GPU=""
+IS_GAMESCOPE_GPU=""
+
+# Check inside users home if gamescope is configured to use a specific GPU
+# This at least does not break gamescope on systems where users have re-enabled the sddm login screen
+while IFS= read -r USERDIR
+do
+    # If a vulkan device config is present
+    if [ -f "$USERDIR/.config/environment.d/00-vulkan-device.conf" ]; then
+        # Check if a vulkan device is configured
+        VULKAN_GPU=$(grep -P "^VULKAN_ADAPTER=" "$USERDIR/.config/environment.d/00-vulkan-device.conf" | sed 's/VULKAN_ADAPTER=//')
+
+        # Write info to journal
+        echo "INFO: VULKAN_ADAPTER is set to $VULKAN_GPU by env config." | systemd-cat -t gamescope-drm-workaround -p info
+
+        # If a vulkan device is configured
+        if [ -n "$VULKAN_GPU" ]; then
+            # Replace list of VGA controllers with just this device
+            VGA_CONTROLLERS=$(lspci -nn -d "$VULKAN_GPU")
+            IS_GAMESCOPE_GPU="yes"
+        fi
+    fi
+done <<< "$HOMES"
+
+# Process the VGA controllers list to see if we match any cards that need the drm workaround
+while IFS= read -r GPU
+do
+    # If we match with a card that requires drm workaround
+    if [[ "$GPU" =~ ($FINAL_RE) ]]; then
+        # If $IS_GAMESCOPE_GPU is empty
+        if [ -z "$IS_GAMESCOPE_GPU" ]; then
+            # Check if the GPU is the default GPU
+            IS_GAMESCOPE_GPU=$(echo "$GPU" | awk -F ';' '{ print $2 }' | sed -E 's/\s+Default:\s+//')
+        fi
+
+        # If this is the gpu used for gamescope session
+        if [ "$IS_GAMESCOPE_GPU" == "yes" ]; then
+            # Write info to journal
+            echo "INFO: $(echo "$GPU" | awk -F ';' '{ print $1 }' | sed -E 's/\s+Name:\s+//') is the GPU used for gamescope" | systemd-cat -t gamescope-drm-workaround -p info
+            echo "INFO: DRM workaround will be applied for this card" | systemd-cat -t gamescope-drm-workaround -p info
+            
+            # This gpu requires drm workaround, exit 0 (true)
+            exit 0
+        else
+            # Empty for next loop
+            IS_GAMESCOPE_GPU=""
+        fi
+    fi
+done <<< "$VGA_CONTROLLERS"
+
+# Write info to journalctl
+echo "INFO: DRM workaround not required for this system" | systemd-cat -t gamescope-drm-workaround -p info
+echo 'INFO: If DRM workaround IS required for your card, provide the bazzite team your "switcherooctl list"' | systemd-cat -t gamescope-drm-workaround -p info
+
+# This GPU does not require drm workaround, exit 1 (false)
+exit 1


### PR DESCRIPTION
This covers for weird things like:
* Having sddm login screen enabled
* Having multiple users (if point 1 is true)
* The gamescope-session user is not uid 1000
* Having VULKAN_ADAPTER defined through `export-gpu` (if none is defined, then it will check the gpu marked as `Default: yes`)
* Ignores gpus used for VFIO as switcherooctl ignores any card bound to the vfio-pci driver

The script exits with exit code 0 if the card requires DRM workaround (currently if a polaris card is detected) and exit code 1 if nothing needs to be done.

NOTE: this is still missing RX 450-460 cards as i do not know the output for those. but they should hopefully get caught by the Ellemeres and Lexa Pro regex checks

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
