### PR TITLE
chore: update f40 pipewire to version 1.0.9

### DIFF
--- a/spec_files/pipewire/pipewire.spec
+++ b/spec_files/pipewire/pipewire.spec
@@ -1,6 +1,6 @@
 %global majorversion 1
 %global minorversion 0
-%global microversion 8
+%global microversion 9
 
 %global apiversion   0.3
 %global spaversion   0.2
@@ -423,26 +423,26 @@ cp %{SOURCE1} subprojects/packagefiles/
 
 %build
 %meson \
-    -D docs=enabled -D man=enabled -D gstreamer=enabled -D systemd=enabled  \
-    -D sdl2=disabled                                \
-    -D audiotestsrc=disabled -D videotestsrc=disabled               \
-    -D volume=disabled -D bluez5-codec-aptx=disabled                \
-    -D bluez5-codec-lc3plus=disabled -D bluez5-codec-lc3=enabled        \
+    -D docs=enabled -D man=enabled -D gstreamer=enabled -D systemd=enabled	\
+    -D sdl2=disabled 								\
+    -D audiotestsrc=disabled -D videotestsrc=disabled				\
+    -D volume=disabled -D bluez5-codec-aptx=disabled 		  		\
+    -D bluez5-codec-lc3plus=disabled -D bluez5-codec-lc3=enabled		\
 %ifarch s390x
-    -D bluez5-codec-ldac=disabled                       \
+    -D bluez5-codec-ldac=disabled						\
 %endif
-    -D session-managers=[]                          \
-    -D rtprio-server=60 -D rtprio-client=55 -D rlimits-rtprio=70        \
-    %{!?with_jack:-D pipewire-jack=disabled}                    \
-    %{!?with_jackserver_plugin:-D jack=disabled}                \
-    %{!?with_libcamera_plugin:-D libcamera=disabled}                \
-    %{?with_jack:-D jack-devel=true}                        \
-    %{!?with_alsa:-D pipewire-alsa=disabled}                    \
-    %{?with_vulkan:-D vulkan=enabled}                       \
-    %{!?with_libmysofa:-D libmysofa=disabled}                   \
-    %{!?with_lv2:-D lv2=disabled}                       \
-    %{!?with_roc:-D roc=disabled}                       \
-    %{!?with_ffado:-D libffado=disabled}                    \
+    -D session-managers=[] 							\
+    -D rtprio-server=60 -D rtprio-client=55 -D rlimits-rtprio=70		\
+    %{!?with_jack:-D pipewire-jack=disabled} 					\
+    %{!?with_jackserver_plugin:-D jack=disabled} 				\
+    %{!?with_libcamera_plugin:-D libcamera=disabled} 				\
+    %{?with_jack:-D jack-devel=true} 						\
+    %{!?with_alsa:-D pipewire-alsa=disabled}					\
+    %{?with_vulkan:-D vulkan=enabled}						\
+    %{!?with_libmysofa:-D libmysofa=disabled}					\
+    %{!?with_lv2:-D lv2=disabled}						\
+    %{!?with_roc:-D roc=disabled}						\
+    %{!?with_ffado:-D libffado=disabled}					\
     %{nil}
 %meson_build
 
@@ -833,6 +833,9 @@ systemctl --no-reload preset --global pipewire.socket >/dev/null 2>&1 || :
 %endif
 
 %changelog
+* Tue Oct 22 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.9-1
+- Update version to 1.0.9
+
 * Thu Sep 19 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.8-1
 - Update version to 1.0.8
 


### PR DESCRIPTION
This tracks upstream changes:
https://src.fedoraproject.org/rpms/pipewire/c/c27f71fbf47e75c0684c44b8b3c4afc098ddf3fc?branch=f40

The only change is version and changelog.
(And some whitespace only changes from me using the upstream copy of spec)


The lack of this update is causing build failures for anyone using the bazzite-multilib COPR. (me, that's how I found this)
And it will maybe also cause issues for bazzite builds.

As such, this change should probably be merged to both `main` and `testing` branches.

Let me know the best workflow here... I can open a PR against both if helpful etc.