### PR TITLE
feat(rechunk): enable previous layer checks and bump version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,14 @@ on:
       - ".github/workflows/build_iso.yml"
   merge_group:
   workflow_dispatch:
-    # TODO: Enable this when the prev tag is enabled in rechunk
-    # inputs:
-    #   fresh-rechunk:
-    #     description: 'Clear rechunk plan'
-    #     type: boolean
-    #     default: false
+    inputs:
+      # Run with this periodically to analyze the image again
+      # As package drift will make the plan eventually non-ideal
+      # (existing users will have to redownload most of the image)
+      fresh-rechunk:
+        description: 'Clear rechunk history'
+        type: boolean
+        default: false
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
@@ -204,7 +206,7 @@ jobs:
             sudo podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ matrix.kernel_flavor}}-${{ matrix.fedora_version }}
 
             # Add rechunk as well to remove this source of failure
-            sudo podman pull ghcr.io/hhd-dev/rechunk:v0.1.8
+            sudo podman pull ghcr.io/hhd-dev/rechunk:v0.2.1
 
       - name: Get source versions
         id: labels
@@ -257,14 +259,11 @@ jobs:
       # Reprocess raw-img using rechunker which will delete it
       - name: Run Rechunker
         id: rechunk
-        uses: hhd-dev/rechunk@v0.1.8
+        uses: hhd-dev/rechunk@v0.2.1
         with:
+          rechunk: 'ghcr.io/hhd-dev/rechunk:v0.2.1'
           ref: 'raw-img'
-          # TODO: After the tag marked with unstable/stable is built with rechunk
-          # remove the comment below to enable using the previous manifest
-          # to avoid layer shifts.
-          # prev-ref: ${{ github.event.inputs.fresh-rechunk == 'true' && '' || 'ghcr.io/ublue-os/bazzite:unstable' }}
-          rechunk: 'ghcr.io/hhd-dev/rechunk:v0.1.8'
+          prev-ref: ${{ github.event.inputs.fresh-rechunk == 'true' && '' || 'ghcr.io/ublue-os/bazzite:unstable' }}
           version: '${{ env.SOURCE_IMAGE_VERSION }}'
           labels: |
             io.artifacthub.package.logo-url=https://raw.githubusercontent.com/ublue-os/bazzite/main/repo_content/logo.png


### PR DESCRIPTION
Bumps rechunk to ver 0.2.1 which makes it fail gracefully if it does not find a previous manifest and enables previous plan lookup on the unstable branch to test successive builds.

Eventually, all branches should look to stable for their previous plan, as that will provide a good baseline for users from stable rebasing to them. But for now only the unstable manifest contains a previous plan.

PR will be upgraded from draft after rechunk CI runs