### PR TITLE
fix (docs): Missing GH_TOKEN for pulling offline docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,10 +169,12 @@ jobs:
         uses: actions/checkout@v4
 
       # Prepare offline documentation
-      - id: download_offline_docs
+      - name: Download offline docs
+        id: download_offline_docs
         continue-on-error: true
         env:
           docs_repo: KyleGospo/docs.bazzite.gg
+          GH_TOKEN: ${{ github.token }}
         run: |
           DOCS_DIR="${{ github.workspace }}/system_files/desktop/shared/usr/share/ublue-os/docs/html"
           mkdir -p $DOCS_DIR


### PR DESCRIPTION
github-cli requires be given a token in order work inside github actions
