### PR TITLE
chore: Rewrite of bazzite-rollback-helper and shorter name

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -69,13 +69,19 @@ function current() {
   echo -e "Current image: '$current_image'\nVersion: '$version'"
 }
 
+##  Rolls back to previously installed Bazzite image. alias for "rpm-ostree rollback"
+function rollback() {
+  rpm-ostree rollback && \
+    echo >&2 "Reboot for changes to take effect"
+}
+
 if [[ "$1" == "list" ]]; then
   list_images "${@:2}"
   exit
 
 elif [[ "$1" == "rollback" ]]; then
-  rpm-ostree rollback
-  echo "Reboot for changes to take effect"
+  rollback "${@:2}"
+  exit
 
 elif [[ "$1" == "current" ]]; then
   current "${@:2}"

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -98,6 +98,58 @@ function rollback() {
     echo >&2 "Reboot for changes to take effect"
 }
 
+function rebase() {
+  local _help="\
+##  Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
+##
+##  INPUTS:
+##    \$1: branch   Branch we want to rebase. Format must be 
+##                 one of the following:
+##
+##                 Fallbacks to \"$DEFAULT_BRANCH\"\
+"
+  if [[ $* =~ --help ]]; then
+  local _help
+    echo "$_help" && return
+  fi
+
+  # shellcheck disable=SC2155
+  local _current_img_ref=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
+
+  # Fetch our image reference prefix (ex.: ostree-image-signed:docker://ghcr.io/ublue-os)
+  # from rpm-ostree
+  local base_img_pfx
+  base_img_pfx=$_current_img_ref
+  base_img_pfx=${base_img_pfx///${DEFAULT_IMAGE}*/}
+
+  # TODO: Handle all possible patterns for rebase inputs
+  local img_ref # Final image ref string to rebase
+  local usr_inpt="$1"
+  case "$usr_inpt" in
+  *:*)
+    # IMG_NAME:TAG
+    echo >&2 "Format detected: IMG_NAME:TAG"
+    img_ref="$base_img_pfx"/"$usr_inpt"
+  ;;
+  "") echo >&2 "$_help"; return ;;
+  *)
+    # TAG
+    echo >&2 "Format detected: TAG"
+    img_ref="$base_img_pfx"/"$DEFAULT_IMAGE":"$usr_inpt"
+  ;;
+  esac
+
+  # Ask for confirmation. If is okay, rebase.
+  local question="\
+Rebasing to $img_ref. Continue? [y/N]: "
+  read -rp "$question" yn
+  case $yn in
+    # Finally, rebase
+    [yY]) rpm-ostree rebase "$img_ref" ;;
+    *) echo >&2 "Canceling..."; return ;;
+  esac
+}
+
 if [[ "$1" == "list" ]]; then
   list_images "${@:2}"
   exit
@@ -111,30 +163,8 @@ elif [[ "$1" == "current" ]]; then
   exit
 
 elif [[ "$1" == "rebase" ]]; then
