### PR TITLE
chore: add more Legion Go S variants and dedup

### DIFF
--- a/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
+++ b/system_files/desktop/shared/usr/libexec/hwsupport/hhd-supported-hardware
@@ -6,7 +6,7 @@ if [[ ":ONE-NETBOOK:GPD:AYANEO:" =~ ":$VEN_ID:" ]]; then
 fi
 
 SYS_ID="$(/usr/libexec/hwsupport/sysid)"
-if [[ ":ROG Ally RC71L:ROG Ally X RC72LA:83E1:83L3:G1618-04:G1617-01:G1619-05:AIR Plus:AIR 1S:AIR 1S Limited:AIR:AYANEO GEEK:AYANEO 2:AYANEO 2S:AOKZOE A1 AR07:AOKZOE A1 Pro:G1619-04:Win600:Loki Max:Loki Zero:Loki MiniPro:V3:ONEXPLAYER F1:ONEXPLAYER F1L:ONEXPLAYER F1 EVA-01:" =~ ":$SYS_ID:" ]]; then
+if [[ ":ROG Ally RC71L:ROG Ally X RC72LA:83E1:83L3:83N6:83Q2:83Q3:AOKZOE A1 AR07:AOKZOE A1 Pro:Win600:Loki Max:Loki Zero:Loki MiniPro:V3:ONE XPLAYER:" =~ ":$SYS_ID:" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
Lenovo blessed us with more variants. Also, remove devices that are caught by the manufacturer check above. Exception is ONE XPLAYER, because it is prior to OneXPlayer's rename.