### PR TITLE
fix(LGO): fix audio input and output priorities for Legion Go

### DIFF
--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/lenovo-83e1/wireplumber.conf.d/51-preferHDMI.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/lenovo-83e1/wireplumber.conf.d/51-preferHDMI.conf
@@ -1,0 +1,15 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "alsa_output.pci-0000_c2_00.1.hdmi-stereo"
+      }
+    ]
+    actions = {
+      update-props = {
+         priority.driver = 1100
+         priority.session = 1100
+      }
+    }
+  }
+]

--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/lenovo-83e1/wireplumber.conf.d/60-raise-internal-mic.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/lenovo-83e1/wireplumber.conf.d/60-raise-internal-mic.conf
@@ -1,0 +1,15 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "alsa_input.pci-0000_c2_00.6.analog-stereo"
+      }
+    ]
+    actions = {
+      update-props = {
+         priority.driver = 8901
+         priority.session = 8901
+      }
+    }
+  }
+]


### PR DESCRIPTION
Currently, there's an issue with the internal mic not being default in gamemode. Also, this gives priority to HDMI/external audio if Legion Go is attached to HDMI audio. Added 2 conf files to wireplumber.conf.d.

This is related to the post here: https://universal-blue.discourse.group/t/legion-go-microphone-does-not-default-to-correct-card-in-gamemode/3215/5

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
