### PR TITLE
chore: gate stable and add promotion action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
             BUILD_TAGS+=("stable-${FEDORA_VERSION}") # flip ver to be last
             
             if [ -n "$LATEST" ]; then
-              BUILD_TAGS+=("latest" "stable")
+              BUILD_TAGS+=("latest" "edge")
             fi
           fi
           

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,62 @@
+name: Promote Edge builds to Stable
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-promote
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - bazzite
+          - bazzite-nvidia
+          - bazzite-nvidia-open
+          - bazzite-gnome
+          - bazzite-gnome-nvidia
+          - bazzite-gnome-nvidia-open
+          - bazzite-deck
+          - bazzite-deck-gnome
+          - bazzite-ally
+          - bazzite-ally-gnome
+          - bazzite-asus
+          - bazzite-gnome-asus
+          - bazzite-asus-nvidia
+          - bazzite-gnome-asus-nvidia
+          - bazzite-asus-nvidia-open
+          - bazzite-gnome-asus-nvidia-open
+        major_version: [40]
+    steps:
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
+      # https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Push Edge to Stable
+        uses: Wandalen/wretry.action@v3.5.0
+        id: push
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ github.token }}
+        with:
+          attempt_limit: 3
+          attempt_delay: 15000
+          commands: |
+            sudo skopeo copy \
+              ${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}:edge \
+              ${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}:stable


### PR DESCRIPTION
The autoupdater pushed a partial update today, and the previous update broke the framework kmod (because it is now "upstream")

The update regression rate is too high for the current state of bazzite, for the vast majority of its users.

That being said, there are a lot of users that like to be a bit ahead.

Therefore, gate the stable builds behind an `edge` tag for power users, and add a small action to promote the current `edge` build to `stable` once it has been validated to work.

Just in time for F41. 

The regression in this update was small: the Ally frame limiter stopped working and we were caught by surprise. It would have been worse, as with F41. The edge channel also allows us to update that channel to F41 earlier than Fedora.