### PR TITLE
fix(Ally X): prefer HDMI audio when docked

### DIFF
--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/51-preferHDMI.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/51-preferHDMI.conf
@@ -1,0 +1,15 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "alsa_output.pci-0000_64_00.1.hdmi-stereo"
+      }
+    ]
+    actions = {
+      update-props = {
+         priority.driver = 1100
+         priority.session = 1100
+      }
+    }
+  }
+]

--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/alsa-card0.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/alsa-card0.conf
@@ -1,0 +1,18 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "alsa_output.pci-0000_64_00.6.analog-stereo"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.driver        = 900
+        priority.session       = 900
+        api.alsa.period-size   = 256
+        api.alsa.headroom      = 1024
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]

--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/alsa-card1.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/alsa-card1.conf
@@ -1,0 +1,37 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_input.*"
+        alsa.card_name = "acp5x"
+      }
+      {
+        node.name = "~alsa_input.*"
+        alsa.card_name = "acp6x"
+      }
+      {
+        node.name = "~alsa_input.*"
+        alsa.card_name = "sof-nau8821-max"
+      }
+      {
+        node.name = "~alsa_output.*"
+        alsa.card_name = "acp5x"
+      }
+      {
+        node.name = "~alsa_output.*"
+        alsa.card_name = "acp6x"
+      }
+      {
+        node.name = "~alsa_output.*"
+        alsa.card_name = "sof-nau8821-max"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds   = 0
+        api.alsa.headroom      = 1024
+      }
+    }
+  }
+]
+


### PR DESCRIPTION
Create rule for HDMI and new folder structure for wireplumber for Ally X.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
