### PR TITLE
chore(yafti): Remove scrcpy from the Bazzite Portal

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -37,11 +37,6 @@ screens:
           default: false
           packages:
           - Install Resilio Sync: ujust install-resilio-sync
-        scrcpy:
-          description: scrcpy provides display and control of Android devices connected on USB (or over TCP/IP)
-          default: false
-          packages:
-          - Install scrcpy: ujust install-scrcpy
   configure-bazzite:
     source: yafti.screen.package
     values:

--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -32,11 +32,6 @@ screens:
           default: false
           packages:
           - Install Resilio Sync: ujust install-resilio-sync
-        scrcpy:
-          description: scrcpy provides display and control of Android devices connected on USB (or over TCP/IP)
-          default: false
-          packages:
-          - Install scrcpy: ujust install-scrcpy
         lact:
           description: LACT provides GPU overclocking for AMD & Nvidia GPUs
           default: false


### PR DESCRIPTION
Too large of a download to setup a container for a first-time setup utility which confuses new users when the device goes to sleep and it breaks among other issues.  It will still be available as a `ujust` command.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
