### PR TITLE
chore(ci): add a workflow to manually sign an image with Cosign

### DIFF
--- a/.github/workflows/sign_image.yml
+++ b/.github/workflows/sign_image.yml
@@ -1,0 +1,48 @@
+name: Sign Image
+
+# A workflow to sign an image on demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Image to sign, including the tag'
+        required: true
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get digest
+        id: get-digest
+        env:
+          IMAGE_TO_SIGN: ${{ inputs.image }}
+        run: |
+          digest=$(skopeo inspect docker://$IMAGE_TO_SIGN --format '{{.Digest}}')
+          name=$(skopeo inspect docker://$IMAGE_TO_SIGN --format '{{.Name}}')
+          echo "DIGEST=$digest" >> $GITHUB_OUTPUT
+          echo "NAME=$name" >> $GITHUB_OUTPUT
+
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
+      - name: Sign Image
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_SECRET }}
+          IMAGE_NAME: ${{ steps.get-digest.outputs.NAME }}
+          IMAGE_DIGEST: ${{ steps.get-digest.outputs.DIGEST }}
+        run: |
+          cosign sign -y --key env://SIGNING_KEY $IMAGE_NAME@$IMAGE_DIGEST


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Creates a GitHub Actions workflow to sign an individual image with Cosign.
Accepts an input string, containing the image name and tag (for example `ghcr.io/ublue-os/bazzite:20240230-something`), and will push an updated signature.

This _should_ allow maintainers to re-sign older images with the new cosign keys, allowing users to rebase from new to old versions.

Please test this in an image from the testing branch before running it on something people depend on.  I don't see what could go wrong, but you never know.