### PR TITLE
fix: Prevent bluetooth preventing suspension

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/bluetooth.service.d/prevent_hanging.conf
+++ b/system_files/desktop/shared/usr/lib/systemd/system/bluetooth.service.d/prevent_hanging.conf
@@ -1,0 +1,4 @@
+# Prevent freezing device with bluetooth controllers
+[Unit]
+Conflicts=sleep.target
+Before=sleep.target


### PR DESCRIPTION
Better fix than pr #1390 addressing both, controllers unable to disconnect on suspension and devices not being able of entering suspension