### PR TITLE
fix(bazzite-powersave): make arg to set PPD to balance work

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-powersave
+++ b/system_files/desktop/shared/usr/libexec/bazzite-powersave
@@ -2,8 +2,8 @@
 # This script sends the Power Profile Daemon dbus call to set tuneD to power-saver mode
 # This is useful only for battery powered devices where you want to start in power-saver mode by default
 POWERSAVE=1
-if [ -z "$1" ]; then
-    if [ "$1" == 0 ]; then
+if [ -n "$1" ]; then
+    if [ "$1" == "0" ]; then
         POWERSAVE=0
     fi
 fi
@@ -11,14 +11,14 @@ fi
 # Check what DE we are on
 if command -v /usr/bin/mutter > /dev/null; then
     # If we are on Gnome send the dbus signal with gdbus
-    if [ $POWERSAVE == 0 ]; then
+    if [ "$POWERSAVE" == "0" ]; then
         gdbus call --system --dest net.hadess.PowerProfiles --object-path /net/hadess/PowerProfiles --method org.freedesktop.DBus.Properties.Set 'net.hadess.PowerProfiles' 'ActiveProfile' "<'balanced'>"
     else
         gdbus call --system --dest net.hadess.PowerProfiles --object-path /net/hadess/PowerProfiles --method org.freedesktop.DBus.Properties.Set 'net.hadess.PowerProfiles' 'ActiveProfile' "<'power-saver'>"
     fi
 else
     # Assume we are on KDE and send the dbus signal with qdbus
-    if [ $POWERSAVE == 0 ]; then
+    if [ "$POWERSAVE" == "0" ]; then
         qdbus org.kde.Solid.PowerManagement /org/kde/Solid/PowerManagement/Actions/PowerProfile setProfile balanced
     else
         qdbus org.kde.Solid.PowerManagement /org/kde/Solid/PowerManagement/Actions/PowerProfile setProfile power-saver


### PR DESCRIPTION
the default is to enable power-saver mode when run and that always worked and was the point of the script, which is why this never got caught before now.

Script was made basically because the dbus calls to do this are horrible for both DEs
`/usr/libexec/bazzite-powersave` sets PPD profile to `power-saver` for gnome and kde (will detect DE)
`/usr/libexec/bazzite-powersave 0` will now correctly set PPD profile to `balanced`

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
