### PR TITLE
fix: General ZRAM Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Variant designed for usage as an alternative to SteamOS on the Steam Deck, and f
 - Update break something? Easily roll back to the previous version of Bazzite thanks to `rpm-ostree`'s rollback functionality. You can even select previous images at boot.
 - Steam and Lutris preinstalled on the image as layered packages.
 - [Discover Overlay](https://github.com/trigg/Discover) for Discord pre-installed and automatically launches in both Game mode and on the Desktop if Discord is installed. [View the official documentation here](https://trigg.github.io/Discover/bazzite).
-- Uses ZRAM<sub><sup>(4GB)</sup></sub> with the ZSTD compression algorithm by default with the option to switch back to a 1GB swap file and set a custom size for it if desired.
+- Uses ZRAM<sub><sup>(same size as RAM)</sup></sub> with the LZ4 compression algorithm by default with optimized kernel parameters.
 - [LAVD](https://crates.io/crates/scx_lavd) and [BORE](https://github.com/firelzrd/bore-scheduler) CPU Schedulers for smooth and responsive gameplay.
 - Kyber I/O scheduler to prevent I/O starvation when installing games or during background `duperemove` process.
 - Applies SteamOS's kernel parameters.

--- a/system_files/deck/shared/etc/systemd/zram-generator.conf
+++ b/system_files/deck/shared/etc/systemd/zram-generator.conf
@@ -1,3 +1,0 @@
-[zram0]
-zram-size=max(ram/4, 4096)
-compression-algorithm=lz4

--- a/system_files/desktop/shared/etc/systemd/zram-generator.conf
+++ b/system_files/desktop/shared/etc/systemd/zram-generator.conf
@@ -1,2 +1,3 @@
 [zram0]
+zram-size=ram
 compression-algorithm=lz4

--- a/system_files/desktop/shared/usr/lib/sysctl.d/65-virtual-memory.conf
+++ b/system_files/desktop/shared/usr/lib/sysctl.d/65-virtual-memory.conf
@@ -1,0 +1,5 @@
+# The values come from https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram
+vm.swappiness = 180
+vm.watermark_boost_factor = 0
+vm.watermark_scale_factor = 125
+vm.page-cluster = 0


### PR DESCRIPTION
### Summary

This PR implements several ZRAM improvements, including:
- Adjusting the default ZRAM size to match system RAM
- Optimizing kernel parameters for better ZRAM utilization
- Updating the outdated README

### Background

I've been using Bazzite on my Legion Go for several weeks and noticed performance issues related to the 16GB RAM limitation. Specifically, Palworld multiplayer would frequently crash and occasionally freeze the system due to out-of-memory (OOM) errors.

After experimenting with various solutions, I found that increasing ZRAM size and tweaking kernel parameters significantly improved stability. While I personally use ZSTD compression on my device, I noticed this project switched from ZSTD to LZ4, so I've maintained LZ4 in this PR to respect that decision.

These changes should help users with similar RAM constraints get better performance and stability from their systems.