### PR TITLE
fix(mesa): add temporary patch for Indiana Jones and the Great Circle

### DIFF
--- a/spec_files/mesa/indiana.patch
+++ b/spec_files/mesa/indiana.patch
@@ -1,30 +1,23 @@
-From b302d9fec18b7c3c045ae53f980824e8734b92f3 Mon Sep 17 00:00:00 2001
-From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
-Date: Fri, 6 Dec 2024 16:25:18 +0100
-Subject: [PATCH] radv: add radv_disable_dcc_stores and enable for Indiana
- Jones: The Great Circle
+From 5f36d879f820797b5ee06186c87a2f294f706d36 Mon Sep 17 00:00:00 2001
+From: Atapi <34801996+Sterophonick@users.noreply.github.com>
+Date: Sat, 7 Dec 2024 11:43:01 -0700
+Subject: [PATCH] backport indiana jones tweaks
 
-Likely a game bug but can't be 100% sure because the game uses RT by
-default and renderdoc still doesn't have support for it.
-
-Cc: mesa-stable
-Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12257
-Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
 ---
  src/amd/vulkan/radv_image.c    | 4 ++++
- src/amd/vulkan/radv_instance.c | 2 ++
+ src/amd/vulkan/radv_instance.c | 3 +++
  src/amd/vulkan/radv_instance.h | 1 +
- src/util/00-radv-defaults.conf | 1 +
+ src/util/00-radv-defaults.conf | 6 ++++++
  src/util/driconf.h             | 4 ++++
- 5 files changed, 12 insertions(+)
+ 5 files changed, 18 insertions(+)
 
 diff --git a/src/amd/vulkan/radv_image.c b/src/amd/vulkan/radv_image.c
-index f7583e4441cef..605207112a58e 100644
+index eeefe236d97..2b3a59e1c6b 100644
 --- a/src/amd/vulkan/radv_image.c
 +++ b/src/amd/vulkan/radv_image.c
