### PR TITLE
fix(virt): Enhance service setup and restrict root execution for virtualization script

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/bazzite-libvirtd-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/bazzite-libvirtd-setup.service
@@ -6,7 +6,7 @@ ConditionPathExists=/usr/lib/systemd/system/libvirtd.service
 [Service]
 Type=oneshot
 # TODO: Rewrite this whenever systemd allows to queue ephemeral commands for next boot without modifying kernel args
-ExecStart=/usr/bin/bash -c "systemctl enable --now libvirtd; systemctl disable %n"
+ExecStart=/usr/bin/bash -c "systemctl enable --now libvirtd; restorecon -Rv /var/log/libvirt /var/lib/libvirt; systemctl disable %n"
 
 [Install]
 WantedBy=multi-user.target

--- a/system_files/desktop/shared/usr/lib/tmpfiles.d/bazzite-libvirt.conf
+++ b/system_files/desktop/shared/usr/lib/tmpfiles.d/bazzite-libvirt.conf
@@ -1,0 +1,1 @@
+d /var/log/libvirt 0700 root root - -

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -4,6 +4,10 @@
 setup-virtualization ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
+    if [[ $(id -u) -eq 0 ]]; then
+      echo "Please do not run this command as root"
+      exit 1
+    fi
     # Check if we are running on a Steam Deck
     if /usr/libexec/hwsupport/valve-hardware; then
       echo "${red}${b}WARNING${n}: Virtualization is not properly supported on Steam Deck by Valve"


### PR DESCRIPTION
Improve the bazzite-libvirtd-setup.service to restore SELinux context and prevent running the setup-virtualization script as root.

Fixes issue #2115.