### PR TITLE
feat(just): Improve install speaker firmware

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -123,7 +123,7 @@ restore-input-remapper:
     sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop
 
 # Install firmware files needed for ayaneo and orangepi speakers
-install-speaker-firmare:
+install-speaker-firmware:
     #!/bin/bash
     BASE_DIR="https://raw.githubusercontent.com/hhd-dev/hwinfo/master/firmware/"
     INSTALL_DIR="/usr/local/firmware"

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -123,19 +123,21 @@ restore-input-remapper:
     sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop
 
 # Install firmware files needed for ayaneo and orangepi speakers
-install-speaker-firmware:
+install-speaker-firmware ACTION="":
     #!/bin/bash
-    BASE_DIR="https://raw.githubusercontent.com/hhd-dev/hwinfo/master/firmware/"
-    INSTALL_DIR="/usr/local/firmware"
-    if [ ! -d "$INSTALL_DIR" ]; then
-      sudo mkdir -p $INSTALL_DIR
+    source /usr/lib/ujust/ujust.sh
+    OPTION={{ ACTION }}
+    FIRMWARE_SCRIPT="https://raw.githubusercontent.com/hhd-dev/hwinfo/refs/heads/master/firmware/bazzite-speaker.sh"
+    curl -o "/tmp/bazzite-speaker.sh" "$FIRMWARE_SCRIPT" && cat /tmp/bazzite-speaker.sh | pygmentize -l bash -O style=emacs
+    echo ""
+    echo "Run the above script using elevated permissions?"
+    if [ "$OPTION" == "" ]; then
+      OPTION=$(Choose "Yes" "No")
     fi
-    sudo wget -O $INSTALL_DIR/aw87xxx_acf_air1s.bin    $BASE_DIR/awinic/aw87xxx_acf_air1s.bin
-    sudo wget -O $INSTALL_DIR/aw87xxx_acf_airplus.bin  $BASE_DIR/awinic/aw87xxx_acf_airplus.bin
-    sudo wget -O $INSTALL_DIR/aw87xxx_acf_flip.bin     $BASE_DIR/awinic/aw87xxx_acf_flip.bin
-    sudo wget -O $INSTALL_DIR/aw87xxx_acf_kun.bin      $BASE_DIR/awinic/aw87xxx_acf_kun.bin
-    sudo wget -O $INSTALL_DIR/aw87xxx_acf_minipro.bin  $BASE_DIR/awinic/aw87xxx_acf_minipro.bin
-    sudo wget -O $INSTALL_DIR/aw87xxx_acf_orangepi.bin $BASE_DIR/awinic/aw87xxx_acf_orangepi.bin
+    if [[ "${OPTION,,}" =~ ^yes || "${OPTION,,}" =~ ^-y ]]; then
+      sudo bash /tmp/bazzite-speaker.sh
+    fi
+    rm /tmp/bazzite-speaker.sh
 
 # Install hhd main branch locally until reboot, helpful for hhd testing and debugging. (rename to install-hhd-dev if we unhide)
 _hhd-dev:


### PR DESCRIPTION
@antheas pointed out I had typoed the original ujust so i have to just live with it.

This improves the `install-speaker-firmare` to be correctly spelled `install-speaker-firmware` and also makes the ujust recipe more dynamic so it does not have to be updated when new speaker firmware is added.

Since this script will be loaded externally it will also be displayed to the user for visual verification before running (unless the `yes` or `-y` action is passed)

if this is to be added to yafti then it has to be called with `sudo -A ujust install-speaker-firmware yes`
in the terminal `ujust install-speaker-firmware yes` will be preferred as it will ask for sudo when needed (and avoiding "teaching" users that some ujusts should be run with sudo... which then causes them to use it on all of them...)

![image](https://github.com/user-attachments/assets/d36efa3b-13dd-41bf-892d-df6959cf66d1)



<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
