### PR TITLE
ci(docs): Add retry logic to build_mkdocs

### DIFF
--- a/.github/workflows/build_mkdocs/action.yml
+++ b/.github/workflows/build_mkdocs/action.yml
@@ -63,7 +63,15 @@ runs:
         _OUTPUT_DIR: ${{ inputs.output_dir }}
       run: |
         source .venv/bin/activate
-        mkdocs build --verbose -d $_OUTPUT_DIR
+        max_tries=3
+        is_ok=0
+        while [[ $max_tries -gt 0 && is_ok -ne 1 ]]; do
+          if ! mkdocs build --verbose -d $_OUTPUT_DIR; then
+            max_tries=$(( $max_tries -1 ))
+          else
+            is_ok=1
+          fi
+        done
 
     - name: Setup Pages
       if: ${{ inputs.upload_github_page == 'true' }}


### PR DESCRIPTION
This change will run mkdocs build with 3 attempts in order to handle a possible timeout by discourse.