### PR TITLE
feat: add firstboot warning to users with polaris gpus about gamemode fix

### DIFF
--- a/system_files/deck/shared/usr/libexec/bazzite-sdl-gpu-warn
+++ b/system_files/deck/shared/usr/libexec/bazzite-sdl-gpu-warn
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+
+# The file to use for tracking if the warning has been shown
+ACCEPTED="$HOME/.config/bazzite/gamescope-sdl-accepted"
+
+# Check if the check has already run
+if [ -f "$ACCEPTED" ]; then
+    # Exit if user has already aknowledged the warning
+    exit 0
+fi
+
+# Show the SDL workaround warning if required
+if /usr/libexec/gamescope-sdl-workaround; then
+    # Add 4 spaces if you want to start a new line,
+    # it makes the text easier to read in the dialog.
+    zenity --text-info --title="WARNING: Problematic GPU detected!" --checkbox="Understood, I made sure to have a controller connected." --width 560 --height 430 <<< "
+    This GPU requires a workaround to work in Game Mode Session!
+    It is applied automatically, however it means that
+    keyboard and mouse will not work AT ALL when using
+    Game Mode Session (Desktop Mode will not be affected)
+
+    Please pair at least 1 bluetooth controller to the system now
+    so you can navigate Steam Game Mode.
+
+    If you plan to use a wired controller or one with a non
+    bluetooth dongle, verify it is detected in Steam BEFORE rebooting!"
+
+    # If the user mark the checkbox and clicks OK
+    # shellcheck disable=SC2181
+    if [ "$?" == "0" ]; then
+        # Make the .config/bazzite folder if needed
+        if [ ! -d "$HOME/.config/bazzite" ]; then
+            mkdir "$HOME/.config/bazzite/"
+        fi
+        # Mark that the user has acknowledged the warning
+        touch "$ACCEPTED"
+    fi
+fi

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/launcher/autostart.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/bash
 
+# Show a warning to people that need gamescope-sdl-workaround
+# Only runs if the script file from the deck image exists
+if [ -f "/usr/libexec/bazzite-sdl-gpu-warn" ]; then
+    # This will only show a warning if the user has not accepted the warning
+    /usr/libexec/bazzite-sdl-gpu-warn &
+fi
+
 # Simply launches the "yafti" GUI with the uBlue image's configuration.
 /usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml


### PR DESCRIPTION
Only triggers if `/usr/libexec/bazzite-sdl-gpu-warn` exists (it only exists on handheld images)
also triggers on any gpus defined in `/usr/libexec/gamescope-sdl-workaround` so the text is kept generic.

![image](https://github.com/ublue-os/bazzite/assets/2557889/73faa06e-9078-40da-aa5d-96f6bbed0b41)


Anomaly: Polaris users already on the `-deck` image will see the warning next time they go into desktop mode, they can accept it, click ok and move on with their day and not see it again.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
