### PR TITLE
chore(docs): Rename user password doc

### DIFF
--- a/docs/src/Advanced/Reset_Forgotten_User_Password.md
+++ b/docs/src/Advanced/Reset_Forgotten_User_Password.md
@@ -1,0 +1,1 @@
+<!-- cmdrun fetch_discourse_md.py "https://universal-blue.discourse.group/docs?topic=161" -->

--- a/docs/src/Advanced/Reset_User_Password.md
+++ b/docs/src/Advanced/Reset_User_Password.md
@@ -1,1 +1,0 @@
-<!-- cmdrun fetch_discourse_md.py "https://universal-blue.discourse.group/docs?topic=161" -->

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,6 +62,6 @@ hide:
 
 ##### **_Follow the documentation below at your own risk!_**
 
-- [Reset User Password](Advanced/Reset_User_Password.md)
+- [Reset Forgotten User Password](Advanced/Reset_User_Password.md)
 - [Creating A Custom Bazzite Image](Advanced/creating_custom_image.md)
 - [Contributing to Bazzite](Advanced/Contributing_to_bazzite.md)


### PR DESCRIPTION
Since we now urge users to change their password if they install Bazzite without a physical keyboard, the name of this documentation is misleading.  This is strictly if the user **forgets** their password.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
