### PR TITLE
feat: add ls-iommu and update virtualization ujust for bootc transition

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -489,6 +489,12 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
     chmod +x /usr/bin/installcab && \
     curl -Lo /usr/bin/install-mf-wmv https://github.com/KyleGospo/steam-proton-mf-wmv/blob/master/install-mf-wmv.sh && \
     chmod +x /usr/bin/install-mf-wmv && \
+    curl -Lo /tmp/ls-iommu.tar.gz $(curl https://api.github.com/repos/HikariKnight/ls-iommu/releases/latest | jq -r '.assets[] | select(.name| test(".*x86_64.tar.gz$")).browser_download_url') && \
+    mkdir -p /tmp/ls-iommu && \
+    tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu.tar.gz -C /tmp/ls-iommu && \
+    rm -f /tmp/ls-iommu.tar.gz && \
+    cp -r /tmp/ls-iommu/ls-iommu /usr/bin/ && \
+    rm -rf /tmp/ls-iommu && \
     /usr/libexec/containerbuild/cleanup.sh && \
     ostree container commit
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -100,7 +100,7 @@ setup-virtualization ACTION="":
           echo 'rpm-ostree kargs --append-if-missing="vfio_pci.ids=xxxx:yyyy,xxxx:yyzz"'
           echo "You will require a $(Urllink "https://www.amazon.com/s?k=hdmi+displayport+dummy+plug" "Dummy HDMI/DisplayPort plug (Ghost Adapter)") or hook the GPU"
           echo "to a separate monitor input in order to turn the GPU on when starting the VM."
-          echo "NOTE: Your second GPU cannot share the same ids as your main gpu and will not be usable by the host after you bind it to the vfio driver!"
+          echo "NOTE: Your second GPU should be as different as possible from your main GPU and will not be usable by the host after you bind it to the vfio driver!"
           echo ""
           echo "${b}Systems with 1 GPU${n}"
           echo "Once rebooted you can continue setting up whatever scripts and hooks you need"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -89,7 +89,7 @@ setup-virtualization ACTION="":
           rpm-ostree kargs \
             --append-if-missing="${VENDOR_KARG}" \
             --append-if-missing="iommu=pt" \
-            --append-if-missing="rd.driver.pre=vfio_pci" \
+            --append-if-missing="rd.driver.pre=vfio-pci" \
             --append-if-missing="vfio_pci.disable_vga=1"
           echo "VFIO will be enabled on next boot, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
           echo "Please understand that since this is such a niche use case, support will be very limited!"
@@ -97,7 +97,7 @@ setup-virtualization ACTION="":
           echo ""
           echo "${b}Systems with multiple GPUs${n}"
           echo "Bind your unused/second GPU device ids to the vfio driver by running"
-          echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
+          echo 'rpm-ostree kargs --append-if-missing="vfio_pci.ids=xxxx:yyyy,xxxx:yyzz"'
           echo "You will require a $(Urllink "https://www.amazon.com/s?k=hdmi+displayport+dummy+plug" "Dummy HDMI/DisplayPort plug (Ghost Adapter)") or hook the GPU"
           echo "to a separate monitor input in order to turn the GPU on when starting the VM."
           echo "NOTE: Your second GPU cannot share the same ids as your main gpu and will not be usable by the host after you bind it to the vfio driver!"
@@ -141,7 +141,7 @@ setup-virtualization ACTION="":
         --delete-if-present="iommu=on" \
         --delete-if-present="amd_iommu=on" \
         --delete-if-present="intel_iommu=on" \
-        --delete-if-present="rd.driver.pre=vfio_pci" \
+        --delete-if-present="rd.driver.pre=vfio-pci" \
         --delete-if-present="vfio_pci.disable_vga=1" \
         --delete-if-present="vfio_pci.disable_vga=0" \
         $VFIO_IDS_KARG \

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -93,6 +93,7 @@ setup-virtualization ACTION="":
             --append-if-missing="vfio_pci.disable_vga=1"
           echo "VFIO will be enabled on next boot, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
           echo "Please understand that since this is such a niche use case, support will be very limited!"
+          echo 'Use the command "ls-iommu -grk" to get iommu information about your GPUs, use the "--help" flag for more options'
           echo ""
           echo "${b}Systems with multiple GPUs${n}"
           echo "Bind your unused/second GPU device ids to the vfio driver by running"
@@ -125,9 +126,16 @@ setup-virtualization ACTION="":
           echo "$VFIO_IDS"
           VFIO_IDS_KARG="--delete-if-present=\"$VFIO_IDS\""
         fi
-        echo "Removing dracut modules"
+        KVMFR_VAL="$(rpm-ostree kargs | sed -E 's/.+(kvmfr.static_size_mb=.+\s)/\1/' | awk '{ print $1 }' | grep kvmfr.static_size_mb)"
+        KVMFR_KARG=""
+        if [ -n "$KVMFR_VAL" ]; then
+          echo "Found KVMFR static_size_mb in kargs, adding the below line to removal list"
+          echo "$KVMFR_VAL"
+          KVMFR_KARG="--delete-if-present=\"$KVMFR_VAL\""
+        fi
+        echo "Removing deprecated dracut modules"
         sudo rm /etc/dracut.conf.d/vfio.conf
-        rpm-ostree initramfs --enable
+        sudo rn /etc/modprobe.d/kvmfr.conf
         rpm-ostree kargs \
         --delete-if-present="iommu=pt" \
         --delete-if-present="iommu=on" \
@@ -136,7 +144,8 @@ setup-virtualization ACTION="":
         --delete-if-present="rd.driver.pre=vfio_pci" \
         --delete-if-present="vfio_pci.disable_vga=1" \
         --delete-if-present="vfio_pci.disable_vga=0" \
-        $VFIO_IDS_KARG
+        $VFIO_IDS_KARG \
+        $KVMFR_KARG
       fi
     elif [[ "${OPTION,,}" =~ kvmfr ]]; then
       # Check if we are running on a Steam Deck
@@ -157,12 +166,14 @@ setup-virtualization ACTION="":
       fi
       echo ""
       echo "Setting up kvmfr module so it loads next boot"
-      sudo bash -c 'cat << KVMFR_DRACUT > /etc/dracut.conf.d/kvmfr.conf
-    install_items+=" /etc/modprobe.d/kvmfr.conf "
-    KVMFR_DRACUT'
       sudo bash -c "cat << KVMFR_MODPROBE > /etc/modprobe.d/kvmfr.conf
-    options kvmfr static_size_mb=128
+    # This is a dummy file and changing it does nothing
+    # If you want to change the kvmfr static_size_mb
+    # Run "rpm-ostree kargs --replace=kvmfr.static_size_mb=oldvalue=newvalue"
+    # Default value set by us is 128 which is enough for 4k SDR
+    # Find the current value by running "rpm-ostree kargs"
     KVMFR_MODPROBE"
+      rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128"
       echo "Adding udev rule for /dev/kvmfr0"
       sudo bash -c 'cat << KVMFR_UDEV > /etc/udev/rules.d/99-kvmfr.rules
     SUBSYSTEM=="kvmfr", OWNER="'$USER'", GROUP="qemu", MODE="0660"
@@ -221,14 +232,11 @@ setup-virtualization ACTION="":
       echo "Most ghost display adapters max out at 4k, hence the default value of 128mb."
       echo ""
       echo "If you need to change it to a different value"
-      echo "you can do that in /etc/modprobe.d/kvmfr.conf"
+      echo "you can do that by running \"rpm-ostree kargs --replace=kvmfr.static_size_mb=128=newvalue\""
+      echo "You can check the current kernel arguments with \"rpm-ostree kargs\""
       echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "Please read official documentation for kvmfr for how to use it")"
