### PR TITLE
fix: btrfs-dedup don't wait on compsize since compsize doesn't run

### DIFF
--- a/system_files/desktop/shared/usr/bin/btrfs-dedup
+++ b/system_files/desktop/shared/usr/bin/btrfs-dedup
@@ -274,7 +274,7 @@ fi
 	cmd find "$TARGET"/ -mindepth 1 -maxdepth 1 -mtime +"$DB_MAX_AGE" \( -name "$RMLINT_DB" -or -name "$DUPEREMOVE_DB" \) -delete
 	powerchange || true
 	# cmd compsize "$TARGET"/ &
-	worker_waiter
+	# worker_waiter
 	if ! is_true "$RMLINT_SKIP"; then
 		if ! is_true "$RMLINT_REPLAY_DISABLE" && [[ -f "$TARGET"/"$RMLINT_DB" ]]; then
 			# shellcheck disable=SC2086
@@ -314,7 +314,7 @@ fi
 		cmd cp -a "$DUPEREMOVE_DB" "$TARGET"/
 		cmd rm -f "$DUPEREMOVE_DB"
 		# cmd compsize "$TARGET"/ &
-		worker_waiter
+		# worker_waiter
 	fi
 ) &
 MAINPID="$!"


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
