### PR TITLE
Revert: chore: Fixed upstream

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -443,7 +443,10 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
         libobs_vkcapture.i686 \
         libobs_glcapture.i686 \
         mangohud.x86_64 \
-        mangohud.i686 && \
+        mangohud.i686 && \    
+        ln -s wine32 /usr/bin/wine && \
+	ln -s wine32-preloader /usr/bin/wine-preloader && \
+	ln -s wineserver64 /usr/bin/wineserver && \
     sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/winetricks.desktop && \
     curl -Lo /tmp/latencyflex.tar.xz $(curl https://api.github.com/repos/ishitatsuyuki/LatencyFleX/releases/latest | jq -r '.assets[] | select(.name| test(".*.tar.xz$")).browser_download_url') && \
     mkdir -p /tmp/latencyflex && \


### PR DESCRIPTION
This is not fixed upstream. Calling `wine32` to run a program doesn't run the wineserver automatically. If you run the wineserver manually it will look for `wine3264`.