### PR TITLE
feat: add support for onexfly 8840U

### DIFF
--- a/system_files/deck/kinoite/usr/libexec/hardware/needs-left-rotation
+++ b/system_files/deck/kinoite/usr/libexec/hardware/needs-left-rotation
@@ -5,7 +5,8 @@ SYS_ID="$(/usr/libexec/hwsupport/sysid)"
 # Legion Go
 # Loki Max
 # AYANEO Air Plus
-if [[ ":83E1:Loki Max:AIR Plus:" =~ ":$SYS_ID:" ]]; then
+# Onexfly (8840u)
+if [[ ":83E1:Loki Max:AIR Plus:ONEXPLAYER F1L:" =~ ":$SYS_ID:" ]]; then
 	exit 0
 fi
 

--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -135,12 +135,14 @@ fi
 
 if [[ ":ONEXPLAYER F1:ONEXPLAYER F1L:" =~ ":$SYS_ID:" ]]; then
   if [[ ! $KARGS =~ "video" ]]; then
-    echo "Adding panel orientation for ONEXPLAYER F1"
+    echo "Adding panel orientation for ONEXPLAYER F1 & ONEXFLY"
     NEEDED_KARGS+=("--append-if-missing=video=eDP-1:panel_orientation=left_side_up")
   fi
-  if [[ ! $KARGS =~ "amdgpu.gttsize" ]]; then
-    echo "Adding GTTSize for ONEXPLAYER F1 (32GB RAM)"
-    NEEDED_KARGS+=("--append-if-missing=amdgpu.gttsize=16256")
+  if [[ "$(awk '/MemTotal/{print $(NF-1)}' /proc/meminfo)" == "31664740" ]]; then
+    if [[ ! $KARGS =~ "amdgpu.gttsize" ]]; then
+      echo "Adding GTTSize for ONEXPLAYER (32GB RAM)"
+      NEEDED_KARGS+=("--append-if-missing=amdgpu.gttsize=16256")
+    fi
   fi
 fi
 

--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -133,7 +133,7 @@ elif [[ ":WIN2:" =~ ":$SYS_ID:" ]]; then
   fi
 fi
 
-if [[ ":ONEXPLAYER F1:" =~ ":$SYS_ID:" ]]; then
+if [[ ":ONEXPLAYER F1:ONEXPLAYER F1L:" =~ ":$SYS_ID:" ]]; then
   if [[ ! $KARGS =~ "video" ]]; then
     echo "Adding panel orientation for ONEXPLAYER F1"
     NEEDED_KARGS+=("--append-if-missing=video=eDP-1:panel_orientation=left_side_up")

--- a/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Returns true for hardware that is supported by HHD
 SYS_ID="$(/usr/libexec/hwsupport/sysid)"
-if [[ ":ROG Ally RC71L:ROG Ally X RC72LA:83E1:G1618-04:G1617-01:G1619-05:AIR Plus:AIR 1S:AIR 1S Limited:AIR:AYANEO GEEK:AYANEO 2:AYANEO 2S:AOKZOE A1 AR07:AOKZOE A1 Pro:G1619-04:Win600:Loki Max:Loki Zero:Loki MiniPro:V3:" =~ ":$SYS_ID:" ]]; then
+if [[ ":ROG Ally RC71L:ROG Ally X RC72LA:83E1:G1618-04:G1617-01:G1619-05:AIR Plus:AIR 1S:AIR 1S Limited:AIR:AYANEO GEEK:AYANEO 2:AYANEO 2S:AOKZOE A1 AR07:AOKZOE A1 Pro:G1619-04:Win600:Loki Max:Loki Zero:Loki MiniPro:V3:ONEXPLAYER F1L:" =~ ":$SYS_ID:" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
However this sysid is shared between the 16gb model and the 32gb model ~~will this cause issues with the GTTSize being applied if this happens on a 16GB model? or will i have to separate out the 2 models in hardware setup by adding additional checks.~~

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
