### PR TITLE
feat: add rocm-smi to non-nvidia images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -705,6 +705,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
         rocm-hip \
         rocm-opencl \
         rocm-clinfo \
+        rocm-smi \
         waydroid \
         cage \
         wlr-randr && \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Install `rocm-smi` to non-Nvidia images as a dependency for `btop`.

#2164 