### PR TITLE
fix(deck): update just recipe to infer DeckHD bios install

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -33,8 +33,8 @@ install-deckhd-bios:
     #!/usr/bin/bash
     SYS_ID="$(/usr/libexec/hwsupport/sysid)"
     if [[ ":Jupiter:" =~ ":$SYS_ID:" ]]; then
-      RESOLUTION=$(sudo lshw -json -c display | jq -r .[]."configuration"."resolution")
-      if [[ "${RESOLUTION}" = "1200,1920" ]]; then
+      RESOLUTION=$(xrandr --display :0 | grep '*' | uniq | awk '{print $1}')
+      if [[ "${RESOLUTION}" = "1920x1200" ]]; then
         sudo systemctl mask --now jupiter-biosupdate.service
         wget -q https://deckhd.com/downloads/install.sh -O /tmp/deckhd-install.sh
         chmod +x /tmp/deckhd-install.sh
@@ -51,8 +51,8 @@ enable-deck-bios-firmware-updates:
     #!/usr/bin/bash
     SYS_ID="$(/usr/libexec/hwsupport/sysid)"
     if [[ ":Jupiter:" =~ ":$SYS_ID:" || ":Galileo:" =~ ":$SYS_ID:" ]]; then
-      RESOLUTION=$(sudo lshw -json -c display | jq -r .[]."configuration"."resolution")
-      if [[ "${RESOLUTION}" = "1200,1920" ]]; then
+      RESOLUTION=$(xrandr --display :0 | grep '*' | uniq | awk '{print $1}')
+      if [[ "${RESOLUTION}" = "1920x1200" ]]; then
         echo "DeckHD detected. Firmware updates enabled. BIOS updates not enabled."
       elif [[ "$(awk '/MemTotal/{print $(NF-1)}' /proc/meminfo)" == "31664740" ]]; then
         echo "32GB RAM modded Deck detected. Firmware updates enabled. BIOS updates not enabled."


### PR DESCRIPTION
The `just` recipe for `install-deckhd-bios` fails because it can't correctly infer the resolution (#1679). By using `xrandr`, we can correctly infer the resolution and install the correct bios.