### PR TITLE
feat(nvidia): add script check for legacy nvidia hardware

### DIFF
--- a/system_files/nvidia/shared/usr/libexec/nvidia-legacy-hardware
+++ b/system_files/nvidia/shared/usr/libexec/nvidia-legacy-hardware
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+# Returns true if legacy nvidia hardware (older than turing) using die names
+# GK### (Kepler), GM### (Maxwell), GP### (Pascal)
+if lspci -nn | grep -P "(VGA compatible|3D) controller .+G(M|P|K)\d{3}"; then
+    exit 0
+fi
+exit 1

--- a/system_files/nvidia/shared/usr/libexec/nvidia-legacy-hardware
+++ b/system_files/nvidia/shared/usr/libexec/nvidia-legacy-hardware
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Returns true if legacy nvidia hardware (older than turing) using die names
 # GK### (Kepler), GM### (Maxwell), GP### (Pascal)
-if lspci -nn | grep -P "(VGA compatible|3D) controller .+G(M|P|K)\d{3}"; then
+if lspci -nn | grep -P "(VGA compatible|3D) controller .+G(M|P|K)\d{3}" > /dev/null; then
     exit 0
 fi
 exit 1

--- a/system_files/nvidia/shared/usr/libexec/nvidia-legacy-hardware
+++ b/system_files/nvidia/shared/usr/libexec/nvidia-legacy-hardware
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Returns true if legacy nvidia hardware (older than turing) using die names
-# GK### (Kepler), GM### (Maxwell), GP### (Pascal)
-if lspci -nn | grep -P "(VGA compatible|3D) controller .+G(M|P|K)\d{3}" > /dev/null; then
+# GK### (Kepler), GM### (Maxwell), GP### (Pascal), GV### (Volta)
+if lspci -nn | grep -P "(VGA compatible|3D) controller .+G(K|M|P|V)\d{3}" > /dev/null; then
     exit 0
 fi
 exit 1


### PR DESCRIPTION
Adds `/usr/libexec/nvidia-legacy-hardware` as a script on nvidia images.
will exit 1 if the machine has no legacy nvidia cards.

I did not add this to the non nvidia image as it is nvidia specific and we also do not want to risk the updater rebasing users from a non nvidia image to an nvidia image if they use the card for gpu passthrough.

once we have tested this here we can look into adding it to nvidia hwe or bluefin until migration period is over
PS: thankfully nvidia has way more sensible names than amd for their gpus as part of their PCI ID data
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
