### PR TITLE
chore(deck): Change variant name to "Handheld & HTPC"

### DIFF
--- a/system_files/deck/kinoite/usr/etc/xdg/kcm-about-distrorc
+++ b/system_files/deck/kinoite/usr/etc/xdg/kcm-about-distrorc
@@ -2,4 +2,4 @@
 LogoPath=/usr/share/pixmaps/system-logo-white.png
 Name=Bazzite
 Website=https://bazzite.gg
-Variant=Steam Deck & HTPC Edition
+Variant=Handheld & HTPC Edition


### PR DESCRIPTION
For consistency purposes, it changes the `-deck` image to be known as the Handheld/HTPC variant since we now support more handhelds outside of the Steam Deck.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
