### PR TITLE
chore: Cleanup version information to be more intuitive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,11 +207,11 @@ jobs:
             VERSION="pr-${FEDORA_VERSION}-${{ github.event.pull_request.number }}"
             PRETTY_VERSION="PR (${{ github.event.pull_request.number }}, ${UPSTREAM_TAG})"
           elif [[ ${{ github.ref_name }} == "unstable" ]]; then
-            VERSION="unstable-${SHA_SHORT}"
-            PRETTY_VERSION="Unstable (#${SHA_SHORT}, F${UPSTREAM_TAG})"
+            VERSION="unstable-${UPSTREAM_TAG}"
+            PRETTY_VERSION="Unstable (F${UPSTREAM_TAG}, #${SHA_SHORT})"
           elif [[ ${{ github.ref_name }} == "testing" ]]; then
             VERSION="testing-${UPSTREAM_TAG}"
-            PRETTY_VERSION="Testing (F${UPSTREAM_TAG})"
+            PRETTY_VERSION="Testing (F${UPSTREAM_TAG}, #${SHA_SHORT})"
           else
             VERSION="${UPSTREAM_TAG}"
             PRETTY_VERSION="Stable (F${UPSTREAM_TAG})"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,9 @@ jobs:
           # Generate the primary version key that will be stored on os-release,
           # shown on the bootloader, and used for the image tag.
           UPSTREAM_TAG="${{ env.SOURCE_IMAGE_VERSION }}"
+          # Remove .0 suffix from upstream tag so we can add our own and
+          # the wrong one does not end up in the image.
+          UPSTREAM_TAG="${UPSTREAM_TAG%.*}"
           FEDORA_VERSION="${{ matrix.fedora_version }}"
           SHA_SHORT="${GITHUB_SHA::7}"
 

--- a/system_files/desktop/shared/usr/libexec/containerbuild/image-info
+++ b/system_files/desktop/shared/usr/libexec/containerbuild/image-info
@@ -61,9 +61,7 @@ sed -i "s/^ANSI_COLOR=.*/ANSI_COLOR=\"$LOGO_COLOR\"/" /usr/lib/os-release
 sed -i "/^REDHAT_BUGZILLA_PRODUCT=/d; /^REDHAT_BUGZILLA_PRODUCT_VERSION=/d; /^REDHAT_SUPPORT_PRODUCT=/d; /^REDHAT_SUPPORT_PRODUCT_VERSION=/d" /usr/lib/os-release
 sed -i "s|^VERSION_CODENAME=.*|VERSION_CODENAME=\"$CODE_NAME\"|" /usr/lib/os-release
 
-if [[ -n "${SHA_HEAD_SHORT:-}" ]]; then
-  echo "BUILD_ID=\"$SHA_HEAD_SHORT (Built $(date +%m-%d-%Y))\"" >> /usr/lib/os-release
-fi
+echo "BUILD_ID=\"$VERSION_PRETTY\"" >> /usr/lib/os-release
 
 # FIXME: Pretty name needs to have deck/KDE/GNOME/etc
 echo "BOOTLOADER_NAME=\"$IMAGE_PRETTY_NAME $VERSION_PRETTY\"" >> /usr/lib/os-release


### PR DESCRIPTION
Modifies build-id to contain a pretty version of the version information. Then, changes that pretty version (in testing) to contain the git hash of the commit that built the image.

To make the image repo sync with what the device reports, the suffix is removed from the upstream build ID and a shortened SHA suffix is added to the tag for testing and unstable.

After these changes, there is no practical difference between testing and unstable, so their options are synced.