### PR TITLE
feat(ujust): add post-gamescope-logs ujust

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -342,3 +342,55 @@ bazzite-cli:
 benchmark:
     echo 'Running a 1 minute benchmark ...'
     cd /tmp && stress-ng --matrix 0 -t 1m --times
+
+post-gamescope-logs:
+    #!/usr/bin/bash
+    OUTPUT_FILE="/tmp/gathered_info.txt"
+
+    # Clear the output file or create it if it doesn't exist
+    > "$OUTPUT_FILE"
+
+    # Gather information from various sources
+    {
+        echo "GPU info"
+        lshw -C display
+
+        # Add a blank line for readability
+        echo
+
+        filepaths=(
+            "/sys/devices/virtual/dmi/id/bios_date"
+            "/sys/devices/virtual/dmi/id/board_name"
+            "/sys/devices/virtual/dmi/id/board_vendor"
+            "/sys/devices/virtual/dmi/id/product_name"
+            "$HOME/.gamescope-cmd.log"
+            "$HOME/.gamescope-stdout.log"
+        )
+
+        # Iterate over each file path in the array
+        for filepath in "${filepaths[@]}"; do
+            # Print the file path
+            echo "File: $filepath"
+
+            # Check if the file exists before trying to read it
+            if [[ -f "$filepath" ]]; then
+                # Print the file content
+                cat "$filepath"
+            else
+                echo "File not found: $filepath"
+            fi
+
+            # Add a blank line for readability
+            echo
+        done
+
+        echo "----- Contents of $HOME/.config/environment.d/ -----"
+        mkdir -p $HOME/.config/environment.d
+        cat "$HOME/.config/environment.d/"* 2>/dev/null || echo "No files found in $HOME/.config/environment.d/"
+
+    } >> "$OUTPUT_FILE"
+
+    fpaste $OUTPUT_FILE
+
+    # cleanup output file
+    rm -rf $OUTPUT_FILE


### PR DESCRIPTION
add a ujust that posts gamescope logs via fpaste, along with dmi info + gpu

`ujust post-gamescope-logs`

example output file:

```
GPU info
  *-display
       description: VGA compatible controller
       product: Rembrandt [Radeon 680M]
       vendor: Advanced Micro Devices, Inc. [AMD/ATI]
       physical id: 0
       bus info: pci@0000:74:00.0
       version: c1
       width: 64 bits
       clock: 33MHz
       capabilities: vga_controller bus_master cap_list
       configuration: driver=amdgpu latency=0
       resources: iomemory:7f0-7ef iomemory:7f0-7ef irq:43 memory:7fe0000000-7fefffffff memory:7ff0000000-7ff01fffff ioport:f000(size=256) memory:dc700000-dc77ffff

File: /sys/devices/virtual/dmi/id/bios_date
10/27/2022
 
File: /sys/devices/virtual/dmi/id/board_name
G1619-04
 
File: /sys/devices/virtual/dmi/id/board_vendor
GPD
 
File: /sys/devices/virtual/dmi/id/product_name
G1619-04
 
File: /home/aarron/.gamescope-cmd.log
/usr/bin/gamescope --bypass-steam-resolution --custom-refresh-rates 40,60 --disable-touch-click --prefer-output *,eDP-1 --xwayland-count 2 --default-touch-mode 4 --hide-cursor-delay 3000 --fade-out-duration 200 --steam -R /run/user/1000/gamescope.QtlHVRT/startup.socket -T /run/user/1000/gamescope.QtlHVRT/stats.pipe
 
File: /home/aarron/.gamescope-stdout.log
[gamescope] [[0;34mInfo[0m]  [0;37mconsole:[0m gamescope version 3.14.24+
ATTENTION: default value of option vk_xwayland_wait_ready overridden by environment.
ATTENTION: default value of option vk_xwayland_wait_ready overridden by environment.
ATTENTION: default value of option vk_xwayland_wait_ready overridden by environment.
ATTENTION: default value of option vk_xwayland_wait_ready overridden by environment.
ATTENTION: default value of option vk_xwayland_wait_ready overridden by environment.
[gamescope] [[0;34mInfo[0m]  [0;37mvulkan:[0m selecting physical device 'AMD Radeon Graphics (RADV REMBRANDT)': queue family 1 (general queue family 0)
...
```