### PR TITLE
fix(GPD): add udev rules for disabling GPD fingerprint sensors

### DIFF
--- a/system_files/deck/shared/usr/lib/udev/rules.d/50-gpd-win-4-fingerprint.rules
+++ b/system_files/deck/shared/usr/lib/udev/rules.d/50-gpd-win-4-fingerprint.rules
@@ -1,0 +1,2 @@
+# Disable FP sensor on the GPD Win 4
+SUBSYSTEM=="usb", ATTR{idVendor}=="2808", ATTR{idProduct}=="9338", ATTR{remove}="1"

--- a/system_files/deck/shared/usr/lib/udev/rules.d/50-gpd-wm2-fingerprint.rules
+++ b/system_files/deck/shared/usr/lib/udev/rules.d/50-gpd-wm2-fingerprint.rules
@@ -1,0 +1,2 @@
+# Fixes a bug that causes suspend/resume to be inconsistent on the GPD Win Max 2
+SUBSYSTEM=="usb", ATTR{idVendor}=="2541", ATTR{idProduct}=="9711", ATTR{remove}="1"


### PR DESCRIPTION
The fingerprint scanners on the GPD Win 4 and GPD Win Max 2 are non-functional on Linux.

Disabling the FP scanners help fix suspend-resume issues on these devices.

Misc: While there is technically a driver for the GPD Win 4's FP sensor, it is proprietary and unmaintained: https://github.com/mrrbrilliant/ft9201-static