-  base_image=ostree-image-signed:docker://ghcr.io/ublue-os
-  rebase_target=$DEFAULT_IMAGE:$DEFAULT_BRANCH
-
-  if [ -z "$2" ]; then
-    rebase_target=$DEFAULT_IMAGE:$DEFAULT_BRANCH
-  else
-    if [ "$image" == "$branch" ]; then
-      # only branch was provided as an arg, use default image
-      rebase_target=$DEFAULT_IMAGE:$branch
-    else
-      rebase_target=$image:$branch
-    fi
-  fi
-  full_image_path=$base_image/$rebase_target
-
-question=$(cat <<EOF
-Rebasing to $full_image_path. Continue? [y/N]:
-EOF
-)
-  read -p "$question" yn
-  case $yn in
-      [Yy]) echo "rebasing to $rebase_target" && rpm-ostree rebase $full_image_path &&  echo "Reboot for changes to take effect";;
-      *) echo "Unknown option, exiting.";;
-  esac
+  rebase "${@:2}"
+  exit
 
 # display the helptext
 elif [[ "$1" == "-h" || "$1" == "--h" || "$1" == "-help" || "$1" == "--help" || "$1" == "help" || -z "$1" ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-image="$(echo $2 | cut -d ':' -f1)"
-branch="$(echo $2 | cut -d ':' -f2)"
+image="$(echo "$2" | cut -d ':' -f1)"
+branch="$(echo "$2" | cut -d ':' -f2)"
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 DEFAULT_IMAGE=$(jq -r '."image-name"' < $IMAGE_INFO)
@@ -17,10 +17,10 @@ This tool aims to help with rollbacks and rebases
 Usage: bazzite-rollback-helper [OPTION] [ARGUMENT]
 
 Options:
-  list      List available Bazzite images, Default is "$DEFAULT_BRANCH"
-  rollback  Rolls back to previously installed Bazzite image. alias for "rpm-ostree rollback"
-  current   Show currently active Bazzite image
-  rebase    Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
+  list [BRANCH]      List available Bazzite images, Default is "$DEFAULT_BRANCH"
+  rollback           Rolls back to previously installed Bazzite image. alias for "rpm-ostree rollback"
+  current            Show currently active Bazzite image
+  rebase             Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
 
 Examples:
   bazzite-rollback-helper list stable
@@ -38,14 +38,23 @@ EOF
 )
 
 
+##  List images with a specified tag
+##
+##  INPUTS:
+##    $1    Branch we want to get tags from.
+##          Fallbacks to $DEFAULT_BRANCH
+function list_images() {
+  local branch=${1:-$DEFAULT_BRANCH}
+  local regex='.Tags[]'
+  regex="$regex"\ ' | select(test("^PLACEHOLDER|^PLACEHOLDER-(?:\\d+\\.\\d+|\\d+)"))'
+  regex=${regex//PLACEHOLDER/$branch}
+  echo -e >&2 "Listing images for $branch\nThis can take a bit of time..."
+  skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r "$regex"
+}
+
 if [[ "$1" == "list" ]]; then
-  if [ -z "$2" ]; then
-      echo "Listing images for $DEFAULT_BRANCH"
-      skopeo list-tags docker://ghcr.io/ublue-os/bazzite | grep -E "\"$DEFAULT_BRANCH-[0-9]+\.[0-9]+|-$DEFAULT_BRANCH-[0-9]+" | sort -rV
-  else
-      echo "Listing images for $2"
-      skopeo list-tags docker://ghcr.io/ublue-os/bazzite | grep -E "\"$2-[0-9]+\.[0-9]+|-$2-[0-9]+" | sort -rV
-  fi
+  list_images "${@:2}"
+  exit
 
 elif [[ "$1" == "rollback" ]]; then
   rpm-ostree rollback

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -88,8 +88,12 @@ function current() {
   echo -e "Current image: '$current_image'\nVersion: '$version'"
 }
 
-##  Rolls back to previously installed Bazzite image. alias for "rpm-ostree rollback"
 function rollback() {
+  local _help="Rolls back to previously installed Bazzite image. alias for \"rpm-ostree rollback\""
+  if [[ $* =~ --help ]]; then
+    echo "$_help" && return
+  fi
+
   rpm-ostree rollback && \
     echo >&2 "Reboot for changes to take effect"
 }

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -59,33 +59,12 @@ INPUTS:
 
 function current() {
   local _help="\
-Show currently active Bazzite image
-
-INPUTS:
-  -v | --verbose    Show the output of 'rpm-ostree status -vb'\
-"
+Show currently active Bazzite image"
   if [[ $* =~ --help ]]; then
     echo "$_help" && return
   fi
 
-  while (( $# > 0 )); do case $1 in
-    -v|--verbose) rpm-ostree status -vb; return ;;
-    *) echo >&2 "$_help"; return 1 ;;
-  esac done
-
-  local tmp_file
-  local current_image
-  local version
-  tmp_file=$(mktemp)
-
-  # shellcheck disable=SC2064
-  trap "rm $tmp_file" RETURN
-  rpm-ostree status -b --json > "$tmp_file"
-
-  current_image=$(jq -r '.deployments[]["container-image-reference"]' < "$tmp_file")
-  version=$(jq -r '.deployments[].version' < "$tmp_file")
-
-  echo -e "Current image: '$current_image'\nVersion: '$version'"
+  rpm-ostree status -vb
 }
 
 function rollback() {

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -38,12 +38,17 @@ EOF
 )
 
 
+function list_images() {
+  local _help="\
 ##  List images with a specified tag
 ##
 ##  INPUTS:
-##    $1    Branch we want to get tags from.
-##          Fallbacks to $DEFAULT_BRANCH
-function list_images() {
+##    \$1: branch   Branch we want to get tags from.
+##                 Fallbacks to \"$DEFAULT_BRANCH\"
+"
+  if [[ $* =~ --help ]]; then
+    echo "$_help" && return
+  fi
   local branch=${1:-$DEFAULT_BRANCH}
   local regex='.Tags[]'
   regex="$regex"\ ' | select(test("^PLACEHOLDER|^PLACEHOLDER-(?:\\d+\\.\\d+|\\d+)"))'

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -84,6 +84,7 @@ Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_B
 INPUTS:
   \$1: branch   Branch we want to rebase. Format must be 
                 one of the following:
+                  - ostree-image (ex.: 'ostree-image-signed:docker://ghcr.io/ublue-os/bazzite:stable')
                   - NAME:TAG (ex.: 'bazzite:stable-40')
                   - TAG (ex.: 'testing')
                 Fallbacks to \"$DEFAULT_BRANCH\"\
@@ -102,16 +103,19 @@ INPUTS:
   base_img_pfx=$_current_img_ref
   base_img_pfx=${base_img_pfx///${DEFAULT_IMAGE}*/}
 
-  # TODO: Handle all possible patterns for rebase inputs
   local img_ref # Final image ref string to rebase
   local usr_inpt="$1"
   case "$usr_inpt" in
+  "") echo >&2 "$_help"; return ;;
+  ostree-image-*)
+    echo >&2 "Format detected"
+    img_ref=$usr_inpt
+  ;;
   *:*)
     # IMG_NAME:TAG
     echo >&2 "Format detected: IMG_NAME:TAG"
     img_ref="$base_img_pfx"/"$usr_inpt"
   ;;
-  "") echo >&2 "$_help"; return ;;
   *)
     # TAG
     echo >&2 "Format detected: TAG"

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -52,6 +52,23 @@ function list_images() {
   skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r "$regex"
 }
 
