### PR TITLE
feat: Add 'restore-gamemode-shortcut' and restore 'configure-grub' with ugum styling

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -212,15 +212,15 @@ restore-gamemode-shortcut:
     SKEL_FILE="/etc/skel/Desktop/Return.desktop"
     # Check if the shortcut already exists
     if [ -f "$SHORTCUT_FILE" ]; then
-        echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
-        echo "No changes were made."
-        exit 0
+      echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
+      echo "No changes were made."
+      exit 0
     fi
     # Check if the original file exists in skel
     if [ ! -f "$SKEL_FILE" ]; then
-        echo "Error: The original file does not exist at $SKEL_FILE."
-        echo "Unable to restore the shortcut."
-        exit 1
+      echo "Error: The original file does not exist at $SKEL_FILE."
+      echo "Unable to restore the shortcut."
+      exit 1
     fi
     # Copy the file from skel to the desktop
     echo "Restoring the 'Return to Gaming Mode' shortcut from $SKEL_FILE..."

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -203,3 +203,30 @@ _toggle-autologin:
     else
       sudo touch $DESKTOP_AUTOLOGIN
     fi
+
+# Restore the "Return to Gaming Mode" shortcut on the Desktop
+restore-gamemode-shortcut:
+    #!/usr/bin/bash
+    # Define paths
+    SHORTCUT_FILE="$HOME/Desktop/Return.desktop"
+    SKEL_FILE="/etc/skel/Desktop/Return.desktop"
+    # Check if the shortcut already exists
+    if [ -f "$SHORTCUT_FILE" ]; then
+        echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
+        echo "No changes were made."
+        exit 0
+    fi
+    # Check if the original file exists in skel
+    if [ ! -f "$SKEL_FILE" ]; then
+        echo "Error: The original file does not exist at $SKEL_FILE."
+        echo "Unable to restore the shortcut."
+        exit 1
+    fi
+    # Copy the file from skel to the desktop
+    echo "Restoring the 'Return to Gaming Mode' shortcut from $SKEL_FILE..."
+    mkdir -p "$HOME/Desktop"  # Ensure the Desktop directory exists
+    cp "$SKEL_FILE" "$SHORTCUT_FILE"
+    # Ensure the file is executable
+    chmod +x "$SHORTCUT_FILE"
+    echo "Shortcut restored successfully at $SHORTCUT_FILE."
+    echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -230,4 +230,3 @@ restore-gamemode-shortcut:
     chmod +x "$SHORTCUT_FILE"
     echo "Shortcut restored successfully at $SHORTCUT_FILE."
     echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."
-    

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -230,3 +230,4 @@ restore-gamemode-shortcut:
     chmod +x "$SHORTCUT_FILE"
     echo "Shortcut restored successfully at $SHORTCUT_FILE."
     echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."
+    

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 
 # Install System Flatpaks (Support for Rebasing)
-install-system-flatpaks:
+_install-system-flatpaks:
     #!/usr/bin/bash
     IMAGE_INFO="/usr/share/ublue-os/image-info.json"
     BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -13,10 +13,21 @@ _install-system-flatpaks:
     FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/bazzite/main/installer/${FLATPAKS} | tr '\n' ' ')"
     flatpak --system -y install --or-update ${FLATPAK_LIST}
 
-# Configure GRUB boot menu visibility
-configure-grub:
+# Configure grub bootmenu visibility. pass action 'help' for more info.
+configure-grub ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
+    # Function to display usage/help with some color
+    print_help() {
+      echo -e "Usage: ujust configure-grub <option>"
+      echo
+      echo -e "Where <option> can be:"
+      echo -e "  ${bold}${cyan}hide${normal}      = GRUB is hidden after a successful boot, even for dual-boot setups."
+      echo -e "  ${bold}${yellow}unhide${normal}    = GRUB is hidden after a successful boot, but it will show if dual-booting."
+      echo -e "  ${bold}${green}show${normal}      = GRUB always shows on boot."
+      echo
+      echo "If <option> is omitted, you will be prompted to choose interactively."
+    }
     # Function to get the current GRUB menu_auto_hide setting and explain it
     get_current_setting() {
         local CURRENT_SETTING
@@ -51,52 +62,60 @@ configure-grub:
             esac
         fi
     }
