### PR TITLE
fix: return on bling.sh if it already got sourced

### DIFF
--- a/system_files/overrides/usr/share/bazzite-cli/bling.sh
+++ b/system_files/overrides/usr/share/bazzite-cli/bling.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# Check if bling has already been sourced so that we dont break atuin. https://github.com/atuinsh/atuin/issues/380#issuecomment-1594014644
+[ "${BLING_SOURCED:-0}" -eq 1 ] && return 
+BLING_SOURCED=1
+
 # ls aliases
 if [ "$(command -v eza)" ]; then
     alias ll='eza -l --icons=auto --group-directories-first'


### PR DESCRIPTION
Port of https://github.com/ublue-os/bluefin/commit/76d7d71e900902845f3e715da85affe4dce52b7a from the bluefin repo. Should fix atuin getting sourced multiple times
