### PR TITLE
feat(kde): add fcitx5-hangul for Korean input

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -485,6 +485,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
             joystickwake \
             fcitx5-mozc \
             fcitx5-chinese-addons \
+            fcitx5-hangul \
             ptyxis && \
         git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 --branch qt6 /tmp/wallpaper-engine-kde-plugin && \
         kpackagetool6 --type=Plasma/Wallpaper --global --install /tmp/wallpaper-engine-kde-plugin/plugin && \


### PR DESCRIPTION
Adds [fcitx5-hangul](https://github.com/fcitx/fcitx5-hangul) to enable Hangul (Korean) input in KDE.