### PR TITLE
fix(just): add toggle-password-feedback to all images

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -89,26 +89,6 @@ enable-ryzenadj-max-performance:
     sudo udevadm control --reload-rules
     echo 'installation complete. Reboot to take effect'
 
-# toggles password prompt feedback in terminal, where sudo password prompts will display asterisks when enabled
-toggle-password-feedback ACTION="":
-    #!/usr/bin/bash
-    PWFEEDBACK_FILE="/etc/sudoers.d/enable-pwfeedback"
-    OPTION={{ ACTION }}
-
-    if [ "$OPTION" = "on" ]; then
-      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
-      echo "enabled, restart terminal to see changes"
-    elif [ "$OPTION" = "off" ]; then
-      sudo rm -f $PWFEEDBACK_FILE
-      echo "disabled pwfeedback. restart your terminal to see changes"
-    elif sudo test -f $PWFEEDBACK_FILE; then
-      sudo rm -f $PWFEEDBACK_FILE
-      echo "disabled pwfeedback. restart your terminal to see changes"
-    else
-      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
-      echo "enabled, restart terminal to see changes"
-    fi
-
 # disables ryzenadj --max-performance on AC power
 disable-ryzenadj-max-performance:
     #/bin/bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -79,6 +79,25 @@ enable-displaylink:
 enable-tailscale:
     systemctl enable --now tailscaled.service
 
+# toggles password prompt feedback in terminal, where sudo password prompts will display asterisks when enabled
+toggle-password-feedback ACTION="":
+    #!/usr/bin/bash
+    PWFEEDBACK_FILE="/etc/sudoers.d/enable-pwfeedback"
+    OPTION={{ ACTION }}
+    if [ "$OPTION" = "on" ]; then
+      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
+      echo "enabled, restart terminal to see changes"
+    elif [ "$OPTION" = "off" ]; then
+      sudo rm -f $PWFEEDBACK_FILE
+      echo "disabled pwfeedback. restart your terminal to see changes"
+    elif sudo test -f $PWFEEDBACK_FILE; then
+      sudo rm -f $PWFEEDBACK_FILE
+      echo "disabled pwfeedback. restart your terminal to see changes"
+    else
+      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
+      echo "enabled, restart terminal to see changes"
+    fi
+
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 configure-watchdog ACTION="":
     #!/usr/bin/bash


### PR DESCRIPTION
Puts the toggle-password-feedback ujust on all images and not just the deck images.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
