### PR TITLE
fix(tuned-ppd): correct config existence check in bazzite-hardware-setup

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -265,7 +265,7 @@ fi
 
 # PPD FIX
 # Correct broken config files on some systems
-if -f "/etc/tuned/ppd.conf" && ! grep "\[battery\]" "/etc/tuned/ppd.conf"; then
+if [[ -f "/etc/tuned/ppd.conf" ]] && ! grep "\[battery\]" "/etc/tuned/ppd.conf"; then
   cp -f "/usr/etc/tuned/ppd.conf" "/etc/tuned/ppd.conf"
 fi
 


### PR DESCRIPTION
While looking through the system journal, I noticed one of the Bazzite scripts was throwing an error on boot:

```
Dec 04 18:46:39 bazzie bazzite-hardware-setup[1936]: /usr/libexec/bazzite-hardware-setup: line 268: -f: command not found
```

This is coming from a recent change (https://github.com/ublue-os/bazzite/commit/389f4a55c905b1efef50dd0bce9ad373543add3d) that is trying to update the `/etc/tuned/ppd.conf` file if it exists, but the existence check is missing brackets.