-    # Function to display an interactive menu using ugum
+    # Interactive menu for choosing the new behavior
     interactive_menu() {
         echo "Choose a new GRUB menu auto-hide behavior:"
         local options=(
-            "Hide Grub (menu_auto_hide=2)"
-            "Unhide Grub (menu_auto_hide=1)"
+            "Always Hide Grub (menu_auto_hide=2)"
+            "Hide After Successful Boot (menu_auto_hide=1)"
             "Always Show Grub (menu_auto_hide=0)"
         )
-        # Prompt the user to select an option
         local choice
         choice=$(ugum choose "${options[@]}")
-        echo "DEBUG: Selected choice is '$choice'"  # Debugging
         echo "$choice"
     }
     # Function to apply the selected setting
     apply_setting() {
         local selected_option="$1"
-        selected_option=$(echo "$selected_option" | xargs)  # Normalize input
-        case "$selected_option" in
-            *"(menu_auto_hide=2)"*)
+        # Support the interactive strings as well as short commands
+        case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
+            *"(menu_auto_hide=2)"*|hide)
                 sudo grub2-editenv - set menu_auto_hide=2
                 echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
                 ;;
-            *"(menu_auto_hide=1)"*)
+            *"(menu_auto_hide=1)"*|unhide)
                 sudo grub2-editenv - set menu_auto_hide=1
                 echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
                 ;;
-            *"(menu_auto_hide=0)"*)
+            *"(menu_auto_hide=0)"*|show)
                 sudo grub2-editenv - set menu_auto_hide=0
                 echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
+                ;;
+            help)
+                print_help
                 ;;
             *)
                 echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
                 ;;
         esac
     }
-    # Main logic
-    echo "Configuring GRUB Menu Behavior..."
+    OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
+    if [ "$OPTION" == "help" ]; then
+      print_help
+      exit 0
+    fi
     get_current_setting
     echo
-    echo "Select a new behavior for the GRUB menu:"
-    NEW_SETTING=$(interactive_menu)
-    if [ -n "$NEW_SETTING" ]; then
-        apply_setting "$NEW_SETTING"
+    # If no ACTION was passed, go interactive
+    if [ -z "$OPTION" ]; then
+        NEW_SETTING=$(interactive_menu)
+        if [ -n "$NEW_SETTING" ]; then
+            apply_setting "$NEW_SETTING"
+        else
+            echo "${bold}No changes were made.${normal}"
+        fi
     else
-        echo "${bold}No changes were made.${normal}"
+        apply_setting "$OPTION"
     fi
 
 # Add user to "input" group required by certain controller drivers

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -15,111 +15,111 @@ _install-system-flatpaks:
 
 # Configure grub bootmenu visibility. pass action 'help' for more info.
 configure-grub ACTION="":
-  #!/usr/bin/bash
-  source /usr/lib/ujust/ujust.sh
-  # Function to display usage/help with some color
-  print_help() {
-    echo -e "Usage: ujust configure-grub <option>"
-    echo
-    echo -e "Where <option> can be:"
-    echo -e "  ${bold}${cyan}hide${normal} = GRUB is hidden after a successful boot, even for dual-boot setups."
-    echo -e "  ${bold}${yellow}unhide${normal} = GRUB is hidden after a successful boot, but it will show if dual-booting."
-    echo -e "  ${bold}${green}show${normal} = GRUB always shows on boot."
-    echo
-    echo "If <option> is omitted, you will be prompted to choose interactively."
-  }
-  # Function to get the current GRUB menu_auto_hide setting and explain it
-  get_current_setting() {
-    local CURRENT_SETTING
-    CURRENT_SETTING=$(sudo grub2-editenv - list | grep menu_auto_hide | cut -d= -f2)
-    if [ -z "$CURRENT_SETTING" ]; then
-      echo "Current GRUB menu_auto_hide setting: ${bold}${red}Not Set (default to 0)${normal}"
-      echo "Explanation:"
-      echo "  - ${bold}0${normal}: GRUB always shows on boot."
-      return 0
-    else
-      case "$CURRENT_SETTING" in
-        0)
-          echo "Current GRUB menu_auto_hide setting: ${bold}${green}0 (Always Show)${normal}"
-          echo "Explanation:"
-          echo "  - ${bold}0${normal}: GRUB always shows on boot."
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    # Function to display usage/help with some color
+    print_help() {
+      echo -e "Usage: ujust configure-grub <option>"
+      echo
+      echo -e "Where <option> can be:"
+      echo -e "  ${bold}${cyan}hide${normal} = GRUB is hidden after a successful boot, even for dual-boot setups."
+      echo -e "  ${bold}${yellow}unhide${normal} = GRUB is hidden after a successful boot, but it will show if dual-booting."
+      echo -e "  ${bold}${green}show${normal} = GRUB always shows on boot."
+      echo
+      echo "If <option> is omitted, you will be prompted to choose interactively."
+    }
+    # Function to get the current GRUB menu_auto_hide setting and explain it
+    get_current_setting() {
+      local CURRENT_SETTING
+      CURRENT_SETTING=$(sudo grub2-editenv - list | grep menu_auto_hide | cut -d= -f2)
+      if [ -z "$CURRENT_SETTING" ]; then
+        echo "Current GRUB menu_auto_hide setting: ${bold}${red}Not Set (default to 0)${normal}"
+        echo "Explanation:"
+        echo "  - ${bold}0${normal}: GRUB always shows on boot."
+        return 0
+      else
+        case "$CURRENT_SETTING" in
+          0)
+            echo "Current GRUB menu_auto_hide setting: ${bold}${green}0 (Always Show)${normal}"
+            echo "Explanation:"
+            echo "  - ${bold}0${normal}: GRUB always shows on boot."
+            ;;
+          1)
+            echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
+            echo "Explanation:"
+            echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
+            ;;
+          2)
+            echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
+            echo "Explanation:"
+            echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
+            ;;
+          *)
+            echo "Current GRUB menu_auto_hide setting: ${bold}${red}Unknown${normal}"
+            echo "Explanation:"
+            echo "  - This setting is unrecognized. Reset it to 0, 1, or 2."
+            ;;
+        esac
+      fi
+    }
+    # Interactive menu for choosing the new behavior
+    interactive_menu() {
+      local options=(
+        "Always Hide Grub (menu_auto_hide=2)"
+        "Hide After Successful Boot (menu_auto_hide=1)"
+        "Always Show Grub (menu_auto_hide=0)"
+        "Exit without changes"
+      )
+      local choice
+      choice=$(ugum choose "${options[@]}")
+      echo "$choice"
+    }
+    # Function to apply the selected setting
+    apply_setting() {
+      local selected_option="$1"
+      # Support the interactive strings as well as short commands
+      case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
+        *"(menu_auto_hide=2)"*|hide)
+          sudo grub2-editenv - set menu_auto_hide=2
+          echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
           ;;
