### PR TITLE
fix(LGO): reduce input source priority and add description

### DIFF
--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/lenovo-83e1/wireplumber.conf.d/60-raise-internal-mic.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/lenovo-83e1/wireplumber.conf.d/60-raise-internal-mic.conf
@@ -7,8 +7,9 @@ monitor.alsa.rules = [
     ]
     actions = {
       update-props = {
-         priority.driver = 8901
-         priority.session = 8901
+         node.description = "ALC257 Analog Internal Microphone"
+         priority.driver = 2100
+         priority.session = 2100
       }
     }
   }


### PR DESCRIPTION
Priority didn't need to be so high. Add a description to see it in wpctl status.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
