### PR TITLE
fix(gpd) don't rotate GPU Win Mini 2024 7640U display

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -103,7 +103,7 @@ elif [[ ":ROG Ally X RC72LA:" =~ ":$SYS_ID:" ]]; then
     echo "Adding SG Display for ASUS Ally X"
     NEEDED_KARGS+=("--append-if-missing=amdgpu.sg_display=0")
   fi
-elif [[ ":G1617-01:" =~ ":$SYS_ID:" && ! $CPU_MODEL =~ 8640U|8840U ]]; then
+elif [[ ":G1617-01:" =~ ":$SYS_ID:" && ! $CPU_MODEL =~ 8640U|8840U|7640U ]]; then
   if [[ ! $KARGS =~ "video" ]]; then
     echo "Adding panel orientation for GPD Win Mini 2023"
     NEEDED_KARGS+=("--append-if-missing=video=eDP-1:panel_orientation=right_side_up")


### PR DESCRIPTION
The GPD Win Mini 2024 edition has a native landscape display. This means it doesn't need to be rotated like the 2023 edition.

They recently released a 7640U version, which is not being detected correctly. This patch correctly identifies this version and omits the rotation.

```
# Output after removing video from kargs with rpm-ostree kargs --editor
root@bazzite:~# /usr/libexec/bazzite-hardware-setup
Current kargs: rhgb quiet root=UUID=b6987ce0-6120-4483-a54f-d5fcb507ee0c rootflags=subvol=root rw iomem=relaxed bluetooth.disable_ertm=1
No karg changes needed
Generic device detected. Performing setup...
No fstab param adjustments needed
Current minimum-free ZRAM value: 130464
No minimum-free ZRAM changes needed
```