### PR TITLE
feat(waydroid) - Add waydroid force restart shortcut

### DIFF
--- a/system_files/desktop/shared/usr/libexec/waydroid-container-restart
+++ b/system_files/desktop/shared/usr/libexec/waydroid-container-restart
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+sudo waydroid container restart

--- a/system_files/desktop/shared/usr/share/applications/waydroid-container-restart.desktop
+++ b/system_files/desktop/shared/usr/share/applications/waydroid-container-restart.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Force Restart Waydroid
+Exec=pkexec /usr/libexec/waydroid-container-restart
+Categories=X-WayDroid-App;
+X-Purism-FormFactor=Workstation;Mobile;
+Icon=waydroid
+NoDisplay=false

--- a/system_files/desktop/shared/usr/share/polkit-1/actions/org.bazzite.waydroid.policy
+++ b/system_files/desktop/shared/usr/share/polkit-1/actions/org.bazzite.waydroid.policy
@@ -28,6 +28,17 @@
     <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/waydroid-container-stop</annotate>
   </action>
 
+  <action id="org.bazzite.policykit.waydroid.container.restart">
+    <description>Restart Waydroid Container</description>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/waydroid-container-restart</annotate>
+  </action>
+
   <action id="org.bazzite.policykit.waydroid.fix.controllers">
     <description>Fix Controllers in Waydroid</description>
     <icon_name>package-x-generic</icon_name>

--- a/system_files/desktop/shared/usr/share/polkit-1/rules.d/30-waydroid.rules
+++ b/system_files/desktop/shared/usr/share/polkit-1/rules.d/30-waydroid.rules
@@ -1,6 +1,7 @@
 polkit.addRule(function(action, subject) {
     if ((action.id == "org.bazzite.policykit.waydroid.container.start" || 
          action.id == "org.bazzite.policykit.waydroid.container.stop" ||
+         action.id == "org.bazzite.policykit.waydroid.container.restart" ||
          action.id == "org.bazzite.policykit.waydroid.fix.controllers") &&
          subject.isInGroup("wheel")) {
         return polkit.Result.YES;

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
@@ -29,6 +29,7 @@ setup-waydroid ACTION="":
       fi
       sudo waydroid init -c 'https://ota.waydro.id/system' -v 'https://ota.waydro.id/vendor'
       sudo restorecon -R /var/lib/waydroid
+      cp /usr/share/applications/waydroid-container-restart.desktop ~/.local/share/applications
       echo "Waydroid has been initialized, please run waydroid once before you Configure Waydroid"
     elif [[ "${OPTION,,}" =~ ^configure ]]; then
       git clone https://github.com/ublue-os/waydroid_script.git --depth 1 /tmp/waydroid_script


### PR DESCRIPTION
Occasionally the Waydroid container becomes unresponsive, but a simple force restart fixes it. This just adds a convenience shortcut for it.