### PR TITLE
feat: allow external scripts to specify nested-desktop/waydroid dimensions

### DIFF
--- a/spec_files/steamdeck-kde-presets/nested-desktop-resolution.patch
+++ b/spec_files/steamdeck-kde-presets/nested-desktop-resolution.patch
@@ -8,14 +8,16 @@ index b833773..f7ae36f 100755
  
  set -eu
  
-@@ -28,8 +28,9 @@ ln -s $XDG_RUNTIME_DIR/pipewire* $NEW_XDG_RUNTIME_DIR/.
+@@ -28,8 +28,11 @@ ln -s $XDG_RUNTIME_DIR/pipewire* $NEW_XDG_RUNTIME_DIR/.
  ## whilst being launched by plasma-session
  mkdir $NEW_XDG_RUNTIME_DIR/bin
  cat <<EOF > $NEW_XDG_RUNTIME_DIR/bin/kwin_wayland_wrapper
 -#!/bin/sh
 -/usr/bin/kwin_wayland_wrapper --width 1280 --height 800 --no-lockscreen \$@
 +#!/usr/bin/bash
-+source /etc/default/steamos-nested-desktop
++if [ -z "${STEAMOS_NESTED_DESKTOP_WIDTH:-}" ] && [ -z "${STEAMOS_NESTED_DESKTOP_HEIGHT:-}" ]; then
++    source /etc/default/steamos-nested-desktop
++fi
 +/usr/bin/kwin_wayland_wrapper --width ${STEAMOS_NESTED_DESKTOP_WIDTH:-1280} --height ${STEAMOS_NESTED_DESKTOP_HEIGHT:-800} --no-lockscreen \$@
  EOF
  chmod a+x $NEW_XDG_RUNTIME_DIR/bin/kwin_wayland_wrapper

--- a/system_files/desktop/shared/usr/bin/waydroid-launcher
+++ b/system_files/desktop/shared/usr/bin/waydroid-launcher
@@ -2,7 +2,10 @@
 
 set -eux
 
-source /etc/default/waydroid-launcher
+# Import defaults if WIDTH/HEIGHT is not defined by an external script
+if [ -z "${WAYDROID_WIDTH:-}" ] || [ -z "${WAYDROID_HEIGHT:-}" ]; then
+    source /etc/default/waydroid-launcher
+fi
 
 # for backwards compatibility, default to show-full-ui
 if (($# == 0)); then

--- a/system_files/desktop/shared/usr/libexec/waydroid-container-start
+++ b/system_files/desktop/shared/usr/libexec/waydroid-container-start
@@ -1,7 +1,9 @@
 #!/usr/bin/bash
 
-source /etc/default/waydroid-launcher
-source /etc/default/steamos-nested-desktop
+# Import defaults if WIDTH/HEIGHT is not defined by an external script
+if [ -z "${WAYDROID_WIDTH:-}" ] || [ -z "${WAYDROID_HEIGHT:-}" ]; then
+    source /etc/default/waydroid-launcher
+fi
 
 # Ensure needed props are present
 if ! grep -q "persist.waydroid.udev=true" "/var/lib/waydroid/waydroid_base.prop"; then


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

This PR allows external scripts to specify the nested-desktop/waydroid screen dimensions by allowing overrides for the `_WIDTH` and `_HEIGHT` environment variables.

This allows for a user to provide their own launcher scripts which may detect the current display resolution using `xdpyinfo` or `wayland-info -i wl_output`. For example:

```bash
#!/bin/bash
set -euo pipefail

if [ -z "$DISPLAY" ]; then
  echo 'No $DISPLAY attached to current session.' >&2
  exit 1
fi

if [ -z "${GAMESCOPE_WAYLAND_DISPLAY:-}" ]; then
  zenity --error --text="This script can only be run in a gamescope session."
  exit 1
fi

_DISPLAY_RESOLUTION="$(xdpyinfo | awk '/dimensions/ {print $2}')"

export STEAMOS_NESTED_DESKTOP_WIDTH="${_DISPLAY_RESOLUTION%x*}"
export STEAMOS_NESTED_DESKTOP_HEIGHT="${_DISPLAY_RESOLUTION#*x}"

exec /usr/bin/steamos-nested-desktop
```