### PR TITLE
chore(hhd): add OneXPlayer, Ayaneo,  and GPD to hhd supported devices

### DIFF
--- a/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
@@ -1,5 +1,10 @@
 #!/usr/bin/bash
 # Returns true for hardware that is supported by HHD
+VEN_ID="$(cat /sys/devices/virtual/dmi/id/sys_vendor)"
+if [[ ":ONE-NETBOOK:GPD:AYANEO:" =~ ":$VEN_ID:" ]]; then
+	exit 0
+fi
+
 SYS_ID="$(/usr/libexec/hwsupport/sysid)"
 if [[ ":ROG Ally RC71L:ROG Ally X RC72LA:83E1:G1618-04:G1617-01:G1619-05:AIR Plus:AIR 1S:AIR 1S Limited:AIR:AYANEO GEEK:AYANEO 2:AYANEO 2S:AOKZOE A1 AR07:AOKZOE A1 Pro:G1619-04:Win600:Loki Max:Loki Zero:Loki MiniPro:V3:ONEXPLAYER F1:ONEXPLAYER F1L:ONEXPLAYER F1 EVA-01:" =~ ":$SYS_ID:" ]]; then
 	exit 0


### PR DESCRIPTION
Bazzite is currently missing way too many devices. We support the whole catalog for all three manufacturers so add all of their devices to the auto-detection.