### PR TITLE
Revert to 40

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -35,7 +35,7 @@ jobs:
           - bazzite-gnome-asus-nvidia
           - bazzite-asus-nvidia-open
           - bazzite-gnome-asus-nvidia-open
-        major_version: [41]
+        major_version: [40]
     steps:
 
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -111,7 +111,7 @@ jobs:
           curl -Lo ${{ github.workspace }}/bazzite.repo https://copr.fedorainfracloud.org/coprs/kylegospo/bazzite/repo/fedora-${{ matrix.major_version }}/kylegospo-bazzite-fedora-${{ matrix.major_version }}.repo
 
       - name: Build ISOs
-        uses: jasonn3/build-container-installer@f41
+        uses: jasonn3/build-container-installer@v1.2.2
         id: build
         with:
           arch: x86_64

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -398,6 +398,9 @@ def main():
     # Tags cannot include / anyway.
     target = args.target.split('/')[-1]
 
+    if target == "main":
+        target = "stable"
+
     manifests = get_manifests(target)
     prev, curr = get_tags(target, manifests)
     print(f"Previous tag: {prev}")

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -57,7 +57,7 @@ From previous `{target}` version `{prev}` there have been the following changes.
 
 {changes}
 
-### How to update
+### How to rebase
 For current users, type the following to rebase to this version:
 ```bash
 # For this branch (if latest):


### PR DESCRIPTION
Revert building 40 ISOs. We still may need to point 41 to them for now and put something on the website.
