### PR TITLE
fix: update ArtifactHub README.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
           version: '${{ steps.generate-version.outputs.tag }}'
           labels: |
             io.artifacthub.package.logo-url=https://raw.githubusercontent.com/ublue-os/bazzite/main/repo_content/logo.png
-            io.artifacthub.package.readme-url=https://docs.bazzite.gg
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/bazzite/refs/heads/main/README.md
             org.opencontainers.image.created=<timestamp>
             org.opencontainers.image.description=Bazzite is a custom image built upon Fedora Atomic Desktops that brings the best of Linux gaming to all of your devices - including your favorite handheld.
             org.opencontainers.image.licenses=Apache-2.0


### PR DESCRIPTION
ArtifactHub requires the raw README file, not a website.  
Currently this is not being rendered correctly, and is only showing HTML of the website (which is not useful).

![image](https://github.com/user-attachments/assets/e14ccd69-44db-47bb-b9dd-c71e0b57d2a2)
