### PR TITLE
chore(docs): New announcement for documentation

### DIFF
--- a/docs/theme_overrides/main.html
+++ b/docs/theme_overrides/main.html
@@ -2,7 +2,5 @@
 
 {% block announce %}
 <span class="twemoji">⚠️</span>
-This new documentation is in development and may have issues.
-Refer to the <a href="https://universal-blue.discourse.group/docs?topic=561">old Bazzite documentation</a> if you
-experience major issues.
+Welcome to the new home for Bazzite documentation!
 {% endblock %}


### PR DESCRIPTION
I am in the process of editing the rest of the documentation to have it on par with the final changes I made to the Discourse version before the Github transcription happens.  That PR will happen either later today or tomorrow, but by the end of the week the Discourse documentation will no longer be updated ever again and will remain the old, unlisted documentation.

The docs (or user guides as I view them) now live here and can be modified in any way that both consistent maintainers/contributors and new users who want to edit the documentation (and gets approved) sees fit.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
