### PR TITLE
chore: remove framework akmod install

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -312,7 +312,6 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
         /tmp/akmods-rpms/kmods/*openrazer*.rpm \
         /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
         /tmp/akmods-rpms/kmods/*wl*.rpm \
-        /tmp/akmods-rpms/kmods/*framework-laptop*.rpm \
         /tmp/akmods-extra-rpms/kmods/*gcadapter_oc*.rpm \
         /tmp/akmods-extra-rpms/kmods/*nct6687*.rpm \
         /tmp/akmods-extra-rpms/kmods/*zenergy*.rpm \


### PR DESCRIPTION
Removes the framework akmod installation since this is being removed from the ublue-os/akmods repo in [this PR](https://github.com/ublue-os/akmods/pull/239).

All changes required for Frameworks should have been moved upstream, so this is redundant.
Bluefin has already removed this akmod a while back.