### PR TITLE
fix(rechunk): use correct previous ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
         with:
           rechunk: 'ghcr.io/hhd-dev/rechunk:v0.8.3'
           ref: 'raw-img'
-          prev-ref: ${{ github.event.inputs.fresh-rechunk == 'true' && '' || 'ghcr.io/ublue-os/bazzite:unstable' }}
+          prev-ref: ${{ github.event.inputs.fresh-rechunk == 'true' && '' || "${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:stable" }}
           version: '${{ steps.generate-version.outputs.tag }}'
           labels: |
             io.artifacthub.package.logo-url=https://raw.githubusercontent.com/ublue-os/bazzite/main/repo_content/logo.png


### PR DESCRIPTION
Leftover from previous PR had rechunk using the KDE package mapping from unstable for all images. This caused an increased update size.

Once verified to work, use the fresh-rechunk button to fix current mappings.