### PR TITLE
fix(decky): change Decky's default 45 sec timeout to 5 seconds

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -138,6 +138,8 @@ setup-decky ACTION="install":
       fi
       curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh
       sudo chcon -R -t bin_t $HOME/homebrew/services/PluginLoader
+      sudo sed -i 's~TimeoutStopSec=.*$~TimeoutStopSec=5~g' /etc/systemd/system/plugin_loader.service
+      sudo systemctl daemon-reload
     fi
     if [[ "${OPTION,,}" =~ prerelease ]]; then
       export HOME=$(getent passwd ${SUDO_USER:-$USER} | cut -d: -f6)
@@ -147,6 +149,8 @@ setup-decky ACTION="install":
       fi
       curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh | sh
       sudo chcon -R -t bin_t $HOME/homebrew/services/PluginLoader
+      sudo sed -i 's~TimeoutStopSec=.*$~TimeoutStopSec=5~g' /etc/systemd/system/plugin_loader.service
+      sudo systemctl daemon-reload
     fi
 
 # Ptyxis terminal transparency


### PR DESCRIPTION
Decky, by default, has a 45 second timeout in it's systemd service. Decky doesn't seem to capture any signals such as SIGINT from the OS, and thus, is not shutting down gracefully.

This leads to perceived slowness when shutting down a device with Decky installed.

As a workaround, this PR changes the 45 second timeout with the `setup-decky` ujust

Decky issue for 45s timeout: https://github.com/SteamDeckHomebrew/decky-loader/issues/683