### PR TITLE
feat(fcitx5): Add advanced Chinese input method `fcitx5-chinese-addons`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -485,6 +485,7 @@ RUN if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
             rom-properties-kf6 \
             joystickwake \
             fcitx5-mozc \
+            fcitx5-chinese-addons \
             ptyxis && \
         mkdir -p /tmp/kwin-system76-scheduler-integration && \
         curl -Lo /tmp/kwin-system76-scheduler-integration/archive.tar.gz https://github.com/maxiberta/kwin-system76-scheduler-integration/archive/refs/heads/main.tar.gz && \


### PR DESCRIPTION
## Main Purpose
Add `fcitx5-chinese-addons` package under fcitx5-mozc to enable advanced input method for Chinese users. (Shuangpin, Wubi..)

## Why
Fcitx5 is a widely used input method framework among Chinese users. It supports various input methods such as Shuangpin and Wubi, which significantly speed up the typing process. Shuangpin allows users to input Chinese characters with just two keystrokes, while Wubi uses stroke-based inputs.

To enable these input methods, an additional Fcitx5 package needs to be layered, similar to `fcitx5-mozc`
![image](https://github.com/ublue-os/bazzite/assets/1501022/3c1473b9-36b7-4d48-8138-c4d5447a8f2e)

Once the package is layered, the package should function correctly.
![image](https://github.com/ublue-os/bazzite/assets/1501022/2b704cf1-e08c-4ea8-b0f9-f8e65e6d0d7f)

## File Changed
+ [Containerfile:488]


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
