### PR TITLE
fix(yafti): Fix Bazzite Portal not launching on -deck images

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -23,8 +23,7 @@ screens:
           packages:
           - Retrieve Decky: sudo -A ujust setup-decky install
         EmuDeck:
-          description: |
-            A utility for installing and configuring emulators on the Steam Deck
+          description: A utility for installing and configuring emulators on the Steam Deck
           default: false
           packages:
           - Retrieve EmuDeck: ujust get-emudeck
@@ -44,11 +43,6 @@ screens:
           default: false
           packages:
           - Install scrcpy: ujust install-scrcpy
-        DaVinci Resolve:
-            description: Install/update DaVinci Resolve, a closed-source video editing utility
-            default: false
-            packages:
-            - Install/Update DaVinci Resolve: sudo -A ujust install-resolve
   configure-bazzite:
     source: yafti.screen.package
     values:
@@ -66,21 +60,16 @@ screens:
           default: true
           packages:
           - Enable Updates: sudo -A ujust enable-deck-bios-firmware-updates
-        Hide GRUB Menu:
-          description: |
-          default: false
-          packages:
-          - Hide GRUB: sudo -A ujust configure-grub hide
         Visible Password Aestriks:
             description: Toggles pwfeedback on.
             default: true
             packages:
-            - Install bazzite-cli: ujust bazzite-cli
-        bazzite-cli:
-            description: Bazzite CLI mod for Bluefin style CLI bling.
-            default: false
-            packages:
-            - Install bazzite-cli: ujust bazzite-cli
+            - Toggle password feedback: sudo -A ujust toggle-password-feedback enable
+        Hide GRUB Menu:
+          description: Hide the GRUB menu on boot
+          default: false
+          packages:
+          - Hide GRUB: sudo -A ujust configure-grub hide
         Oversteer:
           description: Application to control supported steering wheels
           default: false


### PR DESCRIPTION
...Hopefully.  I am a little busy and have to drive for a bit, but if this works, can someone please apply these changes to Desktop images if I don't get around to it today or something?

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
