### PR TITLE
feat: Add HPET configuration from Atomic Studio

### DIFF
--- a/system_files/deck/shared/usr/lib/sysctl.d/65-hpet.conf
+++ b/system_files/deck/shared/usr/lib/sysctl.d/65-hpet.conf
@@ -1,0 +1,1 @@
+dev.hpet.max-user-freq=3072

--- a/system_files/deck/shared/usr/lib/sysctl.d/65-hpet.conf
+++ b/system_files/deck/shared/usr/lib/sysctl.d/65-hpet.conf
@@ -1,1 +1,0 @@
-dev.hpet.max-user-freq=3072

--- a/system_files/desktop/shared/usr/lib/sysctl.d/65-hpet.conf
+++ b/system_files/desktop/shared/usr/lib/sysctl.d/65-hpet.conf
@@ -1,0 +1,1 @@
+dev.hpet.max-user-freq=3072


### PR DESCRIPTION
_I have to preface this by stating that I do not understand the underlying mechanisms adequately myself_ - but after speaking to the Atomic Studio dev last month, I'm told this tweak might help those facing audio issues, particularly on constrained handhelds - and that it should have no ill effect otherwise.

Atomic Studio currently implements it [here](https://github.com/atomic-studio-org/Atomic-Studio/blob/5a215a9a8442c7753d45c6f00d4529d2bc80d55d/files/files/shared/etc/sysctl.d/50-atomicstudio.conf).