### PR TITLE
feat(ujust): Add setup-boot-windows-steam ujust script

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -676,6 +676,7 @@ RUN rm -f /etc/profile.d/toolbox.sh && \
     echo "import \"/usr/share/ublue-os/just/83-bazzite-audio.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/84-bazzite-virt.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/85-bazzite-image.just\"" >> /usr/share/ublue-os/justfile && \
+    echo "import \"/usr/share/ublue-os/just/86-bazzite-windows.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/90-bazzite-de.just\"" >> /usr/share/ublue-os/justfile && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
       mkdir -p "/usr/share/ublue-os/dconfs/desktop-kinoite/" && \

--- a/system_files/desktop/shared/usr/bin/boot-windows
+++ b/system_files/desktop/shared/usr/bin/boot-windows
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# Look up the boot number for Windows in the EFI records
+boot_number=$(echo $(efibootmgr) | grep -Po "(?<=Boot)\S{4}(?=( |\* )Windows)")
+
+# Check that Windows EFI entry was found
+if [ -z "$boot_number" ]; then
+    echo "Cannot find Windows boot in EFI, exiting"
+    exit 1
+fi
+
+# Set next boot to be Windows and reboot the machine
+sudo efibootmgr -n "${boot_number}" && reboot

--- a/system_files/desktop/shared/usr/share/ublue-os/just/86-bazzite-windows.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/86-bazzite-windows.just
@@ -1,0 +1,8 @@
+# vim: set ft=make :
+
+# Adds a script in Steam to boot Windows which is useful for dual-boot setups
+setup-boot-windows-steam:
+    echo "Making efibootmgr -n usable without sudo password"
+    echo "%wheel ALL=(root) NOPASSWD: /usr/sbin/efibootmgr" | sudo tee /etc/sudoers.d/efibootmgr-config
+    echo "Adding /usr/bin/boot-windows as a Non-steam game"
+    /usr/bin/steamos-add-to-steam /usr/bin/boot-windows


### PR DESCRIPTION
I'm seeing a number of people using my https://youtu.be/WR31wkrxock video for making a script to boot into Windows from Steam in GameMode. However, quite a few people miss a step or type a character incorrectly. Thought that it might be possible to automate this with a ujust script.

Also want to give thanks to u/0nlin3 on Reddit for the idea.