### PR TITLE
fix(gamescope): force dpms even if steamui is not blanking

### DIFF
--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -6,7 +6,7 @@
 
 Name:           gamescope
 Version:        100.%{gamescope_tag}
-Release:        13.bazzite
+Release:        14.bazzite
 Summary:        Micro-compositor for video games on Wayland
 
 License:        BSD

--- a/spec_files/gamescope/handheld.patch
+++ b/spec_files/gamescope/handheld.patch
@@ -967,9 +967,9 @@ Subject: feat: add DPMS support through an Atom
 ---
  src/Backends/DRMBackend.cpp | 16 +++++++++++++---
  src/rendervulkan.hpp        |  2 ++
- src/steamcompmgr.cpp        | 11 ++++++++++-
+ src/steamcompmgr.cpp        | 18 +++++++++++++++---
  src/xwayland_ctx.hpp        |  1 +
- 4 files changed, 26 insertions(+), 4 deletions(-)
+ 4 files changed, 31 insertions(+), 6 deletions(-)
 
 diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
 index f014be9..6bb0b88 100644
@@ -1040,7 +1040,7 @@ index b537170..ccabd88 100644
  	struct Layer_t
  	{
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 6c8ce74..7589e3a 100644
+index 6c8ce74..77c9f28 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -169,6 +169,7 @@ bool g_bVRRRequested = false;
@@ -1051,15 +1051,36 @@ index 6c8ce74..7589e3a 100644
  
  static std::vector< steamcompmgr_win_t* > GetGlobalPossibleFocusWindows();
  static bool
+@@ -2271,7 +2272,7 @@ bool ShouldDrawCursor()
+ }
+ 
+ static void
+-paint_all(bool async)
++paint_all(bool async, bool dpms)
+ {
+ 	gamescope_xwayland_server_t *root_server = wlserver_get_xwayland_server(0);
+ 	xwayland_ctx_t *root_ctx = root_server->ctx.get();
 @@ -2322,6 +2323,7 @@ paint_all(bool async)
  	frameInfo.outputEncodingEOTF = g_ColorMgmt.pending.outputEncodingEOTF;
  	frameInfo.allowVRR = cv_adaptive_sync;
  	frameInfo.bFadingOut = fadingOut;
-+	frameInfo.dpms = g_bDPMS;
++	frameInfo.dpms = dpms;
  
  	// If the window we'd paint as the base layer is the streaming client,
  	// find the video underlay and put it up first in the scenegraph
-@@ -5923,6 +5925,10 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
+@@ -2494,6 +2496,11 @@ paint_all(bool async)
+ 
+ 	if ( !bValidContents || !GetBackend()->IsVisible() )
+ 	{
++		// If dpms, we do not need to display a frame.
++		// Force the display to refresh.
++		if ( dpms ) {
++			GetBackend()->Present( &frameInfo, async );
++		}
+ 		return;
+ 	}
+ 
+@@ -5923,6 +5930,10 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
  	{
  		g_bRefreshHalveEnable = !!get_prop( ctx, ctx->root, ctx->atoms.gamescopeFrameHalveAtom, 0 );
  	}
@@ -1070,7 +1091,7 @@ index 6c8ce74..7589e3a 100644
  }
  
  static int
-@@ -7094,6 +7100,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
+@@ -7094,6 +7105,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
  	ctx->atoms.targets = XInternAtom(ctx->dpy, "TARGETS", false);
  
  	ctx->atoms.gamescopeFrameHalveAtom = XInternAtom( ctx->dpy, "GAMESCOPE_STEAMUI_HALFHZ", false );;
@@ -1078,17 +1099,18 @@ index 6c8ce74..7589e3a 100644
  
  	ctx->root_width = DisplayWidth(ctx->dpy, ctx->scr);
  	ctx->root_height = DisplayHeight(ctx->dpy, ctx->scr);
-@@ -8001,7 +8008,9 @@ steamcompmgr_main(int argc, char **argv)
- 		else
- 			eFlipType = FlipType::Normal;
+@@ -8061,9 +8073,9 @@ steamcompmgr_main(int argc, char **argv)
+ 			bShouldPaint = false;
+ 		}
  
--		bool bShouldPaint = false;
-+		// force repaint if DPMS to avoid it not triggering
-+		// if steam stops blanking before suspend
-+		bool bShouldPaint = g_bDPMS;
- 
- 		if ( GetBackend()->IsVisible() )
+-		if ( bShouldPaint )
++		if ( bShouldPaint || (g_bDPMS && vblank) )
  		{
+-			paint_all( eFlipType == FlipType::Async );
++			paint_all( eFlipType == FlipType::Async, g_bDPMS );
+ 
+ 			hasRepaint = false;
+ 			hasRepaintNonBasePlane = false;
 diff --git a/src/xwayland_ctx.hpp b/src/xwayland_ctx.hpp
 index e4eec9f..2347cbb 100644
 --- a/src/xwayland_ctx.hpp


### PR DESCRIPTION
DPMS would not fire correctly if the screen did not blank, causing it to happen after suspend around 20% of the time. Force it to fire even if there is no new frame.

After suspend, steam refreshes the display anyway so it is not an issue.

HHD controls the blanking so this is a prerequisite to adding that functionality.