### PR TITLE
chore: add artifacthub metadata

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,7 @@
+repositoryID: 6f68e5bb-ffaf-4a70-9c1b-b154b772044e
+owners: # (optional, used to claim repository ownership)
+  - name: Jorge Castro
+    email: jorge.castro@gmail.com
+#ignore: # (optional, packages that should not be indexed by Artifact Hub)
+#  - name: package1
+#  - name: package2 # Exact match


### PR DESCRIPTION
This is to show bazzite as verified on artifacthub (tied to our account). 

Tulip will have a follow up PR to update the metadata fields.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
