### PR TITLE
fix(just): display libvirtd hooks guide after it is downloaded

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -53,9 +53,9 @@ setup-virtualization ACTION="":
           sudo chown tss /var/lib/swtpm-localca
           if sudo test ! -f "/etc/libvirt/hooks/qemu"; then
             echo "Adding libvirt qemu hooks"
-            sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
             sudo wget 'https://raw.githubusercontent.com/PassthroughPOST/VFIO-Tools/master/libvirt_hooks/qemu' -O /etc/libvirt/hooks/qemu
             sudo chmod +x /etc/libvirt/hooks/qemu
+            sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
             if sudo test ! -d "/etc/libvirt/hooks/qemu/qemu.d"; then
               sudo mkdir /etc/libvirt/hooks/qemu/qemu.d
             fi


### PR DESCRIPTION
maybe writing the previous PR at 3am was a bad idea?

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