-        1)
-          echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
-          echo "Explanation:"
-          echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
+        *"(menu_auto_hide=1)"*|unhide)
+          sudo grub2-editenv - set menu_auto_hide=1
+          echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
           ;;
-        2)
-          echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
-          echo "Explanation:"
-          echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
+        *"(menu_auto_hide=0)"*|show)
+          sudo grub2-editenv - set menu_auto_hide=0
+          echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
+          ;;
+        *"exit without changes"*|exit)
+          echo "${bold}No changes were made. Exiting...${normal}"
+          ;;
+        help)
+          print_help
           ;;
         *)
-          echo "Current GRUB menu_auto_hide setting: ${bold}${red}Unknown${normal}"
-          echo "Explanation:"
-          echo "  - This setting is unrecognized. Reset it to 0, 1, or 2."
+          echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
           ;;
       esac
+    }
+    OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
+    if [ "$OPTION" == "help" ]; then
+      print_help
+      exit 0
     fi
-  }
-  # Interactive menu for choosing the new behavior
-  interactive_menu() {
-    local options=(
-      "Always Hide Grub (menu_auto_hide=2)"
-      "Hide After Successful Boot (menu_auto_hide=1)"
-      "Always Show Grub (menu_auto_hide=0)"
-      "Exit without changes"
-    )
-    local choice
-    choice=$(ugum choose "${options[@]}")
-    echo "$choice"
-  }
-  # Function to apply the selected setting
-  apply_setting() {
-    local selected_option="$1"
-    # Support the interactive strings as well as short commands
-    case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
-      *"(menu_auto_hide=2)"*|hide)
-        sudo grub2-editenv - set menu_auto_hide=2
-        echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
-        ;;
-      *"(menu_auto_hide=1)"*|unhide)
-        sudo grub2-editenv - set menu_auto_hide=1
-        echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
-        ;;
-      *"(menu_auto_hide=0)"*|show)
-        sudo grub2-editenv - set menu_auto_hide=0
-        echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
-        ;;
-      *"exit without changes"*|exit)
-        echo "${bold}No changes were made. Exiting...${normal}"
-        ;;
-      help)
-        print_help
-        ;;
-      *)
-        echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
-        ;;
-    esac
-  }
-  OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
-  if [ "$OPTION" == "help" ]; then
-    print_help
-    exit 0
-  fi
-  get_current_setting
-  echo
-  # If no ACTION was passed, go interactive
-  if [ -z "$OPTION" ]; then
-    NEW_SETTING=$(interactive_menu)
-    if [ -n "$NEW_SETTING" ]; then
-      apply_setting "$NEW_SETTING"
+    get_current_setting
+    echo
+    # If no ACTION was passed, go interactive
+    if [ -z "$OPTION" ]; then
+      NEW_SETTING=$(interactive_menu)
+      if [ -n "$NEW_SETTING" ]; then
+        apply_setting "$NEW_SETTING"
+      else
+        echo "${bold}No changes were made.${normal}"
+      fi
     else