-      echo ""
-      echo "Press OK to start the process of regenerating your initramfs, this will take a long time"
-      echo "and there is no good way to track progress for it, if anything is wrong it will error out."
-      echo "${b}NOTE: You can start using kvmfr right now without rebooting, but you will need to regenerate initramfs for it to auto load next boot.${n}"
+      echo "${b}NOTE: You can start using kvmfr right now without rebooting if you already rebooted after enabling VFIO.${n}"
       CONFIRM=$(Choose OK)
-      rpm-ostree initramfs --enable
     elif [[ "${OPTION,,}" =~ group ]]; then
       if ! grep -q "^libvirt" /etc/group; then
         grep '^libvirt' /usr/lib/group | sudo tee -a /etc/group > /dev/null

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -135,7 +135,7 @@ setup-virtualization ACTION="":
         fi
         echo "Removing deprecated dracut modules"
         sudo rm /etc/dracut.conf.d/vfio.conf
-        sudo rn /etc/modprobe.d/kvmfr.conf
+        sudo rm /etc/modprobe.d/kvmfr.conf
         rpm-ostree kargs \
         --delete-if-present="iommu=pt" \
         --delete-if-present="iommu=on" \

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -100,7 +100,7 @@ setup-virtualization ACTION="":
           echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
           echo "You will require a $(Urllink "https://www.amazon.com/s?k=hdmi+displayport+dummy+plug" "Dummy HDMI/DisplayPort plug (Ghost Adapter)") or hook the GPU"
           echo "to a separate monitor input in order to turn the GPU on when starting the VM."
-          echo "NOTE: Your second GPU will not be usable by the host after you bind it to the vfio driver!"
+          echo "NOTE: Your second GPU cannot share the same ids as your main gpu and will not be usable by the host after you bind it to the vfio driver!"
           echo ""
           echo "${b}Systems with 1 GPU${n}"
           echo "Once rebooted you can continue setting up whatever scripts and hooks you need"


### PR DESCRIPTION
Adds the latest [ls-iommu](https://github.com/HikariKnight/ls-iommu) tool to the image and updates the virtualization ujust to no longer rely on initramfs regeneration as bootc does not support that.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
