### PR TITLE
chore(docs): fix cmdrun breaking image url replacement

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -10,10 +10,7 @@ on:
     branches:
       - main
     paths:
-      - docs/**/*.md
-      - docs/**/*.png
-      - docs/**/*.jpg
-      - docs/**/*.jpeg
+      - docs/**
       - .github/workflows/deploy_docs.yml
       - README*.md
   workflow_dispatch:

--- a/docs/hooks/cmdrun.py
+++ b/docs/hooks/cmdrun.py
@@ -179,7 +179,7 @@ def _on_page_markdown_replace_urls(
     for src, dst in URL_MAPPINGS:
         if config.site_url:
             dst = f"{config.site_url.rstrip("/")}/{dst.lstrip("/")}"
-        res = re.sub(rf"\b{re.escape(src)}\b", dst, res)
+        res = re.sub(rf"\b{re.escape(src)}\b", dst, res, flags=re.UNICODE)
     return res
 
 


### PR DESCRIPTION
Likely was caused by the lack of `re.UNICODE` flag when searching for discourse urls to be replaced
![image](https://github.com/user-attachments/assets/8f5194f2-9522-474e-8ce7-6442cf507e1c)