-      echo "${bold}No changes were made.${normal}"
+      apply_setting "$OPTION"
     fi
-  else
-    apply_setting "$OPTION"
-  fi
 
 # Add user to "input" group required by certain controller drivers
 add-user-to-input-group:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 
 # Install System Flatpaks (Support for Rebasing)
-_install-system-flatpaks:
+install-system-flatpaks:
     #!/usr/bin/bash
     IMAGE_INFO="/usr/share/ublue-os/image-info.json"
     BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
@@ -13,19 +13,99 @@ _install-system-flatpaks:
     FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/bazzite/main/installer/${FLATPAKS} | tr '\n' ' ')"
     flatpak --system -y install --or-update ${FLATPAK_LIST}
 
-# Configure grub bootmenu visibility and fix duplicate entries
-configure-grub ACTION="":
+# Configure GRUB boot menu visibility
+configure-grub:
     #!/usr/bin/bash
-    echo "Editing grub is no longer recommended and this script has been removed"
+    source /usr/lib/ujust/ujust.sh
+
+    # Function to get the current GRUB menu_auto_hide setting and explain it
+    get_current_setting() {
+        local CURRENT_SETTING
+        CURRENT_SETTING=$(sudo grub2-editenv - list | grep menu_auto_hide | cut -d= -f2)
+
+        if [ -z "$CURRENT_SETTING" ]; then
+            echo "Current GRUB menu_auto_hide setting: ${bold}${red}Not Set (default to 0)${normal}"
+            echo "Explanation:"
+            echo "  - ${bold}0${normal}: GRUB always shows on boot."
+            return 0
+        else
+            case "$CURRENT_SETTING" in
+                0)
+                    echo "Current GRUB menu_auto_hide setting: ${bold}${green}0 (Always Show)${normal}"
+                    echo "Explanation:"
+                    echo "  - ${bold}0${normal}: GRUB always shows on boot."
+                    ;;
+                1)
+                    echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
+                    echo "Explanation:"
+                    echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
+                    ;;
+                2)
+                    echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
+                    echo "Explanation:"
+                    echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
+                    ;;
+                *)
+                    echo "Current GRUB menu_auto_hide setting: ${bold}${red}Unknown${normal}"
+                    echo "Explanation:"
+                    echo "  - This setting is unrecognized. Reset it to 0, 1, or 2."
+                    ;;
+            esac
+        fi
+    }
+
+    # Function to display an interactive menu using ugum
+    interactive_menu() {
+        echo "Choose a new GRUB menu auto-hide behavior:"
+        local options=(
+            "Hide Grub (menu_auto_hide=2)"
+            "Unhide Grub (menu_auto_hide=1)"
+            "Always Show Grub (menu_auto_hide=0)"
+        )
+
+        # Prompt the user to select an option
+        local choice
+        choice=$(ugum choose "${options[@]}")
+        echo "DEBUG: Selected choice is '$choice'"  # Debugging
+        echo "$choice"
+    }
+
+    # Function to apply the selected setting
+    apply_setting() {
+        local selected_option="$1"
+        selected_option=$(echo "$selected_option" | xargs)  # Normalize input
+
+        case "$selected_option" in
+            *"(menu_auto_hide=2)"*)
+                sudo grub2-editenv - set menu_auto_hide=2
+                echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
+                ;;
+            *"(menu_auto_hide=1)"*)
+                sudo grub2-editenv - set menu_auto_hide=1
+                echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
+                ;;
+            *"(menu_auto_hide=0)"*)
+                sudo grub2-editenv - set menu_auto_hide=0
+                echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
+                ;;
+            *)
+                echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
+                ;;
+        esac
+    }
+
+    # Main logic
+    echo "Configuring GRUB Menu Behavior..."
+    get_current_setting
     echo
