### PR TITLE
fix: add potentially missing selinux labels back to nvidia-modeset

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -7,7 +7,7 @@ IMAGE_FLAVOR=$(jq -r '."image-flavor"' < $IMAGE_INFO)
 FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 
 # SCRIPT VERSION
-HWS_VER=49
+HWS_VER=50
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VER_FILE)
 
@@ -259,6 +259,15 @@ fi
 if [[ -f "/var/lib/waydroid/lxc/waydroid/config" ]]; then
   echo "Removing unneeded apparmor entry from Waydroid LXC"
   sed -i '/lxc\.apparmor\.profile\s*=\s*unconfined/d' "/var/lib/waydroid/lxc/waydroid/config"
+fi
+
+# NVIDIA SELINUX FIX
+# Apparently there are missing selinux labels on some nvidia cards which causes
+# at least sddm to crash a lot when connected to a VRR display?
+# Adding the labels almost removes the crashes apparently
+if [[ $IMAGE_NAME =~ "nvidia" ]]; then
+  echo "Fix nvidia-modeset SELinux labels"
+  systemctl enable --now nvidia-modeset-restorecon.service
 fi
 
 # HOSTNAME FIX

--- a/system_files/nvidia/shared/usr/lib/systemd/system/nvidia-modeset-restorecon.service
+++ b/system_files/nvidia/shared/usr/lib/systemd/system/nvidia-modeset-restorecon.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Runs restorecon on nvidia-modeset at boot
+After=local-fs.target
+ConditionPathExists=/dev/nvidia-modeset
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/nvidia-modeset-restorecon
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/nvidia/shared/usr/libexec/nvidia-modeset-restorecon
+++ b/system_files/nvidia/shared/usr/libexec/nvidia-modeset-restorecon
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+# Wait for the nvidia-modeset device node to exist
+while [ ! -e "/dev/nvidia-modeset" ]; do
+    sleep 1
+done
+
+# Apply the fix and write the output to the journal, viewable with "journalctl -t nvidia-modeset-restorecon"
+semanage fcontext -a -t SIMILAR_TYPE 'nvidia-modeset'
+restorecon -v '/dev/nvidia-modeset' | systemd-cat -t nvidia-modeset-restorecon -p info


### PR DESCRIPTION
Apparently this stops sddm from crashing a lot when logging in with a VRR monitor conntected (gdm untested as everyone affected were on kde)

PRing into testing since i have not gotten proper verification that this fully fixes the issue.
can be tracked here: https://www.answeroverflow.com/m/1285186896137425016