### PR TITLE
fix(ujust): removed removed script dependencies for ujust setup-boot-windows-steam

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/86-bazzite-windows.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/86-bazzite-windows.just
@@ -5,4 +5,5 @@ setup-boot-windows-steam:
     echo "Making efibootmgr -n usable without sudo password"
     echo "%wheel ALL=(root) NOPASSWD: /usr/sbin/efibootmgr" | sudo tee /etc/sudoers.d/efibootmgr-config
     echo "Adding /usr/bin/boot-windows as a Non-steam game"
-    /usr/bin/steamos-add-to-steam /usr/bin/boot-windows
+    touch /tmp/addnonsteamgamefile
+    steam "steam://addnonsteamgame/%2Fusr%2Fbin%2Fboot-windows"


### PR DESCRIPTION
This is a fix for #2017, looks like the `/usr/bin/steamos-add-to-steam` file isn't available on Bazzite Gnome desktop, so I've removed the reliance on this script file in the `ujust setup-boot-windows-steam` script