### PR TITLE
fix(cec-control): compare variable rather than variable name

### DIFF
--- a/system_files/desktop/shared/usr/bin/cec-control
+++ b/system_files/desktop/shared/usr/bin/cec-control
@@ -13,7 +13,7 @@ CEC_ONSLEEP_STANDBY=${CEC_ONSLEEP_STANDBY:-false}
 # Run specified actions
 if [ "${ACTION}" = "onboot" ] && [ "$CEC_WAKE" = true ]; then
     echo "on $CEC_TVID" | cec-client -s -d 1
-    if [ "CEC_SETSOURCE" = true ]; then
+    if [ "$CEC_SETSOURCE" = true ]; then
             echo "as" | cec-client -s -d 1
     fi
 elif [ "${ACTION}" = "onpoweroff" ] && [ "$CEC_ONPOWEROFF_STANDBY" = true ]; then


### PR DESCRIPTION
Recently acquired a Pulse Eight USB CEC device and found bazzite wasn't switching on boot or other events it looks like it was configured to do switching on.  Found a fix for the script that should enable it to work again and not only turn the TV on, but also switch inputs.