### PR TITLE
feat: Install `wqy-zenhei-fonts` for GoldSrc engine to display Chinese fonts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -322,6 +322,7 @@ RUN rpm-ostree install \
         xwiimote-ng \
         twitter-twemoji-fonts \
         google-noto-sans-cjk-fonts \
+        wqy-zenhei-fonts \
         lato-fonts \
         fira-code-fonts \
         nerd-fonts \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
## Main Purpose
Add `wqy-zenhei-fonts` package under `google-noto-cjk-fonts` to let GoldSrc engine display Chinese characters. 

## Why
Old GoldSrc engines (Half-Life, Counter-Strike 1.6, Condition Zero) and potentially some Source 1 games, are using `wqy-zenhei` to display Chinese characters. On default installation, the package is not included resulting in blank characters being displayed.
![image](https://github.com/user-attachments/assets/8fef811b-3a8a-4394-a237-a68d9a528204)

![image](https://github.com/user-attachments/assets/894e7bb2-0a81-4f21-ad6f-adc5643b1b31)


It's the well-known solution being mentioned multiple times on [Source-1 repo](https://github.com/ValveSoftware/Source-1-Games/issues?q=wqy-zenhei) and somewhere on the internet that I'm not able to find discussion threads anymore.

After layering the package `wqy-zenhei-fonts` the results are shown below.
![image](https://github.com/user-attachments/assets/7845dd4d-2a8e-4dca-8140-0fc831e23277)

![image](https://github.com/user-attachments/assets/e1617512-1bb6-456b-bf50-8da2316c647b)

## Side note
It also fixes not just Chinese but also special symbols.