-    echo "Reason:"
-    echo "Grub is auto-hidden now on successful boots and reappears only if you"
-    echo "shutdown too early. You can still access it by holding shift. Deck"
-    echo "images will also automatically rollback after 2 failed boots, so grub"
-    echo "will need to be visible for you to see that."
-    echo
-    echo "You can edit /etc/default/grub to change settings manually, then:"
-    echo "grub2-mkconfig -o /etc/grub2-efi.cfg"
+    echo "Select a new behavior for the GRUB menu:"
+    NEW_SETTING=$(interactive_menu)
+
+    if [ -n "$NEW_SETTING" ]; then
+        apply_setting "$NEW_SETTING"
+    else
+        echo "${bold}No changes were made.${normal}"
+    fi
 
 # Add user to "input" group required by certain controller drivers
 add-user-to-input-group:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -17,12 +17,10 @@ install-system-flatpaks:
 configure-grub:
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-
     # Function to get the current GRUB menu_auto_hide setting and explain it
     get_current_setting() {
         local CURRENT_SETTING
         CURRENT_SETTING=$(sudo grub2-editenv - list | grep menu_auto_hide | cut -d= -f2)
-
         if [ -z "$CURRENT_SETTING" ]; then
             echo "Current GRUB menu_auto_hide setting: ${bold}${red}Not Set (default to 0)${normal}"
             echo "Explanation:"
@@ -53,7 +51,6 @@ configure-grub:
             esac
         fi
     }
-
     # Function to display an interactive menu using ugum
     interactive_menu() {
         echo "Choose a new GRUB menu auto-hide behavior:"
@@ -62,19 +59,16 @@ configure-grub:
             "Unhide Grub (menu_auto_hide=1)"
             "Always Show Grub (menu_auto_hide=0)"
         )
-
         # Prompt the user to select an option
         local choice
         choice=$(ugum choose "${options[@]}")
         echo "DEBUG: Selected choice is '$choice'"  # Debugging
         echo "$choice"
     }
-
     # Function to apply the selected setting
     apply_setting() {
         local selected_option="$1"
         selected_option=$(echo "$selected_option" | xargs)  # Normalize input
-
         case "$selected_option" in
             *"(menu_auto_hide=2)"*)
                 sudo grub2-editenv - set menu_auto_hide=2
@@ -93,14 +87,12 @@ configure-grub:
                 ;;
         esac
     }
-
     # Main logic
     echo "Configuring GRUB Menu Behavior..."
     get_current_setting
     echo
     echo "Select a new behavior for the GRUB menu:"
     NEW_SETTING=$(interactive_menu)
-
     if [ -n "$NEW_SETTING" ]; then
         apply_setting "$NEW_SETTING"
     else

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -15,108 +15,111 @@ _install-system-flatpaks:
 
 # Configure grub bootmenu visibility. pass action 'help' for more info.
 configure-grub ACTION="":