+##  Show currently active Bazzite image
+function current() {
+  local tmp_file
+  local current_image
+  local version
+  tmp_file=$(mktemp)
+
+  # shellcheck disable=SC2064
+  trap "rm $tmp_file" RETURN
+  rpm-ostree status -b --json > "$tmp_file"
+
+  current_image=$(jq -r '.deployments[]["container-image-reference"]' < "$tmp_file")
+  version=$(jq -r '.deployments[].version' < "$tmp_file")
+
+  echo -e "Current image: '$current_image'\nVersion: '$version'"
+}
+
 if [[ "$1" == "list" ]]; then
   list_images "${@:2}"
   exit
@@ -61,10 +78,8 @@ elif [[ "$1" == "rollback" ]]; then
   echo "Reboot for changes to take effect"
 
 elif [[ "$1" == "current" ]]; then
-  # current image
-  rpm-ostree status | grep ●
-  # current version
-  rpm-ostree status | grep -A 5 "●" | tail -n +2
+  current "${@:2}"
+  exit
 
 elif [[ "$1" == "rebase" ]]; then
   base_image=ostree-image-signed:docker://ghcr.io/ublue-os

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -94,13 +94,10 @@ INPUTS:
     echo "$_help" && return
   fi
 
-  # shellcheck disable=SC2155
-  local _current_img_ref=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
-
   # Fetch our image reference prefix (ex.: ostree-image-signed:docker://ghcr.io/ublue-os)
   # from rpm-ostree
   local base_img_pfx
