### PR TITLE
feat(fish): enhanced fish performance

### DIFF
--- a/system_files/overrides/usr/share/fish/vendor_conf.d/brew.fish
+++ b/system_files/overrides/usr/share/fish/vendor_conf.d/brew.fish
@@ -1,18 +1,32 @@
 #!/usr/bin/fish
 #shellcheck disable=all
-if status --is-interactive
-    if [ -d /home/linuxbrew/.linuxbrew ]
+set -g __brew_instance_initialize 0
+set -g __brew_binary /home/linuxbrew/.linuxbrew/bin/brew
+
+function brew_new_instance
+  alias brew=$__brew_binary
+  if test $__brew_instance_initialize = 0
+    if status --is-interactive
+      if [ -d /home/linuxbrew/.linuxbrew ]
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         if [ -w /home/linuxbrew/.linuxbrew ]
-            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew ]
-                brew completions link > /dev/null
-            end
+          if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew ]
+            brew completions link > /dev/null
+          end
         end
         if test -d (brew --prefix)/share/fish/completions
-            set -p fish_complete_path (brew --prefix)/share/fish/completions
+          set -p fish_complete_path (brew --prefix)/share/fish/completions
         end
         if test -d (brew --prefix)/share/fish/vendor_completions.d
-            set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+          set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
         end
+      end
     end
+    set __brew_instance_initialize 1
+    brew $argv
+  end
 end
+
+alias brew=brew_new_instance
+
+


### PR DESCRIPTION
**fish shell** take long time to be ready since **homebrew** vendor script must be executed in every shell instance.

I substitute the brew instance by a function that evaluates those commands which are slowing down the fish initial runtime only when you call brew _"when you need it"_