### PR TITLE
fix(just): Ignore locked keys when loading dconfs

### DIFF
--- a/system_files/deck/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
+++ b/system_files/deck/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
@@ -3,16 +3,16 @@
 # Restore Bazzite customized DE settings
 restore-gnome-de-settings:
     for file in /usr/share/ublue-os/dconfs/desktop-silverblue/*; do
-    dconf load / < "${file}"
+    dconf load -f / < "${file}"
     done
     for file in /usr/share/ublue-os/dconfs/deck-silverblue/*; do
-    dconf load / < "${file}"
+    dconf load -f / < "${file}"
     done
 
 # Restore Bazzite customized applications folders
 restore-gnome-folders:
-    dconf load / < /usr/share/ublue-os/dconfs/desktop-silverblue/zz0-02-bazzite-desktop-silverblue-folders
-    dconf load / < /usr/share/ublue-os/dconfs/desktop-silverblue/01-bazzite-desktop-silverblue-folders
+    dconf load -f / < /usr/share/ublue-os/dconfs/desktop-silverblue/zz0-02-bazzite-desktop-silverblue-folders
+    dconf load -f / < /usr/share/ublue-os/dconfs/desktop-silverblue/01-bazzite-desktop-silverblue-folders
 
 # Change automatic power profile switching behavior
 configure-auto-power-profile ACTION="help":

--- a/system_files/desktop/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
+++ b/system_files/desktop/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
@@ -3,13 +3,13 @@
 # Restore Bazzite customized DE settings
 restore-gnome-de-settings:
     for file in /usr/share/ublue-os/dconfs/desktop-silverblue/*; do
-    dconf load / < "${file}"
+    dconf load -f / < "${file}"
     done
 
 # Restore Bazzite customized applications folders
 restore-gnome-folders:
-    dconf load / < /usr/share/ublue-os/dconfs/desktop-silverblue/zz0-02-bazzite-desktop-silverblue-folders
-    dconf load / < /usr/share/ublue-os/dconfs/desktop-silverblue/01-bazzite-desktop-silverblue-folders
+    dconf load -f / < /usr/share/ublue-os/dconfs/desktop-silverblue/zz0-02-bazzite-desktop-silverblue-folders
+    dconf load -f / < /usr/share/ublue-os/dconfs/desktop-silverblue/01-bazzite-desktop-silverblue-folders
 
 # Change automatic power profile switching behavior
 configure-auto-power-profile ACTION="help":


### PR DESCRIPTION
This assures that dconf load will always work.

`restore-gnome-folders` dconf load works.

But I have problems with `restore-gnome-de-settings` in `bazzite-gnome` image, I get

```
sh: -c: line 2: syntax error: unexpected end of file
error: Recipe `restore-gnome-de-settings` failed on line 5 with exit code 2
```

Idk where's the syntax problem here, as the for/done loop works in terminal when I try it.