### PR TITLE
chore(yafti): Remove Sunshine from the Bazzite Portal

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -27,11 +27,6 @@ screens:
           default: false
           packages:
           - Retrieve EmuDeck: ujust get-emudeck
-        Sunshine:
-          description: A self-hosted game stream host for Moonlight
-          default: false
-          packages:
-          - Enable Sunshine: ujust setup-sunshine enable
         Resilio Sync:
           description: A file synchronization utility powered by BitTorrent
           default: false

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -17,11 +17,6 @@ screens:
       show_terminal: true
       package_manager: yafti.plugin.run
       groups:
-        Sunshine:
-          description: A self-hosted game stream host for Moonlight
-          default: false
-          packages:
-          - Enable Sunshine: ujust setup-sunshine enable
         EmuDeck:
           description: A utility for installing and configuring emulators.
           default: false


### PR DESCRIPTION
If Sunshine being part of the image now works fine, then removing it from the Bazzite Portal should also happen.  Please note, this commit does **not** remove the `ujust` commands.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