-    #!/usr/bin/bash
-    source /usr/lib/ujust/ujust.sh
-    # Function to display usage/help with some color
-    print_help() {
-      echo -e "Usage: ujust configure-grub <option>"
-      echo
-      echo -e "Where <option> can be:"
-      echo -e "  ${bold}${cyan}hide${normal}      = GRUB is hidden after a successful boot, even for dual-boot setups."
-      echo -e "  ${bold}${yellow}unhide${normal}    = GRUB is hidden after a successful boot, but it will show if dual-booting."
-      echo -e "  ${bold}${green}show${normal}      = GRUB always shows on boot."
-      echo
-      echo "If <option> is omitted, you will be prompted to choose interactively."
-    }
-    # Function to get the current GRUB menu_auto_hide setting and explain it
-    get_current_setting() {
-        local CURRENT_SETTING
-        CURRENT_SETTING=$(sudo grub2-editenv - list | grep menu_auto_hide | cut -d= -f2)
-        if [ -z "$CURRENT_SETTING" ]; then
-            echo "Current GRUB menu_auto_hide setting: ${bold}${red}Not Set (default to 0)${normal}"
-            echo "Explanation:"
-            echo "  - ${bold}0${normal}: GRUB always shows on boot."
-            return 0
-        else
-            case "$CURRENT_SETTING" in
-                0)
-                    echo "Current GRUB menu_auto_hide setting: ${bold}${green}0 (Always Show)${normal}"
-                    echo "Explanation:"
-                    echo "  - ${bold}0${normal}: GRUB always shows on boot."
-                    ;;
-                1)
-                    echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
-                    echo "Explanation:"
-                    echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
-                    ;;
-                2)
-                    echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
-                    echo "Explanation:"
-                    echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
-                    ;;
-                *)
-                    echo "Current GRUB menu_auto_hide setting: ${bold}${red}Unknown${normal}"
-                    echo "Explanation:"
-                    echo "  - This setting is unrecognized. Reset it to 0, 1, or 2."
-                    ;;
-            esac
-        fi
-    }
-    # Interactive menu for choosing the new behavior
-    interactive_menu() {
-        echo "Choose a new GRUB menu auto-hide behavior:"
-        local options=(
-            "Always Hide Grub (menu_auto_hide=2)"
-            "Hide After Successful Boot (menu_auto_hide=1)"
-            "Always Show Grub (menu_auto_hide=0)"
-        )
-        local choice
-        choice=$(ugum choose "${options[@]}")
-        echo "$choice"
-    }
-    # Function to apply the selected setting
-    apply_setting() {
-        local selected_option="$1"
-        # Support the interactive strings as well as short commands
-        case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
-            *"(menu_auto_hide=2)"*|hide)
-                sudo grub2-editenv - set menu_auto_hide=2
-                echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
-                ;;
-            *"(menu_auto_hide=1)"*|unhide)
-                sudo grub2-editenv - set menu_auto_hide=1
-                echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
-                ;;
-            *"(menu_auto_hide=0)"*|show)
-                sudo grub2-editenv - set menu_auto_hide=0
-                echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
-                ;;
-            help)
-                print_help
-                ;;
-            *)
-                echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
-                ;;
-        esac
-    }
-    OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
-    if [ "$OPTION" == "help" ]; then
-      print_help
-      exit 0
-    fi
-    get_current_setting
+  #!/usr/bin/bash
+  source /usr/lib/ujust/ujust.sh
+  # Function to display usage/help with some color
+  print_help() {
+    echo -e "Usage: ujust configure-grub <option>"
     echo
-    # If no ACTION was passed, go interactive
-    if [ -z "$OPTION" ]; then
-        NEW_SETTING=$(interactive_menu)
-        if [ -n "$NEW_SETTING" ]; then
-            apply_setting "$NEW_SETTING"
-        else
-            echo "${bold}No changes were made.${normal}"
-        fi
+    echo -e "Where <option> can be:"
+    echo -e "  ${bold}${cyan}hide${normal} = GRUB is hidden after a successful boot, even for dual-boot setups."
+    echo -e "  ${bold}${yellow}unhide${normal} = GRUB is hidden after a successful boot, but it will show if dual-booting."
+    echo -e "  ${bold}${green}show${normal} = GRUB always shows on boot."
+    echo
+    echo "If <option> is omitted, you will be prompted to choose interactively."
+  }
+  # Function to get the current GRUB menu_auto_hide setting and explain it
+  get_current_setting() {
+    local CURRENT_SETTING
+    CURRENT_SETTING=$(sudo grub2-editenv - list | grep menu_auto_hide | cut -d= -f2)
+    if [ -z "$CURRENT_SETTING" ]; then
+      echo "Current GRUB menu_auto_hide setting: ${bold}${red}Not Set (default to 0)${normal}"
+      echo "Explanation:"
+      echo "  - ${bold}0${normal}: GRUB always shows on boot."
+      return 0
     else
-        apply_setting "$OPTION"
+      case "$CURRENT_SETTING" in
+        0)
+          echo "Current GRUB menu_auto_hide setting: ${bold}${green}0 (Always Show)${normal}"
+          echo "Explanation:"
+          echo "  - ${bold}0${normal}: GRUB always shows on boot."
+          ;;
+        1)
+          echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
+          echo "Explanation:"
+          echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
+          ;;
+        2)
+          echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
+          echo "Explanation:"
+          echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
+          ;;
+        *)
+          echo "Current GRUB menu_auto_hide setting: ${bold}${red}Unknown${normal}"
+          echo "Explanation:"
+          echo "  - This setting is unrecognized. Reset it to 0, 1, or 2."
+          ;;
+      esac
     fi
