### PR TITLE
chore(rechunk): Always use stable tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
           if [ "${{ github.event.inputs.fresh-rechunk }}" == "true" ]; then
             IMAGEREF=""
           else
-            IMAGEREF="${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"
+            IMAGEREF="${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:stable"
           fi
 
           echo "ref=${IMAGEREF}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hi, thanks for fixing my syntax yesterday (as I have no way of checking locally). Oups.

Using stable as a reference was intentional. Since both unstable and testing are by their nature not stable and happen more often than main, having them diverge in their packaging increases the chance that a) rechunk will fail and will need cleanup sooner and b) when users switch between the 3 main branches they get a much larger download.

Therefore, always use stable when calculating the new plan.

As for the unique version tag, the IMAGEREF points to the same ghcr repo, so all of the tags get referenced always. This will not result in duplicate tags in testing/unstable.