### PR TITLE
fix: update bazzite-rollback-helper list to capture new image tags

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -39,10 +39,10 @@ EOF
 if [[ "$1" == "list" ]]; then
   if [ -z "$2" ]; then
       echo "Listing images for $DEFAULT_BRANCH"
-      skopeo list-tags docker://ghcr.io/ublue-os/bazzite | grep -- "-$DEFAULT_BRANCH-" | sort -rV
+      skopeo list-tags docker://ghcr.io/ublue-os/bazzite | grep -E "\"$DEFAULT_BRANCH-[0-9]+\.[0-9]+|-$DEFAULT_BRANCH-[0-9]+" | sort -rV
   else
       echo "Listing images for $2"
-      skopeo list-tags docker://ghcr.io/ublue-os/bazzite | grep -- "-$2-" | sort -rV
+      skopeo list-tags docker://ghcr.io/ublue-os/bazzite | grep -E "\"$2-[0-9]+\.[0-9]+|-$2-[0-9]+" | sort -rV
   fi
 
 elif [[ "$1" == "rollback" ]]; then


### PR DESCRIPTION
`bazzite-rollback-helper list`

lists available bazzite images that can be rebased back to.

However, due to a recent change in tag names, this is no longer capturing the newest tags.

previous tag format:   `"40-stable-20240809"`
new tag format: `"stable-40.20240809.0"`

This PR updates the command to capture both the previous and new tag formats.

Example of new output

```bash
$ bazzite-rollback-helper list
Listing images for stable
        "stable-40.20240815.0",
        "stable-40.20240809.0",
        "40-stable-20240809",
        "40-stable-20240807",
        "40-stable-20240804",
        "40-stable-20240803",
        "40-stable-20240802",
        "40-stable-20240801",
```