+  }
+  # Interactive menu for choosing the new behavior
+  interactive_menu() {
+    local options=(
+      "Always Hide Grub (menu_auto_hide=2)"
+      "Hide After Successful Boot (menu_auto_hide=1)"
+      "Always Show Grub (menu_auto_hide=0)"
+      "Exit without changes"
+    )
+    local choice
+    choice=$(ugum choose "${options[@]}")
+    echo "$choice"
+  }
+  # Function to apply the selected setting
+  apply_setting() {
+    local selected_option="$1"
+    # Support the interactive strings as well as short commands
+    case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
+      *"(menu_auto_hide=2)"*|hide)
+        sudo grub2-editenv - set menu_auto_hide=2
+        echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
+        ;;
+      *"(menu_auto_hide=1)"*|unhide)
+        sudo grub2-editenv - set menu_auto_hide=1
+        echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
+        ;;
+      *"(menu_auto_hide=0)"*|show)
+        sudo grub2-editenv - set menu_auto_hide=0
+        echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
+        ;;
+      *"exit without changes"*|exit)
+        echo "${bold}No changes were made. Exiting...${normal}"
+        ;;
+      help)
+        print_help
+        ;;
+      *)
+        echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
+        ;;
+    esac
+  }
+  OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
+  if [ "$OPTION" == "help" ]; then
+    print_help
+    exit 0
+  fi
+  get_current_setting
+  echo
+  # If no ACTION was passed, go interactive
+  if [ -z "$OPTION" ]; then
+    NEW_SETTING=$(interactive_menu)
+    if [ -n "$NEW_SETTING" ]; then
+      apply_setting "$NEW_SETTING"
+    else
+      echo "${bold}No changes were made.${normal}"
+    fi
+  else
+    apply_setting "$OPTION"
+  fi
 
 # Add user to "input" group required by certain controller drivers
 add-user-to-input-group:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -48,4 +48,3 @@ fix-reset-steam:
     sleep 1
     bazzite-steam &
     exit 0
-    

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -48,3 +48,37 @@ fix-reset-steam:
     sleep 1
     bazzite-steam &
     exit 0
+
+# Restore the "Return to Gaming Mode" shortcut on the Desktop
+restore-gamemode-shortcut:
+    #!/usr/bin/bash
+
+    # Define the Desktop file path
+    SHORTCUT_FILE="$HOME/Desktop/Return.desktop"
+
+    # Check if the file already exists
+    if [ -f "$SHORTCUT_FILE" ]; then
+        echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
+        echo "No changes were made."
+        exit 0
+    fi
+
+    # Create the Desktop file with the appropriate content
+    echo "Creating the 'Return to Gaming Mode' shortcut on the Desktop..."
+    mkdir -p "$HOME/Desktop"  # Ensure the Desktop directory exists
+
+    # Write the content to the file using echo commands
+    echo '#!/usr/bin/env xdg-open' > "$SHORTCUT_FILE"
+    echo '[Desktop Entry]' >> "$SHORTCUT_FILE"
+    echo 'Name=Return to Gaming Mode' >> "$SHORTCUT_FILE"
+    echo 'Exec=systemctl start return-to-gamemode.service' >> "$SHORTCUT_FILE"
+    echo 'Icon=steamdeck-gaming-return' >> "$SHORTCUT_FILE"
+    echo 'Terminal=false' >> "$SHORTCUT_FILE"
+    echo 'Type=Application' >> "$SHORTCUT_FILE"
+    echo 'StartupNotify=false' >> "$SHORTCUT_FILE"
+
+    # Ensure the file is executable
+    chmod +x "$SHORTCUT_FILE"
+
+    echo "Shortcut created successfully at $SHORTCUT_FILE."
+    echo "Note: The first time you use the shortcut, it may ask you to trust it. Please confirm."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -53,32 +53,31 @@ fix-reset-steam:
 restore-gamemode-shortcut:
     #!/usr/bin/bash
 
-    # Define the Desktop file path
+    # Define paths
     SHORTCUT_FILE="$HOME/Desktop/Return.desktop"
+    SKEL_FILE="/etc/skel/Desktop/Return.desktop"
 
-    # Check if the file already exists
+    # Check if the shortcut already exists
     if [ -f "$SHORTCUT_FILE" ]; then
         echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
         echo "No changes were made."
         exit 0
     fi
 
-    # Create the Desktop file with the appropriate content
-    echo "Creating the 'Return to Gaming Mode' shortcut on the Desktop..."
-    mkdir -p "$HOME/Desktop"  # Ensure the Desktop directory exists
+    # Check if the original file exists in skel
+    if [ ! -f "$SKEL_FILE" ]; then
+        echo "Error: The original file does not exist at $SKEL_FILE."
+        echo "Unable to restore the shortcut."
+        exit 1
+    fi
 
-    # Write the content to the file using echo commands
-    echo '#!/usr/bin/env xdg-open' > "$SHORTCUT_FILE"
-    echo '[Desktop Entry]' >> "$SHORTCUT_FILE"
-    echo 'Name=Return to Gaming Mode' >> "$SHORTCUT_FILE"
-    echo 'Exec=systemctl start return-to-gamemode.service' >> "$SHORTCUT_FILE"
-    echo 'Icon=steamdeck-gaming-return' >> "$SHORTCUT_FILE"
-    echo 'Terminal=false' >> "$SHORTCUT_FILE"
-    echo 'Type=Application' >> "$SHORTCUT_FILE"
-    echo 'StartupNotify=false' >> "$SHORTCUT_FILE"
+    # Copy the file from skel to the desktop
+    echo "Restoring the 'Return to Gaming Mode' shortcut from $SKEL_FILE..."
+    mkdir -p "$HOME/Desktop"  # Ensure the Desktop directory exists
+    cp "$SKEL_FILE" "$SHORTCUT_FILE"
 
     # Ensure the file is executable
     chmod +x "$SHORTCUT_FILE"
 
