### PR TITLE
Initial support for BitTorrent distribution of ISOs

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -147,7 +147,26 @@ jobs:
           additional_templates: '/github/workspace/installer/lorax_templates/remove_root_password_prompt.tmpl /github/workspace/installer/lorax_templates/set_default_user.tmpl'
           repos: '/github/workspace/bazzite.repo /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora-updates.repo'
 
-      - name: Move ISOs to Upload Directory
+      - name: Generate a .torrent file
+        id: create-torrent
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mktorrent
+          TORRENT_DIR=${{ github.workspace }}/torrent
+          mkdir ${TORRENT_DIR}
+          container_uri=docker://${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}:${{ steps.generate-tag.outputs.tag }}
+          installer_version=$(skopeo inspect $container_uri | jq -r '.Labels["org.opencontainers.image.version"]')
+          cd ${TORRENT_DIR} && mktorrent \
+            --announce="udp://fosstorrents.com:6969/announce" \
+            --announce="http://fosstorrents.com:6969/announce" \
+            --comment="Installer for "${{ steps.build.outputs.iso_name }}" version "$installer_version \
+            --piece-length=20 \
+            --web-seed=https://download.bazzite.gg/${{ steps.build.outputs.iso_name }} \
+            ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }}
+          echo "torrent-dir=${TORRENT_DIR}" >> $GITHUB_OUTPUT
+
+      - name: Move ISO, checksum and torrent to Upload Directory
         id: upload-directory
         shell: bash
         run: |
@@ -155,9 +174,10 @@ jobs:
           mkdir ${ISO_UPLOAD_DIR}
           mv ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }} ${ISO_UPLOAD_DIR}
           mv ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }}-CHECKSUM ${ISO_UPLOAD_DIR}
+          mv ${{ steps.create-torrent.outputs.torrent-dir }}/${{ steps.build.outputs.iso_name }}.torrent ${ISO_UPLOAD_DIR}
           echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
 
-      - name: Upload ISOs and Checksum to Job Artifacts
+      - name: Upload ISO, checksum and torrent to Job Artifacts
         if: github.ref_name == 'testing'
         #if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
@@ -169,7 +189,7 @@ jobs:
           compression-level: 0
           overwrite: true
 
-      - name: Upload ISOs and Checksum to R2
+      - name: Upload ISO, checksum and torrent to R2
         if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
         shell: bash
         env:


### PR DESCRIPTION
Hello everyone! Before even becoming a user, I present you with this patchset. The aim here is to make BitTorrent an alternative supported way of obtaining Bazzite ISO images for installation.

The PR is marked as a draft because not everything here is ready to be merged just yet. While the first patch should work (and result in `.torrent` files being published for each built ISO), I wasn't able to test it on my own. When I try to run the GH action from a cloned repo, the build fails at the "Determine Flatpak Dependencies" step (`docker: Error response from daemon: Head "https://ghcr.io/v2/mskiptr/bazzite/manifests/stable": denied.`).

The second patch is a work-in-progress. I would like to mark each generated `.torrent` with the information which build number | version | revision it corresponds to. But how do I obtain that? I couldn't find it anywhere among all variables in that YAML file.

Finally, the third patch adds the official Fedora tracker. It isn't necessary, since there's always the DHT and peer exchange, so the torrent should work without a tracker but adding one might still be beneficial. The patch is marked as a draft because using that tracker will have to be coordinated with the Fedora infrastructure admins most likely. (And btw, if this _really_ needs a tracker, we can always look for some general-purpose one.)


Now, how will the swarm start up? At first I thought that for each variant and version someone will have to obtain the ISO manually and inject it into a torrent client. That would certainly be _not ideal_ to say the least, but at least it should be simpler than [getting someone else to send you parts of the file](https://www.answeroverflow.com/m/1328306949741350963) when the transfer keeps failing for you.

But it turns out we have a much better option. There's this thing called Web Seeds. It basically means that a `.torrent` file can contain a list of URIs that should be tried automatically, side-by-side with any actual BitTorrent peers.

The apparent lack of support for HTTP range requests from the current CDN might throw a wrench in that. But even then having an official `.torrent` available would still be an improvement here. Another problem might be that currently the web download link is not unique between consecutive Bazzite releases. So if someone tries to download the ISO using a `.torrent` file from an older release, the software might get confused.