### PR TITLE
feat: Add ujust command for stress-ng benchmark

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -376,6 +376,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
         topgrade \
         ydotool \
         yafti \
+	stress-ng \
         lsb_release && \
     rpm-ostree install \
         ublue-update && \

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -358,3 +358,6 @@ bazzite-cli:
 
     # Entrypoint
     main ""
+benchmark:
+    echo 'Running a 1 minute benchmark ...'
+    cd /tmp && stress-ng --matrix 0 -t 1m --times


### PR DESCRIPTION
This adds a command to allow running a benchmark directly from ujust. Apprently this is a thing in other ublue variants, so I simply ported it over from bluefin.