-    echo "Shortcut created successfully at $SHORTCUT_FILE."
-    echo "Note: The first time you use the shortcut, it may ask you to trust it. Please confirm."
+    echo "Shortcut restored successfully at $SHORTCUT_FILE."
+    echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -48,30 +48,3 @@ fix-reset-steam:
     sleep 1
     bazzite-steam &
     exit 0
-
-# Restore the "Return to Gaming Mode" shortcut on the Desktop
-restore-gamemode-shortcut:
-    #!/usr/bin/bash
-    # Define paths
-    SHORTCUT_FILE="$HOME/Desktop/Return.desktop"
-    SKEL_FILE="/etc/skel/Desktop/Return.desktop"
-    # Check if the shortcut already exists
-    if [ -f "$SHORTCUT_FILE" ]; then
-        echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
-        echo "No changes were made."
-        exit 0
-    fi
-    # Check if the original file exists in skel
-    if [ ! -f "$SKEL_FILE" ]; then
-        echo "Error: The original file does not exist at $SKEL_FILE."
-        echo "Unable to restore the shortcut."
-        exit 1
-    fi
-    # Copy the file from skel to the desktop
-    echo "Restoring the 'Return to Gaming Mode' shortcut from $SKEL_FILE..."
-    mkdir -p "$HOME/Desktop"  # Ensure the Desktop directory exists
-    cp "$SKEL_FILE" "$SHORTCUT_FILE"
-    # Ensure the file is executable
-    chmod +x "$SHORTCUT_FILE"
-    echo "Shortcut restored successfully at $SHORTCUT_FILE."
-    echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -52,32 +52,26 @@ fix-reset-steam:
 # Restore the "Return to Gaming Mode" shortcut on the Desktop
 restore-gamemode-shortcut:
     #!/usr/bin/bash
-
     # Define paths
     SHORTCUT_FILE="$HOME/Desktop/Return.desktop"
     SKEL_FILE="/etc/skel/Desktop/Return.desktop"
-
     # Check if the shortcut already exists
     if [ -f "$SHORTCUT_FILE" ]; then
         echo "The shortcut 'Return to Gaming Mode' already exists at $SHORTCUT_FILE."
         echo "No changes were made."
         exit 0
     fi
-
     # Check if the original file exists in skel
     if [ ! -f "$SKEL_FILE" ]; then
         echo "Error: The original file does not exist at $SKEL_FILE."
         echo "Unable to restore the shortcut."
         exit 1
     fi
-
     # Copy the file from skel to the desktop
     echo "Restoring the 'Return to Gaming Mode' shortcut from $SKEL_FILE..."
     mkdir -p "$HOME/Desktop"  # Ensure the Desktop directory exists
     cp "$SKEL_FILE" "$SHORTCUT_FILE"
-
     # Ensure the file is executable
     chmod +x "$SHORTCUT_FILE"
-
     echo "Shortcut restored successfully at $SHORTCUT_FILE."
     echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -48,3 +48,4 @@ fix-reset-steam:
     sleep 1
     bazzite-steam &
     exit 0
+    


### PR DESCRIPTION
This PR introduces the following updates and fixes:

1. **`restore-gamemode-shortcut` Command**:
   - Adds a new `ujust` command to restore the "Return to Gaming Mode" shortcut on the Desktop.
   - The shortcut is copied from `/etc/skel/Desktop/Return.desktop`, ensuring it matches the original system-provided file.
   - Includes checks to prevent overwriting the existing shortcut or failing silently if the source file is missing.
   - Sets executable permissions for the shortcut to ensure functionality.
   - Provides meaningful feedback to users at every step.

2. **Restored `configure-grub` Command**:
   - Reintroduces the `ujust configure-grub` command with enhanced functionality using `ugum` for a more user-friendly, styled CLI interface.
   - Users can now:
     - View the current GRUB `menu_auto_hide` setting with a detailed explanation.
     - Interactively select a new setting (`0`, `1`, or `2`) using a clean menu interface.
     - Apply the changes dynamically via `grub2-editenv`.
   - The command ensures proper error handling and includes debug output for troubleshooting edge cases.