-@@ -295,6 +295,10 @@ radv_use_dcc_for_image_early(struct radv_device *device, struct radv_image *imag
-    if (instance->drirc.disable_dcc_mips && pCreateInfo->mipLevels > 1)
-       return false;
+@@ -297,6 +297,10 @@ radv_use_dcc_for_image_early(struct radv_device *device, struct radv_image *imag
+          return false;
+    }
  
 +   /* Force disable DCC for stores to workaround game bugs. */
 +   if (instance->drirc.disable_dcc_stores && (pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT))
@@ -34,56 +27,62 @@ index f7583e4441cef..605207112a58e 100644
     if (pCreateInfo->samples > 1 && pdev->info.gfx_level < GFX11 && (instance->debug_flags & RADV_DEBUG_NO_FMASK))
        return false;
 diff --git a/src/amd/vulkan/radv_instance.c b/src/amd/vulkan/radv_instance.c
-index cacb7f86279db..eebdaed6e3bec 100644
+index 9eba490397b..b5333a4f58b 100644
 --- a/src/amd/vulkan/radv_instance.c
 +++ b/src/amd/vulkan/radv_instance.c
-@@ -174,6 +174,7 @@ static const driOptionDescription radv_dri_options[] = {
+@@ -145,6 +145,7 @@ static const driOptionDescription radv_dri_options[] = {
+       DRI_CONF_RADV_SPLIT_FMA(false)
        DRI_CONF_RADV_DISABLE_TC_COMPAT_HTILE_GENERAL(false)
        DRI_CONF_RADV_DISABLE_DCC(false)
-       DRI_CONF_RADV_DISABLE_DCC_MIPS(false)
 +      DRI_CONF_RADV_DISABLE_DCC_STORES(false)
        DRI_CONF_RADV_DISABLE_ANISO_SINGLE_LEVEL(false)
        DRI_CONF_RADV_DISABLE_TRUNC_COORD(false)
        DRI_CONF_RADV_DISABLE_SINKING_LOAD_INPUT_FS(false)
-@@ -282,6 +283,7 @@ radv_init_dri_options(struct radv_instance *instance)
-    instance->drirc.vk_require_astc = driQueryOptionb(&instance->drirc.options, "vk_require_astc");
+@@ -258,6 +259,8 @@ radv_init_dri_options(struct radv_instance *instance)
  
-    instance->drirc.disable_dcc_mips = driQueryOptionb(&instance->drirc.options, "radv_disable_dcc_mips");
+    instance->drirc.vk_require_etc2 = driQueryOptionb(&instance->drirc.options, "vk_require_etc2");
+    instance->drirc.vk_require_astc = driQueryOptionb(&instance->drirc.options, "vk_require_astc");
++
 +   instance->drirc.disable_dcc_stores = driQueryOptionb(&instance->drirc.options, "radv_disable_dcc_stores");
  }
  
  static const struct vk_instance_extension_table radv_instance_extensions_supported = {
 diff --git a/src/amd/vulkan/radv_instance.h b/src/amd/vulkan/radv_instance.h
-index 88880135fa66e..a7e0645ae7621 100644
+index e87a5301c60..98441116c52 100644
 --- a/src/amd/vulkan/radv_instance.h
 +++ b/src/amd/vulkan/radv_instance.h
-@@ -72,6 +72,7 @@ struct radv_instance {
+@@ -68,6 +68,7 @@ struct radv_instance {
+       bool report_llvm9_version_string;
        bool vk_require_etc2;
        bool vk_require_astc;
-       bool disable_dcc_mips;
 +      bool disable_dcc_stores;
        char *app_layer;
        uint8_t override_graphics_shader_version;
        uint8_t override_compute_shader_version;
 diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
-index a5718a53ea0c8..1d8ca7d5f1a1b 100644
+index 555fc3c79af..a502aa79621 100644
 --- a/src/util/00-radv-defaults.conf
 +++ b/src/util/00-radv-defaults.conf
-@@ -111,6 +111,7 @@ Application bugs worked around in this file:
-         <application name="Indiana Jones: The Great Circle" application_name_match="TheGreatCircle">
-             <option name="radv_zero_vram" value="true" />
+@@ -110,6 +110,12 @@ Application bugs worked around in this file:
              <option name="radv_legacy_sparse_binding" value="true" />
-+            <option name="radv_disable_dcc_stores" value="true" />
          </application>
  
++        <application name="Indiana Jones: The Great Circle" application_name_match="TheGreatCircle">
++            <option name="radv_zero_vram" value="true" />
++            <option name="radv_legacy_sparse_binding" value="true" />
++            <option name="radv_disable_dcc_stores" value="true" />
++        </application>
++
          <application name="DOOM (2016)" application_name_match="DOOM$">
+             <option name="radv_disable_dcc" value="true" />
+         </application>
 diff --git a/src/util/driconf.h b/src/util/driconf.h
-index 0c85305d171b3..5e71e49e1fcc9 100644
+index a2c18e211c9..2878fae35cd 100644
 --- a/src/util/driconf.h
 +++ b/src/util/driconf.h
-@@ -696,6 +696,10 @@
-    DRI_CONF_OPT_B(radv_disable_dcc_mips, def, \
-                   "Disable DCC for color images with mips")
+@@ -657,6 +657,10 @@
+    DRI_CONF_OPT_B(radv_disable_dcc, def, \
+                   "Disable DCC for color images")
  
 +#define DRI_CONF_RADV_DISABLE_DCC_STORES(def) \
 +   DRI_CONF_OPT_B(radv_disable_dcc_stores, def, \
@@ -93,37 +92,5 @@ index 0c85305d171b3..5e71e49e1fcc9 100644
    DRI_CONF_OPT_B(radv_disable_aniso_single_level, def, \
                   "Disable anisotropic filtering for single level images")
 -- 
-GitLab
-
-From c2f8f20ef75a00917a652e32d4caa48029c68681 Mon Sep 17 00:00:00 2001
-From: Friedrich Vock <friedrich.vock@gmx.de>
-Date: Fri, 6 Dec 2024 07:42:31 +0100
-Subject: [PATCH] radv,driconf: Apply DOOM Eternal/idTech workarounds for
- Indiana Jones
-
-It's based on idTech and exhibits the same idTech bugs.
-
-Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32521>
----
- src/util/00-radv-defaults.conf | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
-index 45686f375a289..a5718a53ea0c8 100644
---- a/src/util/00-radv-defaults.conf
-+++ b/src/util/00-radv-defaults.conf
-@@ -108,6 +108,11 @@ Application bugs worked around in this file:
-             <option name="radv_legacy_sparse_binding" value="true" />
-         </application>
- 
-+        <application name="Indiana Jones: The Great Circle" application_name_match="TheGreatCircle">
-+            <option name="radv_zero_vram" value="true" />
-+            <option name="radv_legacy_sparse_binding" value="true" />
-+        </application>
-+
-         <application name="DOOM (2016)" application_name_match="DOOM$">
-             <option name="radv_disable_dcc" value="true" />
-         </application>
--- 
-GitLab
+2.47.1
 

--- a/spec_files/mesa/indiana.patch
+++ b/spec_files/mesa/indiana.patch
@@ -1,0 +1,129 @@
+From b302d9fec18b7c3c045ae53f980824e8734b92f3 Mon Sep 17 00:00:00 2001
+From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+Date: Fri, 6 Dec 2024 16:25:18 +0100
+Subject: [PATCH] radv: add radv_disable_dcc_stores and enable for Indiana
+ Jones: The Great Circle
+
+Likely a game bug but can't be 100% sure because the game uses RT by
+default and renderdoc still doesn't have support for it.
+
+Cc: mesa-stable
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12257
+Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+---
+ src/amd/vulkan/radv_image.c    | 4 ++++
+ src/amd/vulkan/radv_instance.c | 2 ++
+ src/amd/vulkan/radv_instance.h | 1 +
+ src/util/00-radv-defaults.conf | 1 +
+ src/util/driconf.h             | 4 ++++
+ 5 files changed, 12 insertions(+)
+
+diff --git a/src/amd/vulkan/radv_image.c b/src/amd/vulkan/radv_image.c
+index f7583e4441cef..605207112a58e 100644
+--- a/src/amd/vulkan/radv_image.c
++++ b/src/amd/vulkan/radv_image.c
+@@ -295,6 +295,10 @@ radv_use_dcc_for_image_early(struct radv_device *device, struct radv_image *imag
+    if (instance->drirc.disable_dcc_mips && pCreateInfo->mipLevels > 1)
+       return false;
+ 
++   /* Force disable DCC for stores to workaround game bugs. */
++   if (instance->drirc.disable_dcc_stores && (pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT))
++      return false;
++
+    /* DCC MSAA can't work on GFX10.3 and earlier without FMASK. */
+    if (pCreateInfo->samples > 1 && pdev->info.gfx_level < GFX11 && (instance->debug_flags & RADV_DEBUG_NO_FMASK))
+       return false;
+diff --git a/src/amd/vulkan/radv_instance.c b/src/amd/vulkan/radv_instance.c
+index cacb7f86279db..eebdaed6e3bec 100644
+--- a/src/amd/vulkan/radv_instance.c
++++ b/src/amd/vulkan/radv_instance.c
+@@ -174,6 +174,7 @@ static const driOptionDescription radv_dri_options[] = {
+       DRI_CONF_RADV_DISABLE_TC_COMPAT_HTILE_GENERAL(false)
+       DRI_CONF_RADV_DISABLE_DCC(false)
+       DRI_CONF_RADV_DISABLE_DCC_MIPS(false)
++      DRI_CONF_RADV_DISABLE_DCC_STORES(false)
+       DRI_CONF_RADV_DISABLE_ANISO_SINGLE_LEVEL(false)
+       DRI_CONF_RADV_DISABLE_TRUNC_COORD(false)
+       DRI_CONF_RADV_DISABLE_SINKING_LOAD_INPUT_FS(false)
+@@ -282,6 +283,7 @@ radv_init_dri_options(struct radv_instance *instance)
+    instance->drirc.vk_require_astc = driQueryOptionb(&instance->drirc.options, "vk_require_astc");
+ 
+    instance->drirc.disable_dcc_mips = driQueryOptionb(&instance->drirc.options, "radv_disable_dcc_mips");
++   instance->drirc.disable_dcc_stores = driQueryOptionb(&instance->drirc.options, "radv_disable_dcc_stores");
+ }
+ 
+ static const struct vk_instance_extension_table radv_instance_extensions_supported = {
+diff --git a/src/amd/vulkan/radv_instance.h b/src/amd/vulkan/radv_instance.h
+index 88880135fa66e..a7e0645ae7621 100644
+--- a/src/amd/vulkan/radv_instance.h
++++ b/src/amd/vulkan/radv_instance.h
+@@ -72,6 +72,7 @@ struct radv_instance {
+       bool vk_require_etc2;
+       bool vk_require_astc;
+       bool disable_dcc_mips;
++      bool disable_dcc_stores;
+       char *app_layer;
+       uint8_t override_graphics_shader_version;
+       uint8_t override_compute_shader_version;
+diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
+index a5718a53ea0c8..1d8ca7d5f1a1b 100644
+--- a/src/util/00-radv-defaults.conf
++++ b/src/util/00-radv-defaults.conf
+@@ -111,6 +111,7 @@ Application bugs worked around in this file:
+         <application name="Indiana Jones: The Great Circle" application_name_match="TheGreatCircle">
+             <option name="radv_zero_vram" value="true" />
+             <option name="radv_legacy_sparse_binding" value="true" />
++            <option name="radv_disable_dcc_stores" value="true" />
+         </application>
+ 
+         <application name="DOOM (2016)" application_name_match="DOOM$">
+diff --git a/src/util/driconf.h b/src/util/driconf.h
+index 0c85305d171b3..5e71e49e1fcc9 100644
+--- a/src/util/driconf.h
++++ b/src/util/driconf.h
+@@ -696,6 +696,10 @@
+    DRI_CONF_OPT_B(radv_disable_dcc_mips, def, \
+                   "Disable DCC for color images with mips")
+ 
++#define DRI_CONF_RADV_DISABLE_DCC_STORES(def) \
++   DRI_CONF_OPT_B(radv_disable_dcc_stores, def, \
++                  "Disable DCC for color storage images")
++
+ #define DRI_CONF_RADV_DISABLE_ANISO_SINGLE_LEVEL(def) \
+   DRI_CONF_OPT_B(radv_disable_aniso_single_level, def, \
+                  "Disable anisotropic filtering for single level images")
+-- 
+GitLab
+
+From c2f8f20ef75a00917a652e32d4caa48029c68681 Mon Sep 17 00:00:00 2001
+From: Friedrich Vock <friedrich.vock@gmx.de>
+Date: Fri, 6 Dec 2024 07:42:31 +0100
+Subject: [PATCH] radv,driconf: Apply DOOM Eternal/idTech workarounds for
+ Indiana Jones
+
+It's based on idTech and exhibits the same idTech bugs.
+
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32521>
+---
+ src/util/00-radv-defaults.conf | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
+index 45686f375a289..a5718a53ea0c8 100644
+--- a/src/util/00-radv-defaults.conf
++++ b/src/util/00-radv-defaults.conf
+@@ -108,6 +108,11 @@ Application bugs worked around in this file:
+             <option name="radv_legacy_sparse_binding" value="true" />
+         </application>
+ 
++        <application name="Indiana Jones: The Great Circle" application_name_match="TheGreatCircle">
++            <option name="radv_zero_vram" value="true" />
++            <option name="radv_legacy_sparse_binding" value="true" />
++        </application>
++
+         <application name="DOOM (2016)" application_name_match="DOOM$">
+             <option name="radv_disable_dcc" value="true" />
+         </application>
+-- 
+GitLab
+

--- a/spec_files/mesa/mesa.spec
+++ b/spec_files/mesa/mesa.spec
@@ -89,7 +89,7 @@ Patch10:        gnome-shell-glthread-disable.patch
 Patch20:        valve.patch
 
 # TEMPORARY: Patches for Indiana Jones and the Great Circle
-Patch20:        indiana.patch
+Patch30:        indiana.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc

--- a/spec_files/mesa/mesa.spec
+++ b/spec_files/mesa/mesa.spec
@@ -73,7 +73,7 @@ Summary:        Mesa graphics libraries
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
 Epoch:          1
 %global orig_release 1%{?dist}
-Release:        100.bazzite.%{orig_release}
+Release:        101.bazzite.%{orig_release}
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -87,6 +87,9 @@ Patch10:        gnome-shell-glthread-disable.patch
 
 # https://gitlab.com/evlaV/mesa/
 Patch20:        valve.patch
+
+# TEMPORARY: Patches for Indiana Jones and the Great Circle
+Patch20:        indiana.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc


### PR DESCRIPTION
Imports the following two commits into Mesa 24.2.7:
https://gitlab.freedesktop.org/hakzsam/mesa/-/commit/b302d9fec18b7c3c045ae53f980824e8734b92f3
https://gitlab.freedesktop.org/mesa/mesa/-/commit/3f31161eb36680a2b78d935e9018e32280cc8fe3

Game is still not perfect but it's a marked improvement over extreme corruption.