### PR TITLE
fix: reinstate ujust install-lact karg modification

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -3,6 +3,7 @@
 # Install LACT for overclocking & undervolting AMD GPUs
 install-lact:
     #!/usr/bin/bash
+		rpm-ostree kargs --append-if-missing=$(printf 'amdgpu.ppfeaturemask=0x%x\n' "$(($(cat /sys/module/amdgpu/parameters/ppfeaturemask) | 0x4000))")
 		if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
 			rpm-ostree install lact-libadwaita
 		else 


### PR DESCRIPTION
Adds back an accidentally removed line in `ujust install-lact` that sets an amdgpu karg
