### PR TITLE
feat(horipad): add udev rules for Steam horipad

### DIFF
--- a/system_files/deck/shared/usr/lib/udev/rules.d/50-steam-horipad-controller.rules
+++ b/system_files/deck/shared/usr/lib/udev/rules.d/50-steam-horipad-controller.rules
@@ -1,0 +1,9 @@
+# udev rules from GloriousEggroll
+
+# Wireless HORIPAD STEAM; Bluetooth
+KERNEL=="hidraw*", KERNELS=="*0F0D:0196*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="0196", MODE="0660", TAG+="uaccess"
+
+# Wired HORIPAD STEAM; USB
+KERNEL=="hidraw*", KERNELS=="*0F0D:01AB*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="01ab", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
this adds the udev rules required for the Steam Horipad

tested on my Bazzite HTPC, recently received a horipad as a gift