-  base_img_pfx=$_current_img_ref
+  base_img_pfx=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
   base_img_pfx=${base_img_pfx///${DEFAULT_IMAGE}*/}
 
   local img_ref # Final image ref string to rebase
@@ -108,6 +105,7 @@ INPUTS:
   case "$usr_inpt" in
   "") echo >&2 "$_help"; return ;;
   ostree-image-*)
+    # ostree-image
     echo >&2 "Format detected"
     img_ref=$usr_inpt
   ;;

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -105,7 +105,8 @@ Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_B
 INPUTS:
   \$1: branch   Branch we want to rebase. Format must be 
                 one of the following:
-
+                  - NAME:TAG (ex.: 'bazzite:stable-40')
+                  - TAG (ex.: 'testing')
                 Fallbacks to \"$DEFAULT_BRANCH\"\
 "
   if [[ $* =~ --help ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -40,11 +40,11 @@ EOF
 
 function list_images() {
   local _help="\
-##  List images with a specified tag
-##
-##  INPUTS:
-##    \$1: branch   Branch we want to get tags from.
-##                 Fallbacks to \"$DEFAULT_BRANCH\"
+List images with a specified tag
+
+INPUTS:
+  \$1: branch   Branch we want to get tags from.
+                Fallbacks to \"$DEFAULT_BRANCH\"
 "
   if [[ $* =~ --help ]]; then
     echo "$_help" && return
@@ -59,10 +59,10 @@ function list_images() {
 
 function current() {
   local _help="\
-##  Show currently active Bazzite image
-##
-##  INPUTS:
-##    -v | --verbose    Show the output of 'rpm-ostree status -vb'\
+Show currently active Bazzite image
+
+INPUTS:
+  -v | --verbose    Show the output of 'rpm-ostree status -vb'\
 "
   if [[ $* =~ --help ]]; then
     echo "$_help" && return
@@ -100,13 +100,13 @@ function rollback() {
 
 function rebase() {
   local _help="\
-##  Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
-##
-##  INPUTS:
-##    \$1: branch   Branch we want to rebase. Format must be 
-##                 one of the following:
-##
-##                 Fallbacks to \"$DEFAULT_BRANCH\"\
+Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
+
+INPUTS:
+  \$1: branch   Branch we want to rebase. Format must be 
+                one of the following:
+
+                Fallbacks to \"$DEFAULT_BRANCH\"\
 "
   if [[ $* =~ --help ]]; then
   local _help

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -57,8 +57,22 @@ function list_images() {
   skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r "$regex"
 }
 
-##  Show currently active Bazzite image
 function current() {
+  local _help="\
+##  Show currently active Bazzite image
+##
+##  INPUTS:
+##    -v | --verbose    Show the output of 'rpm-ostree status -vb'\
+"
+  if [[ $* =~ --help ]]; then
+    echo "$_help" && return
+  fi
+
+  while (( $# > 0 )); do case $1 in
+    -v|--verbose) rpm-ostree status -vb; return ;;
+    *) echo >&2 "$_help"; return 1 ;;
+  esac done
+
   local tmp_file
   local current_image
   local version

--- a/system_files/desktop/shared/usr/bin/brh
+++ b/system_files/desktop/shared/usr/bin/brh
@@ -1,0 +1,1 @@
+bazzite-rollback-helper


### PR DESCRIPTION
This PR:
* isolates each helper subcommand in the helper (list, rebase, current and rollback) into their own function for easier maintenance.
* Adds a "brh" symlink pointing to bazzite-rollback-helper (too long of a name for a script)
* Fixes some inconsistencies with "current" subcommand output 
