### PR TITLE
fix: update sunshine workaround to handle symlinks

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/sunshine-workaround.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/sunshine-workaround.service
@@ -10,7 +10,7 @@ ExecStartPre=/usr/bin/bash -c "[ -x /usr/local/bin/.sunshine ] || /usr/bin/cp /u
 # This is faster than using .mount unit. Also allows for the previous line/cleanup
 ExecStartPre=/usr/bin/bash -c "/usr/bin/mount --bind /usr/local/bin/.sunshine /usr/bin/sunshine"
 # Fix caps
-ExecStart=/usr/sbin/setcap 'cap_sys_admin+p' /usr/bin/sunshine
+ExecStart=/usr/bin/bash -c "/usr/sbin/setcap 'cap_sys_admin+p' $(/usr/bin/readlink -f $(/usr/bin/which sunshine))"
 # Clean-up after ourselves
 ExecStop=/usr/bin/umount /usr/bin/sunshine
 ExecStop=/usr/bin/rm /usr/local/bin/.sunshine


### PR DESCRIPTION
current systemd unit seems to not like the sunshine symlink
![image](https://github.com/ublue-os/bazzite/assets/2557889/ca30dca3-5497-44fe-827e-0d8cdad43c65)

hopefully this should fix it (it seems to have done it for me)
![image](https://github.com/ublue-os/bazzite/assets/2557889/3e25903a-82ac-404f-aa43-c8b34690d837)



<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
