### PR TITLE
feat(fcitx5): add `kcm-fcitx5` for better integration with KDE

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -639,6 +639,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
             fcitx5-mozc \
             fcitx5-chinese-addons \
             fcitx5-hangul \
+            kcm-fcitx5 \
             ptyxis && \
         git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git --depth 1 --branch main /tmp/wallpaper-engine-kde-plugin && \
         kpackagetool6 --type=Plasma/Wallpaper --global --install /tmp/wallpaper-engine-kde-plugin/plugin && \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Hiya! I'd like to suggest adding `kcm-fcitx5` for better integration with KDE:

1. Users can tweak their Fcitx5 settings in `System Settings / Input Method` instead of launching Fcitx5 individually.
2. Users can use `KDE Plasma (Experimental)` theme for Fcitx5, which is nice because it can dynamically generate theme to fit their Plasma theme. https://planet.kde.org/weng-xuetian-2022-07-04-fcitx-5-plasma-theme-support/

Thank you!
