### PR TITLE
fix: setroubleshoot with no access to /var/lib/setroubleshoot

### DIFF
--- a/system_files/desktop/shared/usr/lib/tmpfiles.d/setroubleshoot-workaround.conf
+++ b/system_files/desktop/shared/usr/lib/tmpfiles.d/setroubleshoot-workaround.conf
@@ -1,0 +1,1 @@
+d /var/lib/setroubleshoot 0755 setroubleshoot setroubleshoot - -


### PR DESCRIPTION
setroubleshootd.service failed if `/var/lib/setroubleshoot` didn't exist owned by `setroubleshoot:setroubleshoot`