### PR TITLE
fix: fix trailing commas in JSON

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/motd/themes/pink.json
+++ b/system_files/desktop/shared/usr/share/ublue-os/motd/themes/pink.json
@@ -77,7 +77,7 @@
     "prefix": " ",
     "suffix": " ",
     "color": "212",
-    "bold": true,
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/desktop/shared/usr/share/ublue-os/motd/themes/purple.json
+++ b/system_files/desktop/shared/usr/share/ublue-os/motd/themes/purple.json
@@ -77,7 +77,7 @@
     "prefix": " ",
     "suffix": " ",
     "color": "165",
-    "bold": true,
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/desktop/shared/usr/share/ublue-os/motd/themes/red.json
+++ b/system_files/desktop/shared/usr/share/ublue-os/motd/themes/red.json
@@ -77,7 +77,7 @@
     "prefix": " ",
     "suffix": " ",
     "color": "203",
-    "bold": true,
+    "bold": true
   },
   "code_block": {},
   "table": {},


### PR DESCRIPTION
Fix for https://github.com/ublue-os/bazzite/issues/1972.

Invalid JSON was causing an error whenever shell was booted.
