### PR TITLE
feat(ujust): add ujust for ryzenadj --max-performance

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -79,6 +79,23 @@ disable-sdgyrodsu:
     #!/usr/bin/bash
     sudo systemctl mask --user sdgyrodsu.service
 
+# runs ryzenadj --max-performance on AC power
+enable-ryzenadj-max-performance:
+    #/bin/bash
+    # credit to adolforegosa on discord for the original fix
+    echo 'this fix sets ryzenadj --max-performance whenever AC status changes to battery from plugged-in'
+    echo 'SUBSYSTEM=="power_supply", ATTR{online}=="0", RUN+="/usr/bin/ryzenadj --max-performance"' | sudo tee "/etc/udev/rules.d/99-ryzenadj-power-source-change.rules" > /dev/null
+
+    sudo udevadm control --reload-rules
+    echo 'installation complete. Reboot to take effect'
+
+# disables ryzenadj --max-performance on AC power
+disable-ryzenadj-max-performance:
+    #/bin/bash
+    sudo rm /etc/udev/rules.d/99-ryzenadj-power-source-change.rules
+    sudo udevadm control --reload-rules
+    echo 'removal complete'
+
 # Re-enable input remapper feature on non-desktop images
 restore-input-remapper:
     systemctl enable --now input-remapper.service && \


### PR DESCRIPTION
On certain devices, such as the ROG Ally X and ROG Ally, as well as some AMD laptops, performance becomes more unstable/worse when the device is taken off AC power.

This workaround adds a udev rule that runs `ryzenadj --max-performance` when a device is taken off AC power, which basically tells the APU to continue behaving as if it's on AC power.

original source of fix: https://github.com/aarron-lee/legion-go-tricks/blob/main/ryzenadj-max-performance.sh