### PR TITLE
fix(wine):Match Fedora wine's configuration

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -433,8 +433,8 @@ RUN rpm-ostree install \
         libobs_glcapture.i686 \
         mangohud.x86_64 \
         mangohud.i686 && \
-    ln -s wine64 /usr/bin/wine && \
-    ln -s wine64-preloader /usr/bin/wine-preloader && \
+    ln -s wine32 /usr/bin/wine && \
+    ln -s wine32-preloader /usr/bin/wine-preloader && \
     ln -s wineserver64 /usr/bin/wineserver && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
         rpm-ostree override remove \


### PR DESCRIPTION
Wine is in wow64 mode which seems to often not work and seemed to cause some people trouble with lutris, by default  Fedora sets wine and wine preloader to be 32 bit executables
