### PR TITLE
fix(deck): update 'ujust changelogs' to pull latest release notes from GitHub

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
@@ -40,4 +40,4 @@ alias changelog := changelogs
 
 # Show the changelog
 changelogs:
-    /usr/bin/glow https://raw.githubusercontent.com/ublue-os/bazzite/main/CHANGELOG-SHORT.md --pager
+    curl -s https://api.github.com/repos/ublue-os/bazzite/releases/latest | jq -r '.body'

--- a/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
@@ -38,6 +38,10 @@ toggle-updates ACTION="prompt":
 
 alias changelog := changelogs
 
-# Show the changelog
+# Show the stable changelog
 changelogs:
     curl -s https://api.github.com/repos/ublue-os/bazzite/releases/latest | jq -r '.body'
+
+# Show the testing (pre-release) changelog
+changelogs-testing:
+    curl -s https://api.github.com/repos/ublue-os/bazzite/releases | jq -r 'map(select(.prerelease)) | .[0].body'


### PR DESCRIPTION
As of changes noted in: https://universal-blue.discourse.group/t/bazzite-3-7-0-update-released/3726, version numbers for Bazzite have been deprecated along with their associated changelogs. Releases are now signified by `yyyymmdd` format with auto-generated GitHub release notes.

The `ujust changelog` and alias `ujust changelogs` commands currently reference the outdated `CHANGELOG-SHORT.md` file, which has not been maintained since Bazzite 3.7.0.

This PR updates the `ujust changelogs` functionality to fetch the latest auto-generated release notes directly from GitHub, ensuring users can quickly access relevant changes.

### Changes:
- Adjusted `ujust changelogs` to fetch the latest stable release notes via the GitHub API.
