### PR TITLE
feat(gamescope): add legion, cherry hotkey patch, fix externals on Intel rotation

### DIFF
--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -3,7 +3,7 @@
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
 #global gamescope_tag 3.15.11
-%global gamescope_commit 4da5e4a37560f9b3c85af2679330f9ec292c8ee1 
+%global gamescope_commit d3174928d47f7e353e7daca63cf882d65660cc7c 
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           gamescope

--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -8,7 +8,7 @@
 
 Name:           gamescope
 #Version:        100.%{gamescope_tag}
-Version:        104.%{short_commit}
+Version:        106.%{short_commit}
 Release:        1.bazzite
 Summary:        Micro-compositor for video games on Wayland
 
@@ -114,7 +114,7 @@ cd gamescope
 export PKG_CONFIG_PATH=pkgconfig
 %meson \
     --auto-features=enabled \
-    -Dforce_fallback_for=vkroots,wlroots,libliftoff
+    -Dforce_fallback_for=vkroots,wlroots,libliftoff,libdisplay-info
 %meson_build
 
 %install

--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -113,7 +113,7 @@ sed -i 's^../thirdparty/SPIRV-Headers/include/spirv/^/usr/include/spirv/^' src/m
 cd gamescope
 export PKG_CONFIG_PATH=pkgconfig
 %meson \
-    -Dforce_fallback_for=libdisplay-info,libliftoff,wlroots,vkroots
+    -Dforce_fallback_for=stb,libdisplay-info,libliftoff,wlroots,vkroots
 %meson_build
 
 %install

--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -8,7 +8,7 @@
 
 Name:           gamescope
 #Version:        100.%{gamescope_tag}
-Version:        105.%{short_commit}
+Version:        104.%{short_commit}
 Release:        1.bazzite
 Summary:        Micro-compositor for video games on Wayland
 
@@ -113,7 +113,8 @@ sed -i 's^../thirdparty/SPIRV-Headers/include/spirv/^/usr/include/spirv/^' src/m
 cd gamescope
 export PKG_CONFIG_PATH=pkgconfig
 %meson \
-    -Dforce_fallback_for=stb,libdisplay-info,libliftoff,wlroots,vkroots
+    --auto-features=enabled \
+    -Dforce_fallback_for=vkroots,wlroots,libliftoff
 %meson_build
 
 %install

