### PR TITLE
chore: remove sudo from bazzite setup script

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -242,8 +242,8 @@ if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
     if [[ $SYS_ID == "Laptop ("* ]]; then
       if [[ ! -f /etc/modprobe.d/alsa.conf ]]; then
         echo 'Fixing 3.5mm jack'
-        sudo tee /etc/modprobe.d/alsa.conf <<< "options snd-hda-intel index=1,0 model=auto,dell-headset-multi"
-        echo 0 | sudo tee /sys/module/snd_hda_intel/parameters/power_save
+        echo "options snd-hda-intel index=1,0 model=auto,dell-headset-multi" > /etc/modprobe.d/alsa.conf
+        echo 0 > /sys/module/snd_hda_intel/parameters/power_save
       fi
       if [[ ! -f /etc/udev/rules.d/20-suspend-fixes.rules ]]; then
         echo 'Fixing suspend issue'
@@ -251,13 +251,6 @@ if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
       fi
     fi
   fi
-fi
-
-# ALLY POWER SAVE FIX
-if [[ ":ROG Ally X RC72LA:" =~ ":$SYS_ID:" ]]; then
-  # Disable amd_pmf until patched upstream
-  modprobe -r amd_pmf
-  echo "blacklist amd_pmf" | sudo tee /etc/modprobe.d/hhd-blacklist.conf
 fi
 
 # WAYDROID FIX


### PR DESCRIPTION
bazzite setup seems to run with root priviledges as it writes to /etc directly. However some commands use sudo.

For some reason, using sudo delays boot by over 2 minutes in certain instances. So remove it.

Also remove pmf script from Ally since it is part of 6.11.