### PR TITLE
feat: Container indicator for fish shell

### DIFF
--- a/system_files/overrides/usr/share/fish/functions/fish_prompt.fish
+++ b/system_files/overrides/usr/share/fish/functions/fish_prompt.fish
@@ -1,0 +1,41 @@
+function fish_prompt --description 'Default prompt with container detection'
+    set -l last_pipestatus $pipestatus
+    set -lx __fish_last_status $status # Export for __fish_print_pipestatus.
+    set -l normal (set_color normal)
+    set -q fish_color_status
+    or set -g fish_color_status red
+    set -g fish_color_user brgreen
+
+    # Color the prompt differently when we're root
+    set -l color_cwd $fish_color_cwd
+    set -l suffix '>'
+    if functions -q fish_is_root_user; and fish_is_root_user
+        if set -q fish_color_cwd_root
+            set color_cwd $fish_color_cwd_root
+        end
+        set suffix '#'
+    end
+    
+    # Detect if we are in a container
+    if test -n "$CONTAINER_ID"
+        set -g prompt_host "[$CONTAINER_ID]"
+        set -g prefix_icon "📦 "
+    else 
+    	set -g prompt_host "$hostname"
+    	set -g prefix_icon ""
+    end
+
+    # Write pipestatus
+    # If the status was carried over (if no command is issued or if `set` leaves the status untouched), don't bold it.
+    set -l bold_flag --bold
+    set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
+    if test $__fish_prompt_status_generation = $status_generation
+        set bold_flag
+    end
+    set __fish_prompt_status_generation $status_generation
+    set -l status_color (set_color $fish_color_status)
+    set -l statusb_color (set_color $bold_flag $fish_color_status)
+    set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
+
+    echo -n -s $prefix_icon (set_color $fish_color_user) "$USER" $normal "@" $prompt_host' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
+end


### PR DESCRIPTION
Modified default fish shell prompt to indicate if a user is inside a container with a box icon and the container name, similar to how bash looks inside a distrobox container. Not sure if there was a better way to do this, but it works!

Here's a comparison of the stock fish shell vs when I'm in a container I made for LLM stuff.

![Screenshot from 2024-07-06 15-24-32](https://github.com/ublue-os/bazzite/assets/18043024/ff2b2341-9e31-48aa-a44c-686b4188319e)
![Screenshot from 2024-07-06 15-24-40](https://github.com/ublue-os/bazzite/assets/18043024/22fa881e-4c1e-4d2a-8767-de7fd0f37b32)


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
