### PR TITLE
fix(yafti): Install More Applications button not opening gnome-software in bazzite-gnome

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
             is_latest_version: true
             is_stable_version: true
             kernel_flavor: bazzite # must match a kernel_flavor from akmods repo
-            kernel_version: 6.11.9-305.bazzite.fc41.x86_64 # must match a cached version of the above flavor
+            kernel_version: 6.11.9-304.bazzite.fc41.x86_64 # must match a cached version of the above flavor
         exclude:
           - base_name: bazzite
             target_nvidia_flavor: nvidia

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
             is_latest_version: true
             is_stable_version: true
             kernel_flavor: bazzite # must match a kernel_flavor from akmods repo
-            kernel_version: 6.11.9-304.bazzite.fc41.x86_64 # must match a cached version of the above flavor
+            kernel_version: 6.11.9-303.bazzite.fc41.x86_64 # must match a cached version of the above flavor
         exclude:
           - base_name: bazzite
             target_nvidia_flavor: nvidia

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -102,7 +102,7 @@ screens:
       icon: "/usr/share/ublue-os/bazzite/logo.svg"
       links:
       - "Install More Applications":
-          run: /usr/bin/plasma-discover
+          run: /usr/bin/plasma-discover || /usr/bin/gnome-software
       - "Documentation":
           run: /usr/bin/xdg-open https://docs.bazzite.gg
       - "Forums":

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -107,7 +107,7 @@ screens:
       icon: "/usr/share/ublue-os/bazzite/logo.svg"
       links:
       - "Install More Applications":
-          run: /usr/bin/plasma-discover
+          run: /usr/bin/plasma-discover || /usr/bin/gnome-software
       - "Documentation":
           run: /usr/bin/xdg-open https://docs.bazzite.gg
       - "Forums":


### PR DESCRIPTION
This is a fix for #1930 the "Install More Applications" at the end of the Bazzite portal wizard will now open Gnome Software  when running bazzite-gnome or bazzite-deck-gnome rather than doing nothing.