--- a/spec_files/gamescope/handheld.patch
+++ b/spec_files/gamescope/handheld.patch
@@ -36,7 +36,7 @@ index 0000000..878bf6c
 +    # sudo reboot
 +EOF
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -155,7 +155,7 @@ index 2e6fb83..390c04a 100644
  enum class GamescopeUpscaleFilter : uint32_t
  {
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -248,7 +248,7 @@ index 095694e..e41fad9 100644
  	bool hasHwndStyle = false;
  	uint32_t hwndStyle = 0;
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -309,7 +309,7 @@ index 78a86ee..99df8aa 100644
  			wlserver_keyboardfocus( old_kb_surf, false );
  			return;
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -378,7 +378,7 @@ index df7616d..4a17499 100644
  				break;
  			case '?':
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -443,7 +443,7 @@ index 4a17499..da3115f 100644
  				break;
  			case '?':
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -479,7 +479,7 @@ index 84e05a9..2398535 100644
  				} else if (strcmp(opt_name, "custom-refresh-rates") == 0) {
  					g_customRefreshRates = parse_custom_refresh_rates( optarg );
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -511,7 +511,7 @@ index 99df8aa..5e8f516 100644
  		default:
  		case GAMESCOPE_PANEL_ORIENTATION_AUTO:
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -588,7 +588,7 @@ index da3115f..69fd348 100644
  					g_bHackyEnabled = true;
  				}
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -700,7 +700,7 @@ index 0569472..104f7a2 100644
  std::vector<ResListEntry_t> wlserver_xdg_commit_queue();
  
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -731,7 +731,7 @@ index 75c3258..f014be9 100644
  					m_Mutable.ValidDynamicRefreshRates = TableToVector<uint32_t>( *otDynamicRefreshRates );
  
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -801,7 +801,7 @@ index 3dd64f8..7dacfe7 100644
  	if ( ev->atom == ctx->atoms.gamescopeDisplayForceInternal )
  	{
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -946,7 +946,7 @@ index 7dacfe7..4098c44 100644
  		const bool bVRR = GetBackend()->IsVRRActive();
  		if ( bVRR )
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -997,7 +997,7 @@ index df2af70..e4eec9f 100644
  
  	bool HasQueuedEvents();
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -1155,7 +1155,7 @@ index e4eec9f..2347cbb 100644
  
  	bool HasQueuedEvents();
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -1164,7 +1164,7 @@ Date: Fri, 6 Dec 2024 16:51:02 +0800
 Subject: feat: add rotation shader for rotating output
 
 ---
- src/Backends/DRMBackend.cpp  |  29 +++++++-
+ src/Backends/DRMBackend.cpp  |  37 +++++++++-
  src/main.cpp                 |   6 ++
  src/main.hpp                 |   1 +
  src/meson.build              |   1 +
@@ -1172,27 +1172,58 @@ Subject: feat: add rotation shader for rotating output
  src/rendervulkan.hpp         |   6 +-
  src/shaders/cs_rotation.comp |  53 +++++++++++++++
  src/wlserver.cpp             |   5 ++
- 8 files changed, 208 insertions(+), 19 deletions(-)
+ 8 files changed, 216 insertions(+), 19 deletions(-)
  create mode 100644 src/shaders/cs_rotation.comp
 
 diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
-index 6bb0b88..506963d 100644
+index 6bb0b88..2fbc090 100644
 --- a/src/Backends/DRMBackend.cpp
 +++ b/src/Backends/DRMBackend.cpp
-@@ -1752,7 +1752,7 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
+@@ -56,6 +56,8 @@
+ 
+ static constexpr bool k_bUseCursorPlane = false;
+ 
++bool l_bEnableRotationShader = false;
++
+ extern int g_nPreferredOutputWidth;
+ extern int g_nPreferredOutputHeight;
+ 
+@@ -1528,6 +1530,10 @@ static void update_drm_effective_orientations( struct drm_t *drm, const drmModeM
+ 		if ( pDRMInternalConnector != drm->pConnector )
+ 			pInternalMode = find_mode( pDRMInternalConnector->GetModeConnector(), 0, 0, 0 );
+ 
++		if ( g_bUseRotationShader ) {
++			l_bEnableRotationShader = true;
++		}
++
+ 		pDRMInternalConnector->UpdateEffectiveOrientation( pInternalMode );
+ 	}
+ 
+@@ -1539,6 +1545,10 @@ static void update_drm_effective_orientations( struct drm_t *drm, const drmModeM
+ 		if ( pDRMExternalConnector != drm->pConnector )
+ 			pExternalMode = find_mode( pDRMExternalConnector->GetModeConnector(), 0, 0, 0 );
+ 
++		if ( g_bUseRotationShader ) {
++			l_bEnableRotationShader = false;
++		}
++
+ 		pDRMExternalConnector->UpdateEffectiveOrientation( pExternalMode );
+ 	}
+ }
+@@ -1752,7 +1762,7 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
  		uint64_t crtcW = srcWidth / frameInfo->layers[ i ].scale.x;
  		uint64_t crtcH = srcHeight / frameInfo->layers[ i ].scale.y;
  
 -		if (g_bRotated)
