### PR TITLE
chore(changelog): Tweak changelog with rebase command, ignore refs in target

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -42,17 +42,9 @@ CHANGELOG_TITLE = "{tag}: {pretty}"
 CHANGELOG_FORMAT = """\
 {handwritten}
 
-From previous `{target}` version `{prev}` there have been the following changes. **One package per new version shown.**
-
 Visit [bazzite.gg](https://bazzite.gg) for more information and to download Bazzite.
 
-For current users, type the following to rebase to this version:
-```bash
-# For this branch (if latest):
-bazzite-rollback-helper rebase {target}
-# For this specific image:
-bazzite-rollback-helper rebase {curr}
-```
+From previous `{target}` version `{prev}` there have been the following changes. **One package per new version shown.**
 
 ### Major packages
 | Name | Version |
@@ -66,6 +58,15 @@ bazzite-rollback-helper rebase {curr}
 | **[HHD](https://github.com/hhd-dev/hhd)** | {pkgrel:hhd} |
 
 {changes}
+
+### How to update
+For current users, type the following to rebase to this version:
+```bash
+# For this branch (if latest):
+bazzite-rollback-helper rebase {target}
+# For this specific image:
+bazzite-rollback-helper rebase {curr}
+```
 """
 HANDWRITTEN_PLACEHOLDER = """\
 This is an automatically generated changelog for release `{curr}`."""

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -295,6 +295,10 @@ def get_commits(prev_manifests, manifests, workdir: str):
             if not commit:
                 continue
             hash, short, subject = commit.split(" ", 2)
+
+            if subject.lower().startswith("merge"):
+                continue
+
             out += (
                 COMMIT_FORMAT.replace("{short}", short)
                 .replace("{subject}", subject)

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -46,6 +46,14 @@ From previous `{target}` version `{prev}` there have been the following changes.
 
 Visit [bazzite.gg](https://bazzite.gg) for more information and to download Bazzite.
 
+For current users, type the following to rebase to this version:
+```bash
+# For this branch (if latest):
+bazzite-rollback-helper rebase {target}
+# For this specific image:
+bazzite-rollback-helper rebase {curr}
+```
+
 ### Major packages
 | Name | Version |
 | --- | --- |

--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Get target
         id: get-target
         run: |
-          echo "target=${{ github.event.inputs.target || github.ref }}" > $GITHUB_OUTPUT
+          TARGET="${{ github.event.inputs.target || github.ref }}"
+          TARGET="${TARGET##*/}"
+          echo "target=$TARGET" >> $GITHUB_OUTPUT
       
       - name: Generate Release Text
         id: generate-release


### PR DESCRIPTION
Currently, the target is used to determine whether a release should be marked as prerelease. If it starts with `refs/head/` the check will break. So truncate to after the last `/`.

Then, add a rebase command for existing users that want to use the image.