### PR TITLE
fix(ujust): move pwfeedback ujust to correct file

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -42,8 +42,6 @@ CHANGELOG_TITLE = "{tag}: {pretty}"
 CHANGELOG_FORMAT = """\
 {handwritten}
 
-Visit [bazzite.gg](https://bazzite.gg) for more information and to download Bazzite.
-
 From previous `{target}` version `{prev}` there have been the following changes. **One package per new version shown.**
 
 ### Major packages

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -6,27 +6,17 @@ screens:
   first-screen:
     source: yafti.screen.title
     values:
-      title: "Welcome to Bazzite (Handheld & HTPC Edition)"
+      title: "Welcome to Bazzite-Deck"
       icon: "/usr/share/ublue-os/bazzite/logo.svg"
       description: |
-        Configure your system to get started. This utility can be re-opened at any time, so don't feel like you have to get it perfect your first go-through.
-  configure-bazzite:
+        Install additional applications.
+  applications:
     source: yafti.screen.package
     values:
       title: Setting up Bazzite
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
-        Add input group to current user:
-          description: Adds the input group to your current user. Required by certain controller drivers.
-          default: true
-          packages:
-          - Set input group: sudo -A ujust add-user-to-input-group
-        BIOS &amp; Firmware Updates:
-          description: Enables BIOS &amp; Firmware updates for Steam Deck hardware
-          default: true
-          packages:
-          - Enable Updates: sudo -A ujust enable-deck-bios-firmware-updates
         Decky Loader:
           description: A plugin loader for the Steam Deck
           default: false
@@ -44,12 +34,53 @@ screens:
           packages:
           - Install Sunshine: ujust setup-sunshine install
           - Autostart Sunshine: ujust setup-sunshine autostart
+        Resilio Sync:
+          description: A file synchronization utility powered by BitTorrent
+          default: false
+          packages:
+          - Install Resilio Sync: ujust install-resilio-sync
+        scrcpy:
+          description: scrcpy provides display and control of Android devices connected on USB (or over TCP/IP)
+          default: false
+          packages:
+          - Install scrcpy: ujust install-scrcpy
+        DaVinci Resolve:
+            description: Install/update DaVinci Resolve, a closed-source video editing utility
+            default: false
+            packages:
+            - Install/Update DaVinci Resolve: sudo -A ujust install-resolve
+  configure-bazzite:
+    source: yafti.screen.package
+    values:
+      title: Application Installation
+      show_terminal: true
+      package_manager: yafti.plugin.flatpak
+      groups:
+        Add input group to current user:
+            description: Adds the input group to your current user. Required by certain controller drivers.
+            default: true
+            packages:
+          - Set input group: sudo -A ujust add-user-to-input-group
+        BIOS &amp; Firmware Updates:
+          description: Enables BIOS &amp; Firmware updates for Steam Deck hardware
+          default: true
+          packages:
+          - Enable Updates: sudo -A ujust enable-deck-bios-firmware-updates
         Hide GRUB Menu:
           description: |
-            NOTE: Press the escape key before boot to show the menu
           default: false
           packages:
           - Hide GRUB: sudo -A ujust configure-grub hide
+        Visible Password Aestriks:
+            description: Toggles pwfeedback on.
+            default: true
+            packages:
+            - Install bazzite-cli: ujust bazzite-cli
+        bazzite-cli:
+            description: Bazzite CLI mod for Bluefin style CLI bling.
+            default: false
+            packages:
+            - Install bazzite-cli: ujust bazzite-cli
         Oversteer:
           description: Application to control supported steering wheels
           default: false
@@ -65,159 +96,16 @@ screens:
           default: false
           packages:
           - Install OpenRGB: ujust install-openrgb
-        Wootility:
-          description: A configurator for Wooting keyboards
-          default: false
-          packages:
-          - Retrieve Wootility: ujust install-wootility
         OpenTabletDriver:
           description: Open source, cross-platform, user-mode tablet driver
           default: false
           packages:
           - Install OpenTabletDriver: ujust install-opentabletdriver
-        Resilio Sync:
-          description: A file synchronization utility powered by BitTorrent
+        Wootility:
+          description: A configurator for Wooting keyboards
           default: false
           packages:
-          - Install Resilio Sync: ujust install-resilio-sync
-        scrcpy:
-          description: scrcpy provides display and control of Android devices connected on USB (or over TCP/IP)
-          default: false
-          packages:
-          - Install scrcpy: ujust install-scrcpy
-        SteamCMD:
-          description: Installs SteamCMD
-          default: true
-          packages:
-          - Install SteamCMD: ujust install-steamcmd
-  applications:
-    source: yafti.screen.package
-    values:
-      title: Application Installation
-      show_terminal: true
-      package_manager: yafti.plugin.flatpak
-      package_manager_defaults:
-        user: true
-        system: false
-      groups:
-        Web Browsers:
-          description: Additional browsers to complement Firefox
-          default: false
-          packages:
-          - Brave: com.brave.Browser
-          - Google Chrome: com.google.Chrome
-          - LibreWolf: io.gitlab.librewolf-community
-          - Microsoft Edge: com.microsoft.Edge
-          - Opera: com.opera.Opera
-          - Vivaldi: com.vivaldi.Vivaldi
-        Gaming:
-          description: "Rock and Stone!"
-          default: false
-          packages:
-          - BoilR: io.github.philipk.boilr
-          - Bottles: com.usebottles.bottles
-          - Chiaki4Deck (PlayStation Remote Play): io.github.streetpea.Chiaki4deck
-          - Discord (Discover Overlay Included): com.discordapp.Discord
-          - DOSBox Staging: io.github.dosbox-staging
-          - Fightcade: com.fightcade.Fightcade
-          - GeForce NOW Electron: io.github.hmlendea.geforcenow-electron
-          - Greenlight: io.github.unknownskl.greenlight
-          - Heroic Games Launcher (GOG &amp; Epic): com.heroicgameslauncher.hgl
-          - itch: io.itch.itch
-          - ludusavi (Game Save Backup): com.github.mtkennerly.ludusavi
-          - Minecraft (Prism Launcher): org.prismlauncher.PrismLauncher
-          - Minecraft Bedrock Launcher: io.mrarm.mcpelauncher
-          - Moonlight: com.moonlight_stream.Moonlight
-          - Mumble: info.mumble.Mumble
-          - OpenMW: org.openmw.OpenMW
-          - osu: sh.ppy.osu
-          - Space Cadet Pinball: com.github.k4zmu2a.spacecadetpinball
-          - Sonic Robo Blast 2: org.srb2.SRB2
-          - Sonic Robo Blast 2 Kart: org.srb2.SRB2Kart
-          - Steam Link: com.valvesoftware.SteamLink
-          - SuperTux: org.supertuxproject.SuperTux
-          - SuperTuxKart: net.supertuxkart.SuperTuxKart
-          - TeamSpeak: com.teamspeak.TeamSpeak
-          - XIV Launcher (Final Fantasy XIV): dev.goats.xivlauncher
-        Emulation:
-          description: Play games like it's 1972 (Leave these all unchecked if you're planning to use EmuDeck)
-          default: false
-          packages:
-          - Cemu: info.cemu.Cemu
-          - Dolphin: org.DolphinEmu.dolphin-emu
-          - DuckStation: org.duckstation.DuckStation
-          - MAME: org.mamedev.MAME
-          - melonDS: net.kuribo64.melonDS
-          - mGBA: io.mgba.mGBA
-          - PCSX2: net.pcsx2.PCSX2
-          - Parallel Launcher: ca.parallel_launcher.ParallelLauncher
-          - Pegasus: org.pegasus_frontend.Pegasus
-          - PPSSPP: org.ppsspp.PPSSPP
-          - RetroArch: org.libretro.RetroArch
-          - RetroDECK: net.retrodeck.retrodeck
-          - Rosalie's Mupen GUI: com.github.Rosalie241.RMG
-          - RPCS3: net.rpcs3.RPCS3
-          - Ryujinx: org.ryujinx.Ryujinx
-          - ScummVM: org.scummvm.ScummVM
-          - Snes9x: com.snes9x.Snes9x
-          - Stella: io.github.stella_emu.Stella
-          - xemu: app.xemu.xemu
-        Streaming:
-          description: Stream to the Internet
-          default: false
-          packages:
-          - OBS Studio: com.obsproject.Studio
-          - Boatswain for Streamdeck: com.feaneron.Boatswain
-        Music:
-          description: "Rock and Roll!"
-          default: false
-          packages:
-          - Cider (Apple Music Client): sh.cider.Cider
-          - Spotify: com.spotify.Client
-          - Strawberry Music Player: org.strawberrymusicplayer.strawberry
-          - Tidal-hifi: com.mastermindzh.tidal-hifi
-        Office and Productivity:
-          description: Bow to Capitalism
-          default: false
-          packages:
-          - Ardour: org.ardour.Ardour
-          - Blender: org.blender.Blender
-          - darktable: org.darktable.Darktable
-          - GIMP: org.gimp.GIMP
-          - Inkscape: org.inkscape.Inkscape
-          - Joplin: net.cozic.joplin_desktop
-          - Kdenlive: org.kde.kdenlive
-          - Krita: org.kde.krita
-          - LibreOffice: org.libreoffice.LibreOffice
-          - Obsidian: md.obsidian.Obsidian
-          - OnlyOffice: org.onlyoffice.desktopeditors
-          - Planify: io.github.alainm23.planify
-          - Slack: com.slack.Slack
-          - Standard Notes: org.standardnotes.standardnotes
-          - Tenacity: org.tenacityaudio.Tenacity
-          - Thunderbird Email: org.mozilla.Thunderbird
-          - Xournal++: com.github.xournalpp.xournalpp
-        Utilities and System Tools:
-          description: Helpful tools
-          default: false
-          packages:
-          - AppImage Pool: io.github.prateekmedia.appimagepool
-          - Barrier: com.github.debauchee.barrier
-          - Bitwarden: com.bitwarden.desktop
-          - Calibre: com.calibre_ebook.calibre
-          - DejaDup: org.gnome.DejaDup
-          - Fedora Media Writer: org.fedoraproject.MediaWriter
-          - Gradience: com.github.GradienceTeam.Gradience
-          - KeePassXC: org.keepassxc.KeePassXC
-          - Main Menu: page.codeberg.libre_menu_editor.LibreMenuEditor
-          - Metadata Cleaner: fr.romainvigier.MetadataCleaner
-          - Pika Backup: org.gnome.World.PikaBackup
-          - qBittorrent: org.qbittorrent.qBittorrent
-          - Resources: net.nokyan.Resources
-          - SaveDesktop: io.github.vikdevelop.SaveDesktop
-          - Solaar: io.github.pwr_solaar.solaar
-          - Syncthing: com.github.zocker_160.SyncThingy
-          - VLC: org.videolan.VLC
+          - Retrieve Wootility: ujust install-wootility
   final-screen:
     source: yafti.screen.title
     values:
@@ -235,4 +123,4 @@ screens:
       - "Reboot now":
           run: systemctl reboot
       description: |
-        Thank you for trying Bazzite (Handheld & HTPC Edition). Please reboot to apply changes made by this setup utility.
+        Please reboot to apply changes made by this setup utility.

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -122,6 +122,21 @@ restore-input-remapper:
     cp /usr/share/applications/input-remapper-gtk.desktop ~/.local/share/applications/input-remapper-gtk.desktop && \
     sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop
 
+# Install firmware files needed for ayaneo and orangepi speakers
+install-speaker-firmare:
+    #!/bin/bash
+    BASE_DIR="https://raw.githubusercontent.com/hhd-dev/hwinfo/master/firmware/"
+    INSTALL_DIR="/usr/local/firmware"
+    if [ ! -d "$INSTALL_DIR" ]; then
+      sudo mkdir -p $INSTALL_DIR
+    fi
+    sudo wget -O $INSTALL_DIR/aw87xxx_acf_air1s.bin    $BASE_DIR/awinic/aw87xxx_acf_air1s.bin
+    sudo wget -O $INSTALL_DIR/aw87xxx_acf_airplus.bin  $BASE_DIR/awinic/aw87xxx_acf_airplus.bin
+    sudo wget -O $INSTALL_DIR/aw87xxx_acf_flip.bin     $BASE_DIR/awinic/aw87xxx_acf_flip.bin
+    sudo wget -O $INSTALL_DIR/aw87xxx_acf_kun.bin      $BASE_DIR/awinic/aw87xxx_acf_kun.bin
+    sudo wget -O $INSTALL_DIR/aw87xxx_acf_minipro.bin  $BASE_DIR/awinic/aw87xxx_acf_minipro.bin
+    sudo wget -O $INSTALL_DIR/aw87xxx_acf_orangepi.bin $BASE_DIR/awinic/aw87xxx_acf_orangepi.bin
+
 # Install hhd main branch locally until reboot, helpful for hhd testing and debugging. (rename to install-hhd-dev if we unhide)
 _hhd-dev:
     #!/usr/bin/bash

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -89,26 +89,6 @@ enable-ryzenadj-max-performance:
     sudo udevadm control --reload-rules
     echo 'installation complete. Reboot to take effect'
 
-# toggles password prompt feedback in terminal, where sudo password prompts will display asterisks when enabled
-toggle-password-feedback ACTION="":
-    #!/usr/bin/bash
-    PWFEEDBACK_FILE="/etc/sudoers.d/enable-pwfeedback"
-    OPTION={{ ACTION }}
-
-    if [ "$OPTION" = "on" ]; then
-      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
-      echo "enabled, restart terminal to see changes"
-    elif [ "$OPTION" = "off" ]; then
-      sudo rm -f $PWFEEDBACK_FILE
-      echo "disabled pwfeedback. restart your terminal to see changes"
-    elif sudo test -f $PWFEEDBACK_FILE; then
-      sudo rm -f $PWFEEDBACK_FILE
-      echo "disabled pwfeedback. restart your terminal to see changes"
-    else
-      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
-      echo "enabled, restart terminal to see changes"
-    fi
-
 # disables ryzenadj --max-performance on AC power
 disable-ryzenadj-max-performance:
     #/bin/bash

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -9,19 +9,14 @@ screens:
       title: "Welcome to Bazzite"
       icon: "/usr/share/ublue-os/bazzite/logo.svg"
       description: |
-        Configure your system to get started. This utility can be re-opened at any time, so don't feel like you have to get it perfect your first go-through.
-  configure-bazzite:
+        Install additional applications.
+  applications:
     source: yafti.screen.package
     values:
       title: Setting up Bazzite
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
-        Add input group to current user:
-          description: Adds the input group to your current user. Required by certain controller drivers.
-          default: true
-          packages:
-          - Set input group: sudo -A ujust add-user-to-input-group
         Sunshine:
           description: A self-hosted game stream host for Moonlight
           default: false
@@ -33,31 +28,6 @@ screens:
           default: false
           packages:
           - Retrieve EmuDeck: ujust install-emudeck
-        OpenRazer:
-          description: Enables additional capabilities for Razer Hardware
-          default: false
-          packages:
-          - Install OpenRazer: ujust install-openrazer
-        OpenRGB:
-          description: Open source RGB lighting control that doesn't depend on manufacturer software
-          default: false
-          packages:
-          - Install OpenRGB: ujust install-openrgb
-        OpenTabletDriver:
-          description: Open source, cross-platform, user-mode tablet driver
-          default: false
-          packages:
-          - Install OpenTabletDriver: ujust install-opentabletdriver
-        Oversteer:
-          description: Application to control supported steering wheels
-          default: false
-          packages:
-          - Install Oversteer: ujust install-oversteer
-        Wootility:
-          description: A configurator for Wooting keyboards
-          default: false
-          packages:
-          - Retrieve Wootility: ujust install-wootility
         Resilio Sync:
           description: A file synchronization utility powered by BitTorrent
           default: false
@@ -68,6 +38,11 @@ screens:
           default: false
           packages:
           - Install scrcpy: ujust install-scrcpy
+        DaVinci Resolve:
+            description: Install/update DaVinci Resolve, a closed-source video editing utility
+            default: false
+            packages:
+            - Install/Update DaVinci Resolve: sudo -A ujust install-resolve
   amd-additions:
     source: yafti.screen.package
     values:
@@ -88,135 +63,58 @@ screens:
       package_manager: yafti.plugin.run
       packages:
         - Supergfxctl (Hybrid GPU Switching): ujust enable-supergfxctl
-  applications:
+  configure-bazzite:
     source: yafti.screen.package
     values:
-      title: Application Installation
+      title: System Configuration
       show_terminal: true
-      package_manager: yafti.plugin.flatpak
-      package_manager_defaults:
-        user: true
-        system: false
+      package_manager: yafti.plugin.run
       groups:
-        Web Browsers:
-          description: Additional browsers to complement Firefox
+        Add input group to current user:
+          description: Adds the input group to your current user. Required by certain controller drivers.
+          default: true
+          packages:
+          - Set input group: sudo -A ujust add-user-to-input-group
+        Visible Password Aestriks:
+            description: Toggles pwfeedback on.
+            default: true
+            packages:
+            - Install bazzite-cli: ujust bazzite-cli
+        bazzite-cli:
+            description: Bazzite CLI mod for Bluefin style CLI bling.
+            default: false
+            packages:
+            - Install bazzite-cli: ujust bazzite-cli
+        OpenRazer:
+          description: Enables additional capabilities for Razer Hardware
           default: false
           packages:
-          - Brave: com.brave.Browser
-          - Google Chrome: com.google.Chrome
-          - LibreWolf: io.gitlab.librewolf-community
-          - Microsoft Edge: com.microsoft.Edge
-          - Opera: com.opera.Opera
-          - Vivaldi: com.vivaldi.Vivaldi
-        Gaming:
-          description: "Rock and Stone!"
+          - Install OpenRazer: ujust install-openrazer
+        OpenRGB:
+          description: Open source RGB lighting control that doesn't depend on manufacturer software
           default: false
           packages:
-          - BoilR: io.github.philipk.boilr
-          - Bottles: com.usebottles.bottles
-          - Chiaki (PlayStation Remote Play): re.chiaki.Chiaki
-          - Discord: com.discordapp.Discord
-          - DOSBox Staging: io.github.dosbox-staging
-          - GeForce NOW Electron: io.github.hmlendea.geforcenow-electron
-          - Greenlight: io.github.unknownskl.greenlight
-          - Heroic Games Launcher (GOG &amp; Epic): com.heroicgameslauncher.hgl
-          - itch: io.itch.itch
-          - ludusavi (Game Save Backup): com.github.mtkennerly.ludusavi
-          - Minecraft (Prism Launcher): org.prismlauncher.PrismLauncher
-          - Minecraft Bedrock Launcher: io.mrarm.mcpelauncher
-          - Moonlight: com.moonlight_stream.Moonlight
-          - Mumble: info.mumble.Mumble
-          - OpenMW: org.openmw.OpenMW
-          - osu: sh.ppy.osu
-          - Space Cadet Pinball: com.github.k4zmu2a.spacecadetpinball
-          - Sonic Robo Blast 2: org.srb2.SRB2
-          - Sonic Robo Blast 2 Kart: org.srb2.SRB2Kart
-          - Steam Link: com.valvesoftware.SteamLink
-          - SuperTux: org.supertuxproject.SuperTux
-          - SuperTuxKart: net.supertuxkart.SuperTuxKart
-          - TeamSpeak: com.teamspeak.TeamSpeak
-          - XIV Launcher (Final Fantasy XIV): dev.goats.xivlauncher
-        Emulation:
-          description: Play games like it's 1972
+          - Install OpenRGB: ujust install-openrgb
+        OpenTabletDriver:
+          description: Open source, cross-platform, user-mode tablet driver
           default: false
           packages:
-          - Cemu: info.cemu.Cemu
-          - Dolphin: org.DolphinEmu.dolphin-emu
-          - DuckStation: org.duckstation.DuckStation
-          - MAME: org.mamedev.MAME
-          - melonDS: net.kuribo64.melonDS
-          - mGBA: io.mgba.mGBA
-          - PCSX2: net.pcsx2.PCSX2
-          - Parallel Launcher: ca.parallel_launcher.ParallelLauncher
-          - Pegasus: org.pegasus_frontend.Pegasus
-          - PPSSPP: org.ppsspp.PPSSPP
-          - RetroArch: org.libretro.RetroArch
-          - RetroDECK: net.retrodeck.retrodeck
-          - Rosalie's Mupen GUI: com.github.Rosalie241.RMG
-          - RPCS3: net.rpcs3.RPCS3
-          - Ryujinx: org.ryujinx.Ryujinx
-          - ScummVM: org.scummvm.ScummVM
-          - Snes9x: com.snes9x.Snes9x
-          - Stella: io.github.stella_emu.Stella
-          - xemu: app.xemu.xemu
-        Streaming:
-          description: Stream to the Internet
+          - Install OpenTabletDriver: ujust install-opentabletdriver
+        Oversteer:
+          description: Application to control supported steering wheels
           default: false
           packages:
-          - OBS Studio: com.obsproject.Studio
-          - Boatswain for Streamdeck: com.feaneron.Boatswain
-        Music:
-          description: "Rock and Roll!"
+          - Install Oversteer: ujust install-oversteer
+        CoolerControl:
+            description: A GUI for viewing all your system's sensors and for creating custom fan and pump profiles
+            default: false
+            packages:
+            - Install CoolerControl: ujust install-coolercontrol
+        Wootility:
+          description: A configurator for Wooting keyboards
           default: false
           packages:
-          - Cider (Apple Music Client): sh.cider.Cider
-          - Spotify: com.spotify.Client
-          - Strawberry Music Player: org.strawberrymusicplayer.strawberry
-          - Tidal-hifi: com.mastermindzh.tidal-hifi
-        Office and Productivity:
-          description: Bow to Capitalism
-          default: false
-          packages:
-          - Ardour: org.ardour.Ardour
-          - Blender: org.blender.Blender
-          - darktable: org.darktable.Darktable
-          - GIMP: org.gimp.GIMP
-          - Inkscape: org.inkscape.Inkscape
-          - Joplin: net.cozic.joplin_desktop
-          - Kdenlive: org.kde.kdenlive
-          - Krita: org.kde.krita
-          - LibreOffice: org.libreoffice.LibreOffice
-          - Obsidian: md.obsidian.Obsidian
-          - OnlyOffice: org.onlyoffice.desktopeditors
-          - Planify: io.github.alainm23.planify
-          - Slack: com.slack.Slack
-          - Standard Notes: org.standardnotes.standardnotes
-          - Tenacity: org.tenacityaudio.Tenacity
-          - Thunderbird Email: org.mozilla.Thunderbird
-          - Xournal++: com.github.xournalpp.xournalpp
-        Utilities and System Tools:
-          description: Helpful tools
-          default: false
-          packages:
-          - AppImage Pool: io.github.prateekmedia.appimagepool
-          - Barrier: com.github.debauchee.barrier
-          - Bitwarden: com.bitwarden.desktop
-          - Calibre: com.calibre_ebook.calibre
-          - DejaDup: org.gnome.DejaDup
-          - Easy Effects: com.github.wwmm.easyeffects
-          - Fedora Media Writer: org.fedoraproject.MediaWriter
-          - Gradience: com.github.GradienceTeam.Gradience
-          - JamesDSP: me.timschneeberger.jdsp4linux
-          - KeePassXC: org.keepassxc.KeePassXC
-          - Main Menu: page.codeberg.libre_menu_editor.LibreMenuEditor
-          - Metadata Cleaner: fr.romainvigier.MetadataCleaner
-          - Pika Backup: org.gnome.World.PikaBackup
-          - qBittorrent: org.qbittorrent.qBittorrent
-          - Resources: net.nokyan.Resources
-          - SaveDesktop: io.github.vikdevelop.SaveDesktop
-          - Solaar: io.github.pwr_solaar.solaar
-          - Syncthing: com.github.zocker_160.SyncThingy
-          - VLC: org.videolan.VLC
+          - Retrieve Wootility: ujust install-wootility
   final-screen:
     source: yafti.screen.title
     values:
@@ -234,4 +132,4 @@ screens:
       - "Reboot now":
           run: systemctl reboot
       description: |
-        Thank you for trying Bazzite. Please reboot to apply changes made by this setup utility.
+        Please reboot to apply changes made by this setup utility.

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -38,11 +38,6 @@ screens:
           default: false
           packages:
           - Install scrcpy: ujust install-scrcpy
-        DaVinci Resolve:
-            description: Install/update DaVinci Resolve, a closed-source video editing utility
-            default: false
-            packages:
-            - Install/Update DaVinci Resolve: sudo -A ujust install-resolve
   amd-additions:
     source: yafti.screen.package
     values:
@@ -75,16 +70,6 @@ screens:
           default: true
           packages:
           - Set input group: sudo -A ujust add-user-to-input-group
-        Visible Password Aestriks:
-            description: Toggles pwfeedback on.
-            default: true
-            packages:
-            - Install bazzite-cli: ujust bazzite-cli
-        bazzite-cli:
-            description: Bazzite CLI mod for Bluefin style CLI bling.
-            default: false
-            packages:
-            - Install bazzite-cli: ujust bazzite-cli
         OpenRazer:
           description: Enables additional capabilities for Razer Hardware
           default: false

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -351,6 +351,26 @@ benchmark:
     echo 'Running a 1 minute benchmark ...'
     cd /tmp && stress-ng --matrix 0 -t 1m --times
 
+# toggles password prompt feedback in terminal, where sudo password prompts will display asterisks when enabled
+toggle-password-feedback ACTION="":
+    #!/usr/bin/bash
+    PWFEEDBACK_FILE="/etc/sudoers.d/enable-pwfeedback"
+    OPTION={{ ACTION }}
+
+    if [ "$OPTION" = "on" ]; then
+      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
+      echo "enabled, restart terminal to see changes"
+    elif [ "$OPTION" = "off" ]; then
+      sudo rm -f $PWFEEDBACK_FILE
+      echo "disabled pwfeedback. restart your terminal to see changes"
+    elif sudo test -f $PWFEEDBACK_FILE; then
+      sudo rm -f $PWFEEDBACK_FILE
+      echo "disabled pwfeedback. restart your terminal to see changes"
+    else
+      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
+      echo "enabled, restart terminal to see changes"
+    fi
+
 post-gamescope-logs:
     #!/usr/bin/bash
     OUTPUT_FILE="/tmp/gathered_info.txt"


### PR DESCRIPTION
I accidentally added the pwfeedback ujust to the `-deck` images only, when it should've been made available for all images.

Mistake on my part, this PR moves the ujust to the correct file. thanks for flagging this @nicknamenamenick 