### PR TITLE
Add protontricks-launch to run .exes via commandline

### DIFF
--- a/system_files/desktop/shared/usr/bin/protontricks-launch
+++ b/system_files/desktop/shared/usr/bin/protontricks-launch
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+/usr/bin/flatpak run --command=protontricks-launch com.github.Matoking.protontricks "$@"


### PR DESCRIPTION
This is a partner script to `/usr/bin/protontricks` to be able to run .exes via commandline.
