### PR TITLE
fix: Adjust yafti and sunshine ujust for layered version of sunshine

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -31,8 +31,7 @@ screens:
           description: A self-hosted game stream host for Moonlight
           default: false
           packages:
-          - Install Sunshine: ujust setup-sunshine install
-          - Autostart Sunshine: ujust setup-sunshine autostart
+          - Enable Sunshine: ujust setup-sunshine enable
         Resilio Sync:
           description: A file synchronization utility powered by BitTorrent
           default: false

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -21,8 +21,7 @@ screens:
           description: A self-hosted game stream host for Moonlight
           default: false
           packages:
-          - Install Sunshine: ujust setup-sunshine install
-          - Autostart Sunshine: ujust setup-sunshine autostart
+          - Enable Sunshine: ujust setup-sunshine enable
         EmuDeck:
           description: A utility for installing and configuring emulators.
           default: false

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -4,14 +4,8 @@
 setup-sunshine ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    SUNSHINE_STATE="$(rpm -qa sunshine)"
     SERVICE_STATE="$(systemctl is-enabled --user sunshine.service)"
     OPTION={{ ACTION }}
-    if [ "$SUNSHINE_STATE" == "" ]; then
-        SUNSHINE_STATE="${red}${b}Not Installed${n}"
-    else
-        SUNSHINE_STATE="${green}${b}Installed${n}"
-    fi
     if [ "$SERVICE_STATE" == "enabled" ]; then
         SERVICE_STATE="${green}${b}Enabled${n}"
     else
@@ -20,30 +14,17 @@ setup-sunshine ACTION="":
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust setup-sunshine <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
-      echo "  Use 'install' to select Install Sunshine"
-      echo "  Use 'remove' to select Remove Sunshine"
-      echo "  Use 'autostart' to select Toggle Autostart"
+      echo "  Use 'enable' to enable the Sunshine service"
+      echo "  Use 'disable' to disable the Sunshine service"
       exit 0
     elif [ "$OPTION" == "" ]; then
-      echo "${bold}Sunshine setup and configuration${normal}"
-      echo "Sunshine is $SUNSHINE_STATE"
       echo "Service is $SERVICE_STATE"
-      OPTION=$(Choose "Install Sunshine" "Remove Sunshine" "Toggle Autostart")
+      OPTION=$(Choose "Enable" "Disable")
     fi
-    if [[ "${OPTION,,}" =~ ^install ]]; then
+    if [[ "${OPTION,,}" =~ ^enable ]]; then
       systemctl enable sunshine-workaround.service
-      ublue-update --wait
-      rpm-ostree install --apply-live -y sunshine
-      echo "Sunshine is installed!"
-    elif [[ "${OPTION,,}" =~ ^(remove|uninstall) ]]; then
+      systemctl enable --user --now sunshine.service
+    elif [[ "${OPTION,,}" =~ ^(remove|uninstall|disable) ]]; then
       systemctl disable sunshine-workaround.service
-      ublue-update --wait
-      rpm-ostree remove -y sunshine
-      echo "Sunshine has been uninstalled."
-    elif [[ "${OPTION,,}" =~ autostart ]]; then
-      if [[ "${SERVICE_STATE,,}" =~ disabled ]]; then
-        systemctl enable --user --now sunshine.service
-      else
-        systemctl disable --user --now sunshine.service 
-      fi
+      systemctl disable --user --now sunshine.service 
     fi


### PR DESCRIPTION
If we decide to switch to sunshine being included in the Bazzite image, its service would be off by default like sshd. So I've adjusted the logic in the yafti.yml files to only enable the service. I've adjusted the `ujust setup-sunshine` script too accordingly.

I'm not certain if the sunshine-workaround.service is needed or not but I've included it in the enable and disable logic
