### PR TITLE
chore(docs): Add a shortcut for auto-mounting drives

### DIFF
--- a/docs/src/Gaming/Game_Launchers.md
+++ b/docs/src/Gaming/Game_Launchers.md
@@ -67,6 +67,10 @@ Right clicking a game on Lutris gives the option to add it as a non-Steam game (
 
 Games installed from the Microsoft Store do **not** run on desktop Linux unless you use a xCloud client like [Greenlight](https://github.com/unknownskl/greenlight).  Fortnite can also be played via xCloud without a Gamepass subscription using this method.
 
+# Auto-Mounting Game Drives
+
+Read the [Auto-Mounting Secondary Drives Guide](https://ublue-os.github.io/bazzite/Advanced/Auto-Mounting_Secondary_Drives/) for more information.  It is also recommended to do your own research on drive mounting on Linux.
+
 <hr>
 
 [**<-- Back to Gaming Guide**](https://universal-blue.discourse.group/docs?topic=31)


### PR DESCRIPTION
Probably a big mistake, but it's still somewhat hidden deep within one of the gaming guides (and the search).  Sick of seeing the question.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
