### PR TITLE
fix(ujust): set install as the default action for the setup-decky ujust

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -155,7 +155,7 @@ setup-decky ACTION="install":
     fi
     OPTION={{ ACTION }}
     if [ "$OPTION" == "help" ]; then
-      echo "Usage: ujust configure-watchdog <option>"
+      echo "Usage: ujust setup-decky <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'install' to select Install Decky"
       exit 0

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -146,7 +146,7 @@ configure-watchdog ACTION="":
     fi
 
 # Install and configure Decky Loader (https://github.com/SteamDeckHomebrew/decky-loader) and plugins for alternative handhelds
-setup-decky ACTION="":
+setup-decky ACTION="install":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     DECKY_STATE="${b}${red}Not Installed${n}"


### PR DESCRIPTION
currently `ujust setup-decky` does nothing, whereas previously it defaulted to start installing decky

change the default action to be `install`

edit: just noticed the setup-decky usage doc was incorrect