### PR TITLE
fix(just): correctly detect if virt-manager is installed

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -41,9 +41,7 @@ setup-virtualization ACTION="":
       )
     fi
     if [[ "${OPTION,,}" =~ (^enable[[:space:]]virtualization|virt-on) ]]; then
-      (
-        virt_test=$(rpm-ostree status -v --jsonpath '.deployments[0].packages')
-        if [[ ${virt_test} == *virt-manager* ]]; then
+        if rpm -q virt-manager | grep -P "^virt-manager-" 1>/dev/null; then
           echo "Installing QEMU and virt-manager..."
           rpm-ostree install -y virt-manager edk2-ovmf qemu
           rpm-ostree kargs \
@@ -53,7 +51,6 @@ setup-virtualization ACTION="":
             && echo "libvirtd will be enabled at next reboot"
           echo 'Please reboot to apply changes'
         fi
-      )
     elif [[ "${OPTION,,}" =~ (^disable[[:space:]]virtualization|virt-off) ]]; then
       if [ "$(systemctl is-enabled libvirtd.service)" == "enabled" ]; then
         echo "${red}Disabling${n} libvirtd before removal"


### PR DESCRIPTION
Seems like PR #1237  did not reliably detect if virt-manager was installed on all images, so i changed it to a simple `rpm -q` check to fix it.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
