### PR TITLE
fix: force vfio modules to hopefully load before gpu modules

### DIFF
--- a/system_files/desktop/shared/usr/lib/dracut/dracut.conf.d/80-vfio.conf
+++ b/system_files/desktop/shared/usr/lib/dracut/dracut.conf.d/80-vfio.conf
@@ -1,1 +1,1 @@
-add_drivers+=" vfio vfio_iommu_type1 vfio-pci "
+force_drivers+=" vfio vfio_iommu_type1 vfio-pci "


### PR DESCRIPTION
should fix issues where the nvidia module and amdgpu module manages to snag the gpu first on some machines.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
