### PR TITLE
feat(just): add ujust to reset steam

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -21,3 +21,30 @@ fix-proton-hang:
     for PROG in "${PROTONCORE[@]}"; do
       killall -9 "$PROG"
     done
+
+# Reset the Steam folder back to a fresh state
+fix-reset-steam:
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    STEAMPATH="$HOME/.local/share/Steam"
+    # Get a list of the contents of steams top level directory except a list of folders/files we can skip to avoid losing data
+    STEAMFILES=$(ls ~/.local/share/Steam/ | grep -vP "(userdata|compatibilitytools\.d|config|controller_base|steamapps|music)")
+    echo "This script will ${b}remove${n} a bunch of files from $STEAMPATH and sign you out of steam!"
+    echo "However your games, music, saves, controller profiles and compatibilitytools/custom-proton will not be touched."
+    echo "To cancel and abort this operation press CTRL+C now, to continue press ENTER."
+    read i
+    killall -9 steam
+    sleep 1
+    echo "Resetting Steam to a freshly installed state."
+    # Loop through each file and process it
+    for STEAMFILE in $STEAMFILES
+    do
+      if [ -d "$STEAMPATH/$STEAMFILE" ]; then
+        rm -rv "$STEAMPATH/$STEAMFILE"
+      elif [ -f "$STEAMPATH/$STEAMFILE" ]; then
+        rm -v "$STEAMPATH/$STEAMFILE"
+      fi
+    done
+    sleep 1
+    bazzite-steam &
+    exit 0


### PR DESCRIPTION
Kills steam, removes all files except userdata, games, controller profiles, music and compatibilitytools/custom-proton then starts steam again using `bazzite-steam`.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