-+		if (g_bRotated && !g_bUseRotationShader)
++		if (g_bRotated && !l_bEnableRotationShader)
  		{
  			int64_t imageH = frameInfo->layers[ i ].tex->contentHeight() / frameInfo->layers[ i ].scale.y;
  
-@@ -2045,6 +2045,17 @@ namespace gamescope
+@@ -2045,6 +2055,17 @@ namespace gamescope
  
  	void CDRMConnector::UpdateEffectiveOrientation( const drmModeModeInfo *pMode )
  	{
-+        if (g_bUseRotationShader)
++        if (l_bEnableRotationShader)
 +        {
 +			drm_log.infof("Using rotation shader");
 +			if (g_DesiredInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_270) {
@@ -1206,27 +1237,25 @@ index 6bb0b88..506963d 100644
  		if ( this->GetScreenType() == GAMESCOPE_SCREEN_TYPE_INTERNAL && g_DesiredInternalOrientation != GAMESCOPE_PANEL_ORIENTATION_AUTO )
  		{
  			m_ChosenOrientation = g_DesiredInternalOrientation;
-@@ -3035,6 +3046,15 @@ bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode )
+@@ -3035,6 +3056,13 @@ bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode )
  		g_bRotated = false;
  		g_nOutputWidth = mode->hdisplay;
  		g_nOutputHeight = mode->vdisplay;
 +
-+		if (g_bUseRotationShader && drm->pConnector->GetScreenType() == gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL) {
++		if (l_bEnableRotationShader) {
 +			g_bRotated = true;
 +			g_nOutputWidth = mode->vdisplay;
 +			g_nOutputHeight = mode->hdisplay;
-+		} else {
-+			g_bUseRotationShader = false;
 +		}
 +
  		break;
  	case GAMESCOPE_PANEL_ORIENTATION_90:
  	case GAMESCOPE_PANEL_ORIENTATION_270:
-@@ -3294,6 +3314,11 @@ namespace gamescope
+@@ -3294,6 +3322,11 @@ namespace gamescope
  
  			bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
  
-+			if (g_bUseRotationShader)
++			if (l_bEnableRotationShader)
 +			{
 +				bNeedsFullComposite = true;
 +			}
@@ -1234,12 +1263,12 @@ index 6bb0b88..506963d 100644
  			bool bDoComposite = true;
  			if ( !bNeedsFullComposite && !bWantsPartialComposite )
  			{
-@@ -3384,7 +3409,7 @@ namespace gamescope
+@@ -3384,7 +3417,7 @@ namespace gamescope
  			if ( bDefer && !!( g_uCompositeDebug & CompositeDebugFlag::Markers ) )
  				g_uCompositeDebug |= CompositeDebugFlag::Markers_Partial;
  
 -			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite );
-+			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite, nullptr, true, nullptr, g_bUseRotationShader );
++			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite, nullptr, true, nullptr, l_bEnableRotationShader );
  
  			m_bWasCompositing = true;
  
@@ -1650,7 +1679,7 @@ index 1eeaa25..5aa986a 100644
  	*y = ty;
  }
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -1693,10 +1722,10 @@ index 97dea45..fefb2a0 100644
  * `-S stretch`: use stretch scaling, the game will fill the window. (e.g. 4:3 to 16:9)
  * `-b`: create a border-less window.
 diff --git a/src/Backends/DRMBackend.cpp b/src/Backends/DRMBackend.cpp
-index 506963d..98bdb71 100644
+index 2fbc090..8bde9e9 100644
 --- a/src/Backends/DRMBackend.cpp
 +++ b/src/Backends/DRMBackend.cpp
-@@ -3293,6 +3293,7 @@ namespace gamescope
+@@ -3301,6 +3301,7 @@ namespace gamescope
  			bNeedsFullComposite |= bWasFirstFrame;
  			bNeedsFullComposite |= pFrameInfo->useFSRLayer0;
  			bNeedsFullComposite |= pFrameInfo->useNISLayer0;
@@ -2367,7 +2396,7 @@ index 2347cbb..bc38c98 100644
  		Atom gamescopeBlurMode;
  		Atom gamescopeBlurRadius;
 -- 
-2.47.1
+2.48.0
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
@@ -2435,5 +2464,127 @@ index c817880..407dae8 100644
        static uint32_t s_minImageCount = []() -> uint32_t {
          if (auto minCount = parseEnv<uint32_t>("GAMESCOPE_WSI_MIN_IMAGE_COUNT")) {
 -- 
-2.47.1
+2.48.0
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Schwartz <matthew.schwartz@linux.dev>
+Date: Sat, 14 Dec 2024 20:54:57 -0800
+Subject: WaylandBackend: Fix hotkeys failing to bind on Wayland desktops
+
+Per Wayland protocol specsheet regarding keymapping:
+"From version 7 onwards, the fd must be mapped with MAP_PRIVATE by the
+recipient, as MAP_SHARED may fail."
+
+This matches up exactly with what we're seeing with this error:
+[gamescope] [Error] xdg_backend: Failed to map keymap fd.
+
+Changing MAP_SHARED to MAP_PRIVATE per the spec addresses this error.
+
+Fixes: #1658
+(hopefully) fixes: #1637
+---
+ src/Backends/WaylandBackend.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Backends/WaylandBackend.cpp b/src/Backends/WaylandBackend.cpp
+index 7ae273f..0a3657f 100644
+--- a/src/Backends/WaylandBackend.cpp
++++ b/src/Backends/WaylandBackend.cpp
+@@ -2709,7 +2709,7 @@ namespace gamescope
+         defer( close( nFd ) );
+         assert( uFormat == WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1 );
+ 
+-        char *pMap = (char *)mmap( nullptr, uSize, PROT_READ, MAP_SHARED, nFd, 0 );
++        char *pMap = (char *)mmap( nullptr, uSize, PROT_READ, MAP_PRIVATE, nFd, 0 );
+         if ( !pMap || pMap == MAP_FAILED )
+         {
+             xdg_log.errorf( "Failed to map keymap fd." );
+-- 
+2.48.0
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <git@antheas.dev>
+Date: Sun, 19 Jan 2025 17:52:28 +0100
+Subject: feat: add legion go s display (works only with VRR on)
+
+---
+ .../displays/lenovo.legiongos.lcd.lua         | 64 +++++++++++++++++++
+ 1 file changed, 64 insertions(+)
+ create mode 100644 scripts/00-gamescope/displays/lenovo.legiongos.lcd.lua
+
+diff --git a/scripts/00-gamescope/displays/lenovo.legiongos.lcd.lua b/scripts/00-gamescope/displays/lenovo.legiongos.lcd.lua
+new file mode 100644
+index 0000000..e522b38
+--- /dev/null
++++ b/scripts/00-gamescope/displays/lenovo.legiongos.lcd.lua
+@@ -0,0 +1,64 @@
++gamescope.config.known_displays.legiongos_lcd = {
++    pretty_name = "Lenovo Legion Go S LCD",
++    hdr = {
++        -- Setup some fallbacks for undocking with HDR, meant
++        -- for the internal panel. It does not support HDR.
++        supported = false,
++        force_enabled = false,
++        eotf = gamescope.eotf.gamma22,
++        max_content_light_level = 500,
++        max_frame_average_luminance = 500,
++        min_content_light_level = 0.5
++    },
++    
++    dynamic_refresh_rates = {
++        48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
++        58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
++        68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
++        78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
++        88, 89, 90, 91, 92, 93, 94, 95, 96, 97,
++        98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
++        108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
++        118, 119, 120
++    },
++    
++    -- Detailed Timing Descriptors:
++    -- DTD 1:  1920x1200  120.002 Hz   8:5   151.683 kHz 315.500 MHz (172 mm x 107 mm)
++    --   Modeline "1920x1200_120.00" 315.500  1920 1968 2000 2080  1200 1254 1260 1264  -HSync -VSync
++    -- DTD 2:  1920x1200   60.001 Hz   8:5    75.841 kHz 157.750 MHz (172 mm x 107 mm)
++    --   Modeline "1920x1200_60.00" 157.750  1920 1968 2000 2080  1200 1254 1260 1264  -HSync -VSync
++    dynamic_modegen = function(base_mode, refresh)
++        debug("Generating mode "..refresh.."Hz with fixed pixel clock")
++        local vfps = {
++            1950, 1885, 1824, 1764, 1707, 1652, 1599, 1548, 1499, 1451, 1405,
++            1361, 1318, 1277, 1237, 1198, 1160, 1124, 1088, 1054, 1021, 988,
++            957, 927, 897, 868, 840, 813, 786, 760, 735, 710, 686, 663, 640,
++            618, 596, 575, 554, 534, 514, 495, 476, 457, 439, 421, 404, 387,
++            370, 354, 338, 322, 307, 292, 277, 263, 249, 235, 221, 208, 195,
++            182, 169, 157, 145, 133, 121, 109, 98, 87, 76, 65, 54
++        }
++        local vfp = vfps[zero_index(refresh - 48)]
++        if vfp == nil then
++            warn("Couldn't do refresh "..refresh.." on ROG Ally")
++            return base_mode
++        end
++
++        local mode = base_mode
++
++        gamescope.modegen.adjust_front_porch(mode, vfp)
++        mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)
++
++        --debug(inspect(mode))
++        return mode
++    end,
++
++    
++    matches = function(display)
++        if display.vendor == "CSW" and display.model == "PN8007QB1-1" then
++            debug("[legos_lcd] Matched vendor: "..display.vendor.." model: "..display.model.." product:"..display.product)
++            return 5000
++        end
++        return -1
++    end
++}
++debug("Registered Lenovo Legion Go S LCD as a known display")
+\ No newline at end of file
+-- 
+2.48.0
 

--- a/spec_files/gamescope/handheld.patch
+++ b/spec_files/gamescope/handheld.patch
@@ -10,7 +10,7 @@ Subject: [NA] add dev script
 
 diff --git a/sync.sh b/sync.sh
 new file mode 100755
-index 0000000..676d652
+index 0000000..878bf6c
 --- /dev/null
 +++ b/sync.sh
 @@ -0,0 +1,21 @@
@@ -30,7 +30,7 @@ index 0000000..676d652
 +scp build/src/gamescope ${HOST}:gamescope
 +
 +ssh $HOST /bin/bash << EOF
-+    sudo rpm-ostree usroverlay
++    sudo rpm-ostree usroverlay --hotfix
 +    sudo mv ~/gamescope /usr/bin/gamescope
 +    bazzite-session-select gamescope
 +    # sudo reboot
@@ -171,7 +171,7 @@ This reverts commit 299bc3410dcfd46da5e3c988354b60ed3a356900.
  2 files changed, 24 insertions(+), 16 deletions(-)
 
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 18be94d..cd7e8ac 100644
+index 11a7cad..df7616d 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -3299,7 +3299,7 @@ found:;
@@ -183,7 +183,7 @@ index 18be94d..cd7e8ac 100644
  
  		// Always update X's idea of focus, but still dirty
  		// the it being outdated so we can resolve that globally later.
-@@ -6050,28 +6050,37 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
+@@ -6044,28 +6044,37 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
  			// Window just got a new available commit, determine if that's worth a repaint
  
  			// If this is an overlay that we're presenting, repaint
@@ -348,7 +348,7 @@ index 8381889..a76b51b 100644
  	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
  	"  --force-orientation            rotate the internal display (left, right, normal, upsidedown)\n"
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index cd7e8ac..3f3d499 100644
+index df7616d..4a17499 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -197,6 +197,7 @@ update_runtime_info();
@@ -368,7 +368,7 @@ index cd7e8ac..3f3d499 100644
  	{
  		gamescope::cv_touch_click_mode = (gamescope::TouchClickMode) get_prop(ctx, ctx->root, ctx->atoms.steamTouchClickModeAtom, 0u );
  	}
-@@ -7482,6 +7483,8 @@ steamcompmgr_main(int argc, char **argv)
+@@ -7476,6 +7477,8 @@ steamcompmgr_main(int argc, char **argv)
  					g_reshade_technique_idx = atoi(optarg);
  				} else if (strcmp(opt_name, "mura-map") == 0) {
  					set_mura_overlay(optarg);
@@ -413,7 +413,7 @@ index a76b51b..84e05a9 100644
  	"  --xwayland-count               create N xwayland servers\n"
  	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 3f3d499..5345b55 100644
+index 4a17499..da3115f 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -147,6 +147,7 @@ static lut3d_t g_tmpLut3d;
@@ -433,7 +433,7 @@ index 3f3d499..5345b55 100644
  	{
  		auto tex = vulkan_get_hacky_blank_texture();
  		if ( tex != nullptr )
-@@ -7485,6 +7486,8 @@ steamcompmgr_main(int argc, char **argv)
+@@ -7479,6 +7480,8 @@ steamcompmgr_main(int argc, char **argv)
  					set_mura_overlay(optarg);
  				} else if (strcmp(opt_name, "disable-touch-click") == 0) {
  					cv_disable_touch_click = true;
@@ -549,7 +549,7 @@ index 2398535..0621c65 100644
  	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
  	"  --force-orientation            rotate the internal display (left, right, normal, upsidedown)\n"
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 5345b55..6544cf0 100644
+index da3115f..69fd348 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -148,6 +148,7 @@ extern int g_nDynamicRefreshHz;
@@ -578,7 +578,7 @@ index 5345b55..6544cf0 100644
  		return false;
  
  	if ( g_bChangeDynamicRefreshBasedOnGameOpenRatherThanActive )
-@@ -7486,6 +7487,8 @@ steamcompmgr_main(int argc, char **argv)
+@@ -7480,6 +7481,8 @@ steamcompmgr_main(int argc, char **argv)
  					set_mura_overlay(optarg);
  				} else if (strcmp(opt_name, "disable-touch-click") == 0) {
  					cv_disable_touch_click = true;
@@ -650,10 +650,10 @@ index 0621c65..056e1c1 100644
  					g_customRefreshRates = parse_custom_refresh_rates( optarg );
  				} else if (strcmp(opt_name, "sharpness") == 0 ||
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 6544cf0..d541f70 100644
+index 69fd348..3dd64f8 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
-@@ -7198,7 +7198,7 @@ void update_mode_atoms(xwayland_ctx_t *root_ctx, bool* needs_flush = nullptr)
+@@ -7192,7 +7192,7 @@ void update_mode_atoms(xwayland_ctx_t *root_ctx, bool* needs_flush = nullptr)
  	if (needs_flush)
  		*needs_flush = true;
  
@@ -746,7 +746,7 @@ disable VRR and use the classic frame limiter.
  1 file changed, 28 insertions(+), 2 deletions(-)
 
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index d541f70..8e5ad6a 100644
+index 3dd64f8..7dacfe7 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -165,6 +165,7 @@ uint32_t g_reshade_technique_idx = 0;
@@ -815,7 +815,7 @@ Subject: fix(battery): run at half hz while at steamUI and disable VRR V2 +
  1 file changed, 32 insertions(+), 11 deletions(-)
 
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 8e5ad6a..bc238e4 100644
+index 7dacfe7..4098c44 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -166,6 +166,9 @@ uint32_t g_reshade_technique_idx = 0;
@@ -921,7 +921,7 @@ index 8e5ad6a..bc238e4 100644
  	}
  	if ( ev->atom == ctx->atoms.gamescopeDisplayForceInternal )
  	{
-@@ -7634,6 +7638,23 @@ steamcompmgr_main(int argc, char **argv)
+@@ -7628,6 +7632,23 @@ steamcompmgr_main(int argc, char **argv)
  		// as a question.
  		const bool bIsVBlankFromTimer = vblank;
  
@@ -960,7 +960,7 @@ Subject: feat(battery): add atom for controlling frame halving
  2 files changed, 8 insertions(+)
 
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index bc238e4..d968de5 100644
+index 4098c44..6c8ce74 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -5919,6 +5919,10 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
@@ -974,7 +974,7 @@ index bc238e4..d968de5 100644
  }
  
  static int
-@@ -7095,6 +7099,8 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
+@@ -7089,6 +7093,8 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
  	ctx->atoms.primarySelection = XInternAtom(ctx->dpy, "PRIMARY", false);
  	ctx->atoms.targets = XInternAtom(ctx->dpy, "TARGETS", false);
  
@@ -1068,7 +1068,7 @@ index f014be9..6bb0b88 100644
  
  			if ( bNeedsFullComposite )
 diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
-index d8a24e9..00f5ece 100644
+index b537170..ccabd88 100644
 --- a/src/rendervulkan.hpp
 +++ b/src/rendervulkan.hpp
 @@ -281,6 +281,8 @@ struct FrameInfo_t
@@ -1081,7 +1081,7 @@ index d8a24e9..00f5ece 100644
  	struct Layer_t
  	{
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index d968de5..86773db 100644
+index 6c8ce74..dfee904 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -169,6 +169,8 @@ bool g_bVRRRequested = false;
@@ -1121,7 +1121,7 @@ index d968de5..86773db 100644
  }
  
  static int
-@@ -7100,6 +7107,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
+@@ -7094,6 +7101,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
  	ctx->atoms.targets = XInternAtom(ctx->dpy, "TARGETS", false);
  
  	ctx->atoms.gamescopeFrameHalveAtom = XInternAtom( ctx->dpy, "GAMESCOPE_STEAMUI_HALFHZ", false );;
@@ -1129,7 +1129,7 @@ index d968de5..86773db 100644
  
  	ctx->root_width = DisplayWidth(ctx->dpy, ctx->scr);
  	ctx->root_height = DisplayHeight(ctx->dpy, ctx->scr);
-@@ -8067,9 +8075,10 @@ steamcompmgr_main(int argc, char **argv)
+@@ -8061,9 +8069,10 @@ steamcompmgr_main(int argc, char **argv)
  			bShouldPaint = false;
  		}
  
@@ -1544,7 +1544,7 @@ index 54d7608..10d6c78 100644
  
  	if ( pPipewireTexture != nullptr )
 diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
-index 00f5ece..8cffcbe 100644
+index ccabd88..51a62bc 100644
 --- a/src/rendervulkan.hpp
 +++ b/src/rendervulkan.hpp
 @@ -393,7 +393,7 @@ gamescope::OwningRc<CVulkanTexture> vulkan_create_texture_from_dmabuf( struct wl
@@ -1556,7 +1556,7 @@ index 00f5ece..8cffcbe 100644
  void vulkan_wait( uint64_t ulSeqNo, bool bReset );
  gamescope::Rc<CVulkanTexture> vulkan_get_last_output_image( bool partial, bool defer );
  gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace = k_EStreamColorspace_Unknown);
-@@ -530,6 +530,9 @@ struct VulkanOutput_t
+@@ -522,6 +522,9 @@ struct VulkanOutput_t
  	// NIS
  	gamescope::OwningRc<CVulkanTexture> nisScalerImage;
  	gamescope::OwningRc<CVulkanTexture> nisUsmImage;
@@ -1566,7 +1566,7 @@ index 00f5ece..8cffcbe 100644
  };
  
  
-@@ -542,6 +545,7 @@ enum ShaderType {
+@@ -534,6 +537,7 @@ enum ShaderType {
  	SHADER_TYPE_RCAS,
  	SHADER_TYPE_NIS,
  	SHADER_TYPE_RGB_TO_NV12,
@@ -1654,77 +1654,9 @@ index 1eeaa25..5aa986a 100644
 
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: brainantifreeze <you@example.com>
-Date: Thu, 19 Dec 2024 09:16:15 +0000
-Subject: fix(nvidia): allow disabling Vulkan extension for nvidia to work
-
-This adds a workaround for #1592 which removes the
-VkPhysicalDevicePresentWaitFeaturesKHR extension in
-the layer if the environment variable
-GAMESCOPE_WSI_HIDE_PRESENT_WAIT_EXT is set.
-
-This resolves the current freezing issue on nVidia
-in dx12 (without having to set
-VKD3D_DISABLE_EXTENSIONS), dx11 (without having
-to patch DXVK not to use the extension) and in
-native vulkan games.
----
- layer/VkLayer_FROG_gamescope_wsi.cpp | 20 +++++++++++++++++++-
- 1 file changed, 19 insertions(+), 1 deletion(-)
-
-diff --git a/layer/VkLayer_FROG_gamescope_wsi.cpp b/layer/VkLayer_FROG_gamescope_wsi.cpp
-index 718a260..f33da7f 100644
---- a/layer/VkLayer_FROG_gamescope_wsi.cpp
-+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
-@@ -183,6 +183,16 @@ namespace GamescopeWSILayer {
-     return s_ensureMinImageCount;
-   }
- 
-+  static bool getHidePresentWait() {
-+    static bool s_hidePresentWait = []() -> bool {
-+      if (auto hide = parseEnv<bool>("GAMESCOPE_WSI_HIDE_PRESENT_WAIT_EXT")) {
-+        return *hide;
-+      }
-+      return false;
-+    }();
-+    return s_hidePresentWait;
-+  }
-+
-   // Taken from Mesa, licensed under MIT.
-   //
-   // No real reason to rewrite this code,
-@@ -588,7 +598,11 @@ namespace GamescopeWSILayer {
-       createInfo.ppEnabledExtensionNames = enabledExts.data();
- 
-       setenv("vk_xwayland_wait_ready", "false", 0);
--      setenv("vk_khr_present_wait", "true", 0);
-+      if (getHidePresentWait()) {
-+        setenv("vk_khr_present_wait", "false", 0);
-+      } else {
-+        setenv("vk_khr_present_wait", "true", 0);
-+      }
- 
-       VkResult result = pfnCreateInstanceProc(&createInfo, pAllocator, pInstance);
-       if (result != VK_SUCCESS)
-@@ -893,6 +907,10 @@ namespace GamescopeWSILayer {
-       const vkroots::VkInstanceDispatch* pDispatch,
-             VkPhysicalDevice             physicalDevice,
-             VkPhysicalDeviceFeatures2*   pFeatures) {
-+      if (getHidePresentWait()) {
-+        fprintf(stderr, "[Gamescope WSI] Removing VkPhysicalDevicePresentWaitFeaturesKHR because GAMESCOPE_WSI_HIDE_PRESENT_WAIT_EXT is set\n");
-+        vkroots::RemoveFromChain<VkPhysicalDevicePresentWaitFeaturesKHR>(pFeatures);
-+      }
-       pDispatch->GetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
-     }
- 
--- 
-2.47.1
-
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "Ruan E. Formigoni" <ruanformigoni@gmail.com>
 Date: Thu, 2 Jan 2025 17:07:36 +0100
-Subject: feat: implemented bicubic downscaling
+Subject: feat: implement bicubic downscaling
 
 From https://github.com/ValveSoftware/gamescope/pull/740
 ---
@@ -1800,10 +1732,10 @@ index 6d50f8d..c24b864 100644
  								g_wantedUpscaleFilter = (g_wantedUpscaleFilter == GamescopeUpscaleFilter::FSR) ?
  									GamescopeUpscaleFilter::LINEAR : GamescopeUpscaleFilter::FSR;
 diff --git a/src/Backends/WaylandBackend.cpp b/src/Backends/WaylandBackend.cpp
-index f90c096..9f136dd 100644
+index 3226400..7ae273f 100644
 --- a/src/Backends/WaylandBackend.cpp
 +++ b/src/Backends/WaylandBackend.cpp
-@@ -1624,6 +1624,7 @@ namespace gamescope
+@@ -1614,6 +1614,7 @@ namespace gamescope
              bNeedsFullComposite |= cv_composite_force;
              bNeedsFullComposite |= pFrameInfo->useFSRLayer0;
              bNeedsFullComposite |= pFrameInfo->useNISLayer0;
@@ -2059,7 +1991,7 @@ index 10d6c78..8b31c1e 100644
  		uint32_t inputX = frameInfo->layers[0].tex->width();
  		uint32_t inputY = frameInfo->layers[0].tex->height();
 diff --git a/src/rendervulkan.hpp b/src/rendervulkan.hpp
-index 8cffcbe..91e2af7 100644
+index 51a62bc..eeb304c 100644
 --- a/src/rendervulkan.hpp
 +++ b/src/rendervulkan.hpp
 @@ -270,6 +270,7 @@ struct FrameInfo_t
@@ -2070,7 +2002,7 @@ index 8cffcbe..91e2af7 100644
  	bool bFadingOut;
  	BlurMode blurLayer0;
  	int blurRadius;
-@@ -544,6 +545,7 @@ enum ShaderType {
+@@ -536,6 +537,7 @@ enum ShaderType {
  	SHADER_TYPE_EASU,
  	SHADER_TYPE_RCAS,
  	SHADER_TYPE_NIS,
@@ -2324,7 +2256,7 @@ index f2b8527..64cc1c9 100644
  
  const int EOTF_Gamma22 = 0;
 diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
-index 86773db..f88576f 100644
+index dfee904..c2111d2 100644
 --- a/src/steamcompmgr.cpp
 +++ b/src/steamcompmgr.cpp
 @@ -906,6 +906,7 @@ gamescope::ConCommand cc_debug_set_fps_limit( "debug_set_fps_limit", "Set refres
@@ -2369,7 +2301,7 @@ index 86773db..f88576f 100644
  		}
  		hasRepaint = true;
  	}
-@@ -7023,6 +7033,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
+@@ -7017,6 +7027,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
  	ctx->atoms.gamescopeLowLatency = XInternAtom( ctx->dpy, "GAMESCOPE_LOW_LATENCY", false );
  
  	ctx->atoms.gamescopeFSRFeedback = XInternAtom( ctx->dpy, "GAMESCOPE_FSR_FEEDBACK", false );
@@ -2377,7 +2309,7 @@ index 86773db..f88576f 100644
  
  	ctx->atoms.gamescopeBlurMode = XInternAtom( ctx->dpy, "GAMESCOPE_BLUR_MODE", false );
  	ctx->atoms.gamescopeBlurRadius = XInternAtom( ctx->dpy, "GAMESCOPE_BLUR_RADIUS", false );
-@@ -7281,6 +7292,7 @@ extern int g_nPreferredOutputWidth;
+@@ -7275,6 +7286,7 @@ extern int g_nPreferredOutputWidth;
  extern int g_nPreferredOutputHeight;
  
  static bool g_bWasFSRActive = false;
@@ -2385,7 +2317,7 @@ index 86773db..f88576f 100644
  
  bool g_bAppWantsHDRCached = false;
  
-@@ -7695,6 +7707,16 @@ steamcompmgr_main(int argc, char **argv)
+@@ -7689,6 +7701,16 @@ steamcompmgr_main(int argc, char **argv)
  			flush_root = true;
  		}
  
@@ -2402,7 +2334,7 @@ index 86773db..f88576f 100644
  		if (global_focus.IsDirty())
  			determine_and_apply_focus();
  
-@@ -7931,6 +7953,7 @@ steamcompmgr_main(int argc, char **argv)
+@@ -7925,6 +7947,7 @@ steamcompmgr_main(int argc, char **argv)
  			g_bSteamIsActiveWindow = false;
  			g_upscaleScaler = g_wantedUpscaleScaler;
  			g_upscaleFilter = g_wantedUpscaleFilter;
@@ -2434,6 +2366,74 @@ index 2347cbb..bc38c98 100644
  
  		Atom gamescopeBlurMode;
  		Atom gamescopeBlurRadius;
+-- 
+2.47.1
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brainantifreeze <you@example.com>
+Date: Thu, 19 Dec 2024 09:16:15 +0000
+Subject: fix(nvidia): allow disabling Vulkan extension for nvidia to work
+
+This adds a workaround for #1592 which removes the
+VkPhysicalDevicePresentWaitFeaturesKHR extension in
+the layer if the environment variable
+GAMESCOPE_WSI_HIDE_PRESENT_WAIT_EXT is set.
+
+This resolves the current freezing issue on nVidia
+in dx12 (without having to set
+VKD3D_DISABLE_EXTENSIONS), dx11 (without having
+to patch DXVK not to use the extension) and in
+native vulkan games.
+---
+ layer/VkLayer_FROG_gamescope_wsi.cpp | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/layer/VkLayer_FROG_gamescope_wsi.cpp b/layer/VkLayer_FROG_gamescope_wsi.cpp
+index c817880..407dae8 100644
+--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
++++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
+@@ -496,7 +496,11 @@ namespace GamescopeWSILayer {
+       createInfo.ppEnabledExtensionNames = enabledExts.data();
+ 
+       setenv("vk_xwayland_wait_ready", "false", 0);
+-      setenv("vk_khr_present_wait", "true", 0);
++      if (getHidePresentWait()) {
++        setenv("vk_khr_present_wait", "false", 0);
++      } else {
++        setenv("vk_khr_present_wait", "true", 0);
++      }
+ 
+       VkResult result = pfnCreateInstanceProc(&createInfo, pAllocator, pInstance);
+       if (result != VK_SUCCESS)
+@@ -801,6 +805,10 @@ namespace GamescopeWSILayer {
+       const vkroots::VkInstanceDispatch* pDispatch,
+             VkPhysicalDevice             physicalDevice,
+             VkPhysicalDeviceFeatures2*   pFeatures) {
++      if (getHidePresentWait()) {
++        fprintf(stderr, "[Gamescope WSI] Removing VkPhysicalDevicePresentWaitFeaturesKHR because GAMESCOPE_WSI_HIDE_PRESENT_WAIT_EXT is set\n");
++        vkroots::RemoveFromChain<VkPhysicalDevicePresentWaitFeaturesKHR>(pFeatures);
++      }
+       pDispatch->GetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
+     }
+ 
+@@ -1015,6 +1023,16 @@ namespace GamescopeWSILayer {
+       return value;
+     }
+ 
++    static bool getHidePresentWait() {
++      static bool s_hidePresentWait = []() -> bool {
++        if (auto hide = parseEnv<uint32_t>("GAMESCOPE_WSI_HIDE_PRESENT_WAIT_EXT")) {
++          return *hide == 1;
++        }
++        return false;
++      }();
++      return s_hidePresentWait;
++    }
++
+     static uint32_t getMinImageCount() {
+       static uint32_t s_minImageCount = []() -> uint32_t {
+         if (auto minCount = parseEnv<uint32_t>("GAMESCOPE_WSI_MIN_IMAGE_COUNT")) {
 -- 
 2.47.1
 


### PR DESCRIPTION
First, do some reverts to fix our shame with trying to get master. Master has some openvr stuff we dont care about so we can procrastinate on it.

Then, cherry Matt's hotkey fix, add legion config that only works properly with our vrr patch, and fix external rotation when applying the rotation shader on intel