### PR TITLE
fix(btrfs-assistant) Enable snapper-cleanup.timer

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -769,6 +769,7 @@ RUN rm -f /etc/profile.d/toolbox.sh && \
     systemctl disable tailscaled.service && \
     systemctl enable dev-hugepages1G.mount && \
     systemctl enable bazzite-snapper-setup && \
+    systemctl enable snapper-cleanup.timer && \
     systemctl --global enable bazzite-user-setup.service && \
     systemctl --global enable podman.socket && \
     systemctl --global enable systemd-tmpfiles-setup.service && \


### PR DESCRIPTION
This will avoid snapper creating snapshots without removing old one, eventually filling up the space