### PR TITLE
feat: add ujust get-framegen

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -769,6 +769,7 @@ RUN rm -f /etc/profile.d/toolbox.sh && \
     echo "import \"/usr/share/ublue-os/just/84-bazzite-virt.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/85-bazzite-image.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/86-bazzite-windows.just\"" >> /usr/share/ublue-os/justfile && \
+    echo "import \"/usr/share/ublue-os/just/87-bazzite-framegen.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/90-bazzite-de.just\"" >> /usr/share/ublue-os/justfile && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
       systemctl enable usr-share-sddm-themes.mount && \

--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -22,6 +22,11 @@ screens:
           default: false
           packages:
           - Retrieve Decky: sudo -A ujust setup-decky install
+        Decky Framegen:
+          description: A Decky plugin that swaps DLSS for FSR 3 Upscaling and Framegen
+          default: false
+          packages:
+          - Retrieve Decky Framegen: sudo -A ujust get-framegen install-decky-plugin 
         EmuDeck:
           description: A utility for installing and configuring emulators on the Steam Deck
           default: false

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -63,6 +63,7 @@ get-framegen ACTION="prompt":
         echo "To revert changes to the game's files, use: '~/fgmod/fgmod-uninstaller.sh %COMMAND%'"
         echo ""
         echo "What would you like to do with FGmod?"
+        echo ""
         OPTION=$(ugum choose "Install Decky Framegen plugin" "Install FGmod" "Uninstall FGmod" "Exit without changes")
     elif [ "$OPTION" == "help" ]; then
         echo "Usage: just get-framegen <option>"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -9,11 +9,12 @@ get-framegen ACTION="prompt":
 
   if [ "$OPTION" == "prompt" ]; then
     echo "What would you like to do with FGmod?"
-    OPTION=$(ugum choose "Install FGmod" "Uninstall FGmod" "Exit without changes")
+    OPTION=$(ugum choose "Install FGmod" "Install Decky Framegen plugin" "Uninstall FGmod" "Exit without changes")
   elif [ "$OPTION" == "help" ]; then
     echo "Usage: ujust get-framegen <option>"
-    echo "  <option>: Specify an action - 'install' or 'uninstall'"
+    echo "  <option>: Specify an action - 'install', 'install-decky-plugin', or 'uninstall'"
     echo "  Use 'install' to install FGmod."
+    echo "  Use 'install-decky-plugin' to install the Decky Framegen plugin."
     echo "  Use 'uninstall' to remove FGmod."
     exit 0
   fi
@@ -25,15 +26,69 @@ get-framegen ACTION="prompt":
     chmod +x prepare.sh
     ./prepare.sh
     echo "FGmod installed successfully!"
+    echo "Add launch option '~/fgmod/fgmod %COMMAND%' to the game you want to patch"
+
+  elif [ "${OPTION,,}" == "install decky framegen plugin" ]; then
+    echo "Installing Decky Framegen plugin..."
+
+    # Get the latest release URL dynamically
+    API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
+    PLUGIN_URL=$(curl -s "$API_URL" | grep "browser_download_url" | grep ".zip" | cut -d '"' -f 4)
+
+    if [ -z "$PLUGIN_URL" ]; then
+      echo "Failed to fetch the latest Decky Framegen release. Exiting..."
+      exit 1
+    fi
+
+    PLUGIN_NAME="Decky-Framegen"
+    PLUGIN_DIR="$HOME/homebrew/plugins"
+
+    if [ ! -d "$PLUGIN_DIR" ]; then
+      echo "Creating plugins directory with sudo..."
+      sudo mkdir -p "$PLUGIN_DIR"
+    fi
+
+    cd "$PLUGIN_DIR" || { echo "Failed to navigate to plugins directory"; exit 1; }
+
+    if [ -d "$PLUGIN_NAME" ]; then
+      echo "Removing existing $PLUGIN_NAME directory with sudo..."
+      sudo rm -rf "$PLUGIN_NAME"
+    fi
+
+    echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
+    sudo curl -L -o "${PLUGIN_NAME}.zip" "$PLUGIN_URL"
+
+    if [ $? -ne 0 ]; then
+      echo "Download failed!"
+      exit 1
+    fi
+
+    echo "Extracting $PLUGIN_NAME..."
+    sudo unzip -o "${PLUGIN_NAME}.zip" -d .
+
+    if [ $? -ne 0 ]; then
+      echo "Extraction failed!"
+      exit 1
+    fi
+
+    if [ -d "./${PLUGIN_NAME}/${PLUGIN_NAME}" ]; then
+      echo "Fixing folder structure..."
+      sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
+      sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
+    fi
+
+    echo "Cleaning up..."
+    sudo rm -f "${PLUGIN_NAME}.zip"
+    echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
+    echo "Please restart Decky Loader to activate the plugin."
+
   elif [ "${OPTION,,}" == "uninstall fgmod" ]; then
     echo "Uninstalling FGmod..."
 
-    # Remove ~/fgmod directory if it exists
     if [[ -d "$HOME/fgmod" ]]; then
       rm -rf "$HOME/fgmod"
     fi
 
-    # Remove specific files from ~/Downloads if they exist
     downloads_dir="$HOME/Downloads"
     files_to_remove=("prepare.sh" "fgmod.sh" "fgmod-uninstaller.sh")
 
@@ -44,6 +99,7 @@ get-framegen ACTION="prompt":
     done
 
     echo "FGmod removed successfully!"
+
   elif [ "${OPTION,,}" == "exit without changes" ]; then
     echo "No changes made. Exiting..."
     exit 0

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -50,6 +50,7 @@ get-framegen ACTION="prompt":
     if [ "$OPTION" == "prompt" ]; then
         echo ""
         echo "Current Status:"
+        echo ""
         check_fgmod_installed
         echo ""
         check_decky_installed

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -18,30 +18,30 @@ get-framegen ACTION="prompt":
     function check_fgmod_installed() {
         FG_DIR="$HOME/fgmod"
         if [[ -d "$FG_DIR" ]]; then
-        for file in "${FG_FILES[@]}"; do
-            # Check if each required file exists in the directory
-            if [[ "$file" == "licenses" ]]; then
-            if [[ ! -d "$FG_DIR/$file" ]]; then
-                echo "${yellow}${bold}FGmod is partially installed. 'licenses' is missing or not a directory.${normal}"
-                return
-            fi
-            elif [[ ! -f "$FG_DIR/$file" ]]; then
-            echo "${yellow}${bold}FGmod is partially installed. Missing file: ${file}${normal}"
-            return
-            fi
-        done
-        echo "${green}${bold}FGmod is installed and ready to use.${normal}"
+            for file in "${FG_FILES[@]}"; do
+                # Check if 'licenses' is a directory
+                if [[ "$file" == "licenses" ]]; then
+                    if [[ ! -d "$FG_DIR/$file" ]]; then
+                        echo "${yellow}${bold}FGmod is partially installed. 'licenses' is missing or not a directory.${normal}"
+                        return
+                    fi
+                elif [[ ! -f "$FG_DIR/$file" ]]; then
+                    echo "${yellow}${bold}FGmod is partially installed. Missing file: ${file}${normal}"
+                    return
+                fi
+            done
+            echo "${green}${bold}FGmod is installed and ready to use.${normal}"
         else
-        echo "${red}${bold}FGmod is not installed.${normal}"
+            echo "${red}${bold}FGmod is not installed.${normal}"
         fi
     }
 
     function check_decky_installed() {
         PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
         if [[ -d "$PLUGIN_DIR" ]]; then
-        echo "${green}${bold}Decky Framegen plugin is installed.${normal}"
+            echo "${green}${bold}Decky Framegen plugin is installed.${normal}"
         else
-        echo "${red}${bold}Decky Framegen plugin is not installed.${normal}"
+            echo "${red}${bold}Decky Framegen plugin is not installed.${normal}"
         fi
     }
 
@@ -50,7 +50,6 @@ get-framegen ACTION="prompt":
     if [ "$OPTION" == "prompt" ]; then
         echo ""
         echo "Current Status:"
-        echo ""
         check_fgmod_installed
         echo ""
         check_decky_installed
@@ -66,7 +65,7 @@ get-framegen ACTION="prompt":
         echo "What would you like to do with FGmod?"
         OPTION=$(ugum choose "Install Decky Framegen plugin" "Install FGmod" "Uninstall FGmod" "Exit without changes")
     elif [ "$OPTION" == "help" ]; then
-        echo "Usage: ujust get-framegen <option>"
+        echo "Usage: just get-framegen <option>"
         echo "  <option>: Specify an action - 'install', 'install-decky-plugin', or 'uninstall'"
         echo "  Use 'install' to install FGmod."
         echo "  Use 'install-decky-plugin' to install the Decky Framegen plugin."
@@ -74,7 +73,7 @@ get-framegen ACTION="prompt":
         exit 0
     fi
 
-    if [ "${OPTION,,}" == "install fgmod" ]; then
+    if [ "${OPTION,,}" == "install" ] || [ "${OPTION,,}" == "install fgmod" ]; then
         echo "Installing FGmod..."
         TMP_DIR=$(mktemp -d) && cd "$TMP_DIR"
         git clone https://github.com/xXJSONDeruloXx/fgmod-bazzite.git .
@@ -83,52 +82,52 @@ get-framegen ACTION="prompt":
         echo "FGmod installed successfully!"
         echo "To patch a game, add the launch option '~/fgmod/fgmod %COMMAND%' in its settings."
 
-    elif [ "${OPTION,,}" == "install decky framegen plugin" ]; then
+    elif [ "${OPTION,,}" == "install-decky-plugin" ] || [ "${OPTION,,}" == "install decky framegen plugin" ]; then
         echo "Installing Decky Framegen plugin..."
 
         API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
         PLUGIN_URL=$(curl -s "$API_URL" | grep "browser_download_url" | grep ".zip" | cut -d '"' -f 4)
 
         if [ -z "$PLUGIN_URL" ]; then
-        echo "Failed to fetch the latest Decky Framegen release. Exiting..."
-        exit 1
+            echo "Failed to fetch the latest Decky Framegen release. Exiting..."
+            exit 1
         fi
 
         PLUGIN_NAME="Decky-Framegen"
         PLUGIN_DIR="$HOME/homebrew/plugins"
 
         if [ ! -d "$PLUGIN_DIR" ]; then
-        echo "Creating plugins directory with sudo..."
-        sudo mkdir -p "$PLUGIN_DIR"
+            echo "Creating plugins directory with sudo..."
+            sudo mkdir -p "$PLUGIN_DIR"
         fi
 
         cd "$PLUGIN_DIR" || { echo "Failed to navigate to plugins directory"; exit 1; }
 
         if [ -d "$PLUGIN_NAME" ]; then
-        echo "Removing existing $PLUGIN_NAME directory with sudo..."
-        sudo rm -rf "$PLUGIN_NAME"
+            echo "Removing existing $PLUGIN_NAME directory with sudo..."
+            sudo rm -rf "$PLUGIN_NAME"
         fi
 
         echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
         sudo curl -L -o "${PLUGIN_NAME}.zip" "$PLUGIN_URL"
 
         if [ $? -ne 0 ]; then
-        echo "Download failed!"
-        exit 1
+            echo "Download failed!"
+            exit 1
         fi
 
         echo "Extracting $PLUGIN_NAME..."
         sudo unzip -o "${PLUGIN_NAME}.zip" -d .
 
         if [ $? -ne 0 ]; then
-        echo "Extraction failed!"
-        exit 1
+            echo "Extraction failed!"
+            exit 1
         fi
 
         if [ -d "./${PLUGIN_NAME}/${PLUGIN_NAME}" ]; then
-        echo "Fixing folder structure..."
-        sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
-        sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
+            echo "Fixing folder structure..."
+            sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
+            sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
         fi
 
         echo "Cleaning up..."
@@ -136,27 +135,28 @@ get-framegen ACTION="prompt":
         echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
         echo "Please restart Decky Loader to activate the plugin."
 
-    elif [ "${OPTION,,}" == "uninstall fgmod" ]; then
+    elif [ "${OPTION,,}" == "uninstall" ] || [ "${OPTION,,}" == "uninstall fgmod" ]; then
         echo "Uninstalling FGmod..."
 
         if [[ -d "$HOME/fgmod" ]]; then
-        rm -rf "$HOME/fgmod"
+            rm -rf "$HOME/fgmod"
         fi
 
         downloads_dir="$HOME/Downloads"
         files_to_remove=("prepare.sh" "fgmod.sh" "fgmod-uninstaller.sh")
 
         for file in "${files_to_remove[@]}"; do
-        if [[ -f "$downloads_dir/$file" ]]; then
-            rm "$downloads_dir/$file"
-        fi
+            if [[ -f "$downloads_dir/$file" ]]; then
+                rm "$downloads_dir/$file"
+            fi
         done
 
         echo "FGmod removed successfully!"
 
-    elif [ "${OPTION,,}" == "exit without changes" ]; then
+    elif [ "${OPTION,,}" == "exit" ] || [ "${OPTION,,}" == "exit without changes" ]; then
         echo "No changes made. Exiting..."
         exit 0
+
     else
         echo "Invalid option. Exiting..."
         exit 1

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -1,6 +1,53 @@
 # vim: set ft=make :
 
 # set up DLSS-Enabler upscaling and framegen mod. Allows FSR3 upscaling and framegen via DLSS equivalents in supported games
-get-framegen:
-    #!/usr/bin/bash
-    TMP_DIR=$(mktemp -d) && cd "$TMP_DIR" && git clone https://github.com/xXJSONDeruloXx/fgmod-bazzite.git . && chmod +x prepare.sh && ./prepare.sh
+get-framegen ACTION="prompt":
+  #!/usr/bin/bash
+  source /usr/lib/ujust/ujust.sh
+
+  OPTION={{ ACTION }}
+
+  if [ "$OPTION" == "prompt" ]; then
+    echo "What would you like to do with FGmod?"
+    OPTION=$(ugum choose "Install FGmod" "Uninstall FGmod" "Exit without changes")
+  elif [ "$OPTION" == "help" ]; then
+    echo "Usage: ujust get-framegen <option>"
+    echo "  <option>: Specify an action - 'install' or 'uninstall'"
+    echo "  Use 'install' to install FGmod."
+    echo "  Use 'uninstall' to remove FGmod."
+    exit 0
+  fi
+
+  if [ "${OPTION,,}" == "install fgmod" ]; then
+    echo "Installing FGmod..."
+    TMP_DIR=$(mktemp -d) && cd "$TMP_DIR"
+    git clone https://github.com/xXJSONDeruloXx/fgmod-bazzite.git .
+    chmod +x prepare.sh
+    ./prepare.sh
+    echo "FGmod installed successfully!"
+  elif [ "${OPTION,,}" == "uninstall fgmod" ]; then
+    echo "Uninstalling FGmod..."
+
+    # Remove ~/fgmod directory if it exists
+    if [[ -d "$HOME/fgmod" ]]; then
+      rm -rf "$HOME/fgmod"
+    fi
+
+    # Remove specific files from ~/Downloads if they exist
+    downloads_dir="$HOME/Downloads"
+    files_to_remove=("prepare.sh" "fgmod.sh" "fgmod-uninstaller.sh")
+
+    for file in "${files_to_remove[@]}"; do
+      if [[ -f "$downloads_dir/$file" ]]; then
+        rm "$downloads_dir/$file"
+      fi
+    done
+
+    echo "FGmod removed successfully!"
+  elif [ "${OPTION,,}" == "exit without changes" ]; then
+    echo "No changes made. Exiting..."
+    exit 0
+  else
+    echo "Invalid option. Exiting..."
+    exit 1
+  fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -2,155 +2,159 @@
 
 # Set up DLSS-Enabler Upscaling and Framegen mod. This mod replaces DLSS upscaling and frame generation with FSR3 equivalents in supported games.
 get-framegen ACTION="prompt":
-  #!/usr/bin/bash
-  source /usr/lib/ujust/ujust.sh
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
 
-  FG_FILES=(
-    "amd_fidelityfx_dx12.dll" "dlssg_to_fsr3_amd_is_better.dll" "libxess.dll"
-    "amd_fidelityfx_vk.dll" "dlssg_to_fsr3.ini"
-    "d3dcompiler_47.dll" "dxgi.dll" "nvapi64.dll"
-    "DisableNvidiaSignatureChecks.reg" "dxvk.conf" "_nvngx.dll"
-    "dlss-enabler.dll" "fakenvapi.ini" "nvngx.ini"
-    "dlss-enabler-upscaler.dll" "fgmod" "nvngx-wrapper.dll"
-    "dlssg_to_fsr3_amd_is_better-3.0.dll" "fgmod-uninstaller.sh" "RestoreNvidiaSignatureChecks.reg"
+    FG_FILES=(
+        "amd_fidelityfx_dx12.dll" "dlssg_to_fsr3_amd_is_better.dll" "libxess.dll"
+        "amd_fidelityfx_vk.dll" "dlssg_to_fsr3.ini"
+        "d3dcompiler_47.dll" "dxgi.dll" "nvapi64.dll"
+        "DisableNvidiaSignatureChecks.reg" "dxvk.conf" "_nvngx.dll"
+        "dlss-enabler.dll" "fakenvapi.ini" "nvngx.ini"
+        "dlss-enabler-upscaler.dll" "fgmod" "nvngx-wrapper.dll"
+        "dlssg_to_fsr3_amd_is_better-3.0.dll" "fgmod-uninstaller.sh" "RestoreNvidiaSignatureChecks.reg"
     )
 
     function check_fgmod_installed() {
-    FG_DIR="$HOME/fgmod"
-    if [[ -d "$FG_DIR" ]]; then
+        FG_DIR="$HOME/fgmod"
+        if [[ -d "$FG_DIR" ]]; then
         for file in "${FG_FILES[@]}"; do
-        # Check if each required file exists in the directory
-        if [[ ! -f "$FG_DIR/$file" ]]; then
+            # Check if each required file exists in the directory
+            if [[ "$file" == "licenses" ]]; then
+            if [[ ! -d "$FG_DIR/$file" ]]; then
+                echo "${yellow}${bold}FGmod is partially installed. 'licenses' is missing or not a directory.${normal}"
+                return
+            fi
+            elif [[ ! -f "$FG_DIR/$file" ]]; then
             echo "${yellow}${bold}FGmod is partially installed. Missing file: ${file}${normal}"
             return
-        fi
+            fi
         done
         echo "${green}${bold}FGmod is installed and ready to use.${normal}"
-    else
+        else
         echo "${red}${bold}FGmod is not installed.${normal}"
-    fi
+        fi
     }
 
-  function check_decky_installed() {
-    PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
-    if [[ -d "$PLUGIN_DIR" ]]; then
-      echo "${green}${bold}Decky Framegen plugin is installed.${normal}"
+    function check_decky_installed() {
+        PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
+        if [[ -d "$PLUGIN_DIR" ]]; then
+        echo "${green}${bold}Decky Framegen plugin is installed.${normal}"
+        else
+        echo "${red}${bold}Decky Framegen plugin is not installed.${normal}"
+        fi
+    }
+
+    OPTION={{ ACTION }}
+
+    if [ "$OPTION" == "prompt" ]; then
+        echo ""
+        echo "Current Status:"
+        check_fgmod_installed
+        echo ""
+        check_decky_installed
+        echo ""
+        echo "FGmod enables the replacement of DLSS Upscaling and Framegen with FSR3 equivalents."
+        echo "You can directly install or remove FGmod files, or install the Decky Framegen plugin for managing everything conveniently in Game Mode."
+        echo ""
+        echo "To patch a Steam game after installation, use the launch option: '~/fgmod/fgmod %COMMAND%'"
+        echo "To revert changes to the game's files, use: '~/fgmod/fgmod-uninstaller.sh %COMMAND%'"
+        echo ""
+        echo "What would you like to do with FGmod?"
+        OPTION=$(ugum choose "Install Decky Framegen plugin" "Install FGmod" "Uninstall FGmod" "Exit without changes")
+    elif [ "$OPTION" == "help" ]; then
+        echo "Usage: ujust get-framegen <option>"
+        echo "  <option>: Specify an action - 'install', 'install-decky-plugin', or 'uninstall'"
+        echo "  Use 'install' to install FGmod."
+        echo "  Use 'install-decky-plugin' to install the Decky Framegen plugin."
+        echo "  Use 'uninstall' to remove FGmod."
+        exit 0
+    fi
+
+    if [ "${OPTION,,}" == "install fgmod" ]; then
+        echo "Installing FGmod..."
+        TMP_DIR=$(mktemp -d) && cd "$TMP_DIR"
+        git clone https://github.com/xXJSONDeruloXx/fgmod-bazzite.git .
+        chmod +x prepare.sh
+        ./prepare.sh
+        echo "FGmod installed successfully!"
+        echo "To patch a game, add the launch option '~/fgmod/fgmod %COMMAND%' in its settings."
+
+    elif [ "${OPTION,,}" == "install decky framegen plugin" ]; then
+        echo "Installing Decky Framegen plugin..."
+
+        API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
+        PLUGIN_URL=$(curl -s "$API_URL" | grep "browser_download_url" | grep ".zip" | cut -d '"' -f 4)
+
+        if [ -z "$PLUGIN_URL" ]; then
+        echo "Failed to fetch the latest Decky Framegen release. Exiting..."
+        exit 1
+        fi
+
+        PLUGIN_NAME="Decky-Framegen"
+        PLUGIN_DIR="$HOME/homebrew/plugins"
+
+        if [ ! -d "$PLUGIN_DIR" ]; then
+        echo "Creating plugins directory with sudo..."
+        sudo mkdir -p "$PLUGIN_DIR"
+        fi
+
+        cd "$PLUGIN_DIR" || { echo "Failed to navigate to plugins directory"; exit 1; }
+
+        if [ -d "$PLUGIN_NAME" ]; then
+        echo "Removing existing $PLUGIN_NAME directory with sudo..."
+        sudo rm -rf "$PLUGIN_NAME"
+        fi
+
+        echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
+        sudo curl -L -o "${PLUGIN_NAME}.zip" "$PLUGIN_URL"
+
+        if [ $? -ne 0 ]; then
+        echo "Download failed!"
+        exit 1
+        fi
+
+        echo "Extracting $PLUGIN_NAME..."
+        sudo unzip -o "${PLUGIN_NAME}.zip" -d .
+
+        if [ $? -ne 0 ]; then
+        echo "Extraction failed!"
+        exit 1
+        fi
+
+        if [ -d "./${PLUGIN_NAME}/${PLUGIN_NAME}" ]; then
+        echo "Fixing folder structure..."
+        sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
+        sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
+        fi
+
+        echo "Cleaning up..."
+        sudo rm -f "${PLUGIN_NAME}.zip"
+        echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
+        echo "Please restart Decky Loader to activate the plugin."
+
+    elif [ "${OPTION,,}" == "uninstall fgmod" ]; then
+        echo "Uninstalling FGmod..."
+
+        if [[ -d "$HOME/fgmod" ]]; then
+        rm -rf "$HOME/fgmod"
+        fi
+
+        downloads_dir="$HOME/Downloads"
+        files_to_remove=("prepare.sh" "fgmod.sh" "fgmod-uninstaller.sh")
+
+        for file in "${files_to_remove[@]}"; do
+        if [[ -f "$downloads_dir/$file" ]]; then
+            rm "$downloads_dir/$file"
+        fi
+        done
+
+        echo "FGmod removed successfully!"
+
+    elif [ "${OPTION,,}" == "exit without changes" ]; then
+        echo "No changes made. Exiting..."
+        exit 0
     else
-      echo "${red}${bold}Decky Framegen plugin is not installed.${normal}"
+        echo "Invalid option. Exiting..."
+        exit 1
     fi
-  }
-
-  OPTION={{ ACTION }}
-
-  if [ "$OPTION" == "prompt" ]; then
-    echo ""
-    echo "Current Status:"
-    echo ""
-    check_fgmod_installed
-    echo ""
-    check_decky_installed
-    echo ""
-    echo "FGmod enables the replacement of DLSS Upscaling and Framegen with FSR3 equivalents."
-    echo "You can directly install or remove FGmod files, or install the Decky Framegen plugin for managing everything conveniently in Game Mode."
-    echo ""
-    echo "To patch a Steam game after installation, use the launch option: '~/fgmod/fgmod %COMMAND%'"
-    echo "To revert changes to the game's files, use: '~/fgmod/fgmod-uninstaller.sh %COMMAND%'"
-    echo ""
-    echo "What would you like to do with FGmod?"
-    OPTION=$(ugum choose "Install Decky Framegen plugin" "Install FGmod" "Uninstall FGmod" "Exit without changes")
-  elif [ "$OPTION" == "help" ]; then
-    echo "Usage: ujust get-framegen <option>"
-    echo "  <option>: Specify an action - 'install', 'install-decky-plugin', or 'uninstall'"
-    echo "  Use 'install' to install FGmod."
-    echo "  Use 'install-decky-plugin' to install the Decky Framegen plugin."
-    echo "  Use 'uninstall' to remove FGmod."
-    exit 0
-  fi
-
-  if [ "${OPTION,,}" == "install fgmod" ]; then
-    echo "Installing FGmod..."
-    TMP_DIR=$(mktemp -d) && cd "$TMP_DIR"
-    git clone https://github.com/xXJSONDeruloXx/fgmod-bazzite.git .
-    chmod +x prepare.sh
-    ./prepare.sh
-    echo "FGmod installed successfully!"
-    echo "To patch a game, add the launch option '~/fgmod/fgmod %COMMAND%' in its settings."
-
-  elif [ "${OPTION,,}" == "install decky framegen plugin" ]; then
-    echo "Installing Decky Framegen plugin..."
-
-    API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
-    PLUGIN_URL=$(curl -s "$API_URL" | grep "browser_download_url" | grep ".zip" | cut -d '"' -f 4)
-
-    if [ -z "$PLUGIN_URL" ]; then
-      echo "Failed to fetch the latest Decky Framegen release. Exiting..."
-      exit 1
-    fi
-
-    PLUGIN_NAME="Decky-Framegen"
-    PLUGIN_DIR="$HOME/homebrew/plugins"
-
-    if [ ! -d "$PLUGIN_DIR" ]; then
-      echo "Creating plugins directory with sudo..."
-      sudo mkdir -p "$PLUGIN_DIR"
-    fi
-
-    cd "$PLUGIN_DIR" || { echo "Failed to navigate to plugins directory"; exit 1; }
-
-    if [ -d "$PLUGIN_NAME" ]; then
-      echo "Removing existing $PLUGIN_NAME directory with sudo..."
-      sudo rm -rf "$PLUGIN_NAME"
-    fi
-
-    echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
-    sudo curl -L -o "${PLUGIN_NAME}.zip" "$PLUGIN_URL"
-
-    if [ $? -ne 0 ]; then
-      echo "Download failed!"
-      exit 1
-    fi
-
-    echo "Extracting $PLUGIN_NAME..."
-    sudo unzip -o "${PLUGIN_NAME}.zip" -d .
-
-    if [ $? -ne 0 ]; then
-      echo "Extraction failed!"
-      exit 1
-    fi
-
-    if [ -d "./${PLUGIN_NAME}/${PLUGIN_NAME}" ]; then
-      echo "Fixing folder structure..."
-      sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
-      sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
-    fi
-
-    echo "Cleaning up..."
-    sudo rm -f "${PLUGIN_NAME}.zip"
-    echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
-    echo "Please restart Decky Loader to activate the plugin."
-
-  elif [ "${OPTION,,}" == "uninstall fgmod" ]; then
-    echo "Uninstalling FGmod..."
-
-    if [[ -d "$HOME/fgmod" ]]; then
-      rm -rf "$HOME/fgmod"
-    fi
-
-    downloads_dir="$HOME/Downloads"
-    files_to_remove=("prepare.sh" "fgmod.sh" "fgmod-uninstaller.sh")
-
-    for file in "${files_to_remove[@]}"; do
-      if [[ -f "$downloads_dir/$file" ]]; then
-        rm "$downloads_dir/$file"
-      fi
-    done
-
-    echo "FGmod removed successfully!"
-
-  elif [ "${OPTION,,}" == "exit without changes" ]; then
-    echo "No changes made. Exiting..."
-    exit 0
-  else
-    echo "Invalid option. Exiting..."
-    exit 1
-  fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -1,13 +1,61 @@
 # vim: set ft=make :
 
-# set up DLSS-Enabler upscaling and framegen mod. Allows FSR3 upscaling and framegen via DLSS equivalents in supported games
+# Set up DLSS-Enabler Upscaling and Framegen mod. This mod replaces DLSS upscaling and frame generation with FSR3 equivalents in supported games.
 get-framegen ACTION="prompt":
   #!/usr/bin/bash
   source /usr/lib/ujust/ujust.sh
 
+  FG_FILES=(
+    "amd_fidelityfx_dx12.dll" "dlssg_to_fsr3_amd_is_better.dll" "libxess.dll"
+    "amd_fidelityfx_vk.dll" "dlssg_to_fsr3.ini"
+    "d3dcompiler_47.dll" "dxgi.dll" "nvapi64.dll"
+    "DisableNvidiaSignatureChecks.reg" "dxvk.conf" "_nvngx.dll"
+    "dlss-enabler.dll" "fakenvapi.ini" "nvngx.ini"
+    "dlss-enabler-upscaler.dll" "fgmod" "nvngx-wrapper.dll"
+    "dlssg_to_fsr3_amd_is_better-3.0.dll" "fgmod-uninstaller.sh" "RestoreNvidiaSignatureChecks.reg"
+    )
+
+    function check_fgmod_installed() {
+    FG_DIR="$HOME/fgmod"
+    if [[ -d "$FG_DIR" ]]; then
+        for file in "${FG_FILES[@]}"; do
+        # Check if each required file exists in the directory
+        if [[ ! -f "$FG_DIR/$file" ]]; then
+            echo "${yellow}${bold}FGmod is partially installed. Missing file: ${file}${normal}"
+            return
+        fi
+        done
+        echo "${green}${bold}FGmod is installed and ready to use.${normal}"
+    else
+        echo "${red}${bold}FGmod is not installed.${normal}"
+    fi
+    }
+
+  function check_decky_installed() {
+    PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
+    if [[ -d "$PLUGIN_DIR" ]]; then
+      echo "${green}${bold}Decky Framegen plugin is installed.${normal}"
+    else
+      echo "${red}${bold}Decky Framegen plugin is not installed.${normal}"
+    fi
+  }
+
   OPTION={{ ACTION }}
 
   if [ "$OPTION" == "prompt" ]; then
+    echo ""
+    echo "Current Status:"
+    echo ""
+    check_fgmod_installed
+    echo ""
+    check_decky_installed
+    echo ""
+    echo "FGmod enables the replacement of DLSS Upscaling and Framegen with FSR3 equivalents."
+    echo "You can directly install or remove FGmod files, or install the Decky Framegen plugin for managing everything conveniently in Game Mode."
+    echo ""
+    echo "To patch a Steam game after installation, use the launch option: '~/fgmod/fgmod %COMMAND%'"
+    echo "To revert changes to the game's files, use: '~/fgmod/fgmod-uninstaller.sh %COMMAND%'"
+    echo ""
     echo "What would you like to do with FGmod?"
     OPTION=$(ugum choose "Install Decky Framegen plugin" "Install FGmod" "Uninstall FGmod" "Exit without changes")
   elif [ "$OPTION" == "help" ]; then
@@ -26,12 +74,11 @@ get-framegen ACTION="prompt":
     chmod +x prepare.sh
     ./prepare.sh
     echo "FGmod installed successfully!"
-    echo "Add launch option '~/fgmod/fgmod %COMMAND%' to the game you want to patch"
+    echo "To patch a game, add the launch option '~/fgmod/fgmod %COMMAND%' in its settings."
 
   elif [ "${OPTION,,}" == "install decky framegen plugin" ]; then
     echo "Installing Decky Framegen plugin..."
 
-    # Get the latest release URL dynamically
     API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
     PLUGIN_URL=$(curl -s "$API_URL" | grep "browser_download_url" | grep ".zip" | cut -d '"' -f 4)
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -4,7 +4,6 @@
 get-framegen ACTION="prompt":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-
     FG_FILES=(
         "amd_fidelityfx_dx12.dll" "dlssg_to_fsr3_amd_is_better.dll" "libxess.dll"
         "amd_fidelityfx_vk.dll" "dlssg_to_fsr3.ini"
@@ -14,7 +13,6 @@ get-framegen ACTION="prompt":
         "dlss-enabler-upscaler.dll" "fgmod" "nvngx-wrapper.dll"
         "dlssg_to_fsr3_amd_is_better-3.0.dll" "fgmod-uninstaller.sh" "RestoreNvidiaSignatureChecks.reg"
     )
-
     function check_fgmod_installed() {
         FG_DIR="$HOME/fgmod"
         if [[ -d "$FG_DIR" ]]; then
@@ -35,7 +33,6 @@ get-framegen ACTION="prompt":
             echo "${red}${bold}FGmod is not installed.${normal}"
         fi
     }
-
     function check_decky_installed() {
         PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
         if [[ -d "$PLUGIN_DIR" ]]; then
@@ -44,9 +41,7 @@ get-framegen ACTION="prompt":
             echo "${red}${bold}Decky Framegen plugin is not installed.${normal}"
         fi
     }
-
     OPTION={{ ACTION }}
-
     if [ "$OPTION" == "prompt" ]; then
         echo ""
         echo "Current Status:"
@@ -73,7 +68,6 @@ get-framegen ACTION="prompt":
         echo "  Use 'uninstall' to remove FGmod."
         exit 0
     fi
-
     if [ "${OPTION,,}" == "install" ] || [ "${OPTION,,}" == "install fgmod" ]; then
         echo "Installing FGmod..."
         TMP_DIR=$(mktemp -d) && cd "$TMP_DIR"
@@ -82,10 +76,8 @@ get-framegen ACTION="prompt":
         ./prepare.sh
         echo "FGmod installed successfully!"
         echo "To patch a game, add the launch option '~/fgmod/fgmod %COMMAND%' in its settings."
-
     elif [ "${OPTION,,}" == "install-decky-plugin" ] || [ "${OPTION,,}" == "install decky framegen plugin" ]; then
         echo "Installing Decky Framegen plugin..."
-
         API_URL="https://api.github.com/repos/xXJSONDeruloXx/Decky-Framegen/releases/latest"
         PLUGIN_URL=$(curl -s "$API_URL" | grep "browser_download_url" | grep ".zip" | cut -d '"' -f 4)
 
@@ -93,71 +85,54 @@ get-framegen ACTION="prompt":
             echo "Failed to fetch the latest Decky Framegen release. Exiting..."
             exit 1
         fi
-
         PLUGIN_NAME="Decky-Framegen"
         PLUGIN_DIR="$HOME/homebrew/plugins"
-
         if [ ! -d "$PLUGIN_DIR" ]; then
             echo "Creating plugins directory with sudo..."
             sudo mkdir -p "$PLUGIN_DIR"
         fi
-
         cd "$PLUGIN_DIR" || { echo "Failed to navigate to plugins directory"; exit 1; }
-
         if [ -d "$PLUGIN_NAME" ]; then
             echo "Removing existing $PLUGIN_NAME directory with sudo..."
             sudo rm -rf "$PLUGIN_NAME"
         fi
-
         echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
         sudo curl -L -o "${PLUGIN_NAME}.zip" "$PLUGIN_URL"
-
         if [ $? -ne 0 ]; then
             echo "Download failed!"
             exit 1
         fi
-
         echo "Extracting $PLUGIN_NAME..."
         sudo unzip -o "${PLUGIN_NAME}.zip" -d .
-
         if [ $? -ne 0 ]; then
             echo "Extraction failed!"
             exit 1
         fi
-
         if [ -d "./${PLUGIN_NAME}/${PLUGIN_NAME}" ]; then
             echo "Fixing folder structure..."
             sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
             sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
         fi
-
         echo "Cleaning up..."
         sudo rm -f "${PLUGIN_NAME}.zip"
         echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
         echo "Please restart Decky Loader to activate the plugin."
-
     elif [ "${OPTION,,}" == "uninstall" ] || [ "${OPTION,,}" == "uninstall fgmod" ]; then
         echo "Uninstalling FGmod..."
-
         if [[ -d "$HOME/fgmod" ]]; then
             rm -rf "$HOME/fgmod"
         fi
-
         downloads_dir="$HOME/Downloads"
         files_to_remove=("prepare.sh" "fgmod.sh" "fgmod-uninstaller.sh")
-
         for file in "${files_to_remove[@]}"; do
             if [[ -f "$downloads_dir/$file" ]]; then
                 rm "$downloads_dir/$file"
             fi
         done
-
         echo "FGmod removed successfully!"
-
     elif [ "${OPTION,,}" == "exit" ] || [ "${OPTION,,}" == "exit without changes" ]; then
         echo "No changes made. Exiting..."
         exit 0
-
     else
         echo "Invalid option. Exiting..."
         exit 1

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -54,8 +54,10 @@ get-framegen ACTION="prompt":
         echo ""
         check_decky_installed
         echo ""
-        echo "FGmod enables the replacement of DLSS Upscaling and Framegen with FSR3 equivalents."
-        echo "You can directly install or remove FGmod files, or install the Decky Framegen plugin for managing everything conveniently in Game Mode."
+        echo "${bold}FGmod${normal} enables the replacement of DLSS Upscaling and Framegen with FSR3 equivalents."
+        echo ""
+        echo "Below you can install or remove ${bold}FGmod${normal} files,"
+        echo "or install the ${bold}Decky Framegen${normal} plugin for managing everything conveniently in Game Mode."
         echo ""
         echo "To patch a Steam game after installation, use the launch option: '~/fgmod/fgmod %COMMAND%'"
         echo "To revert changes to the game's files, use: '~/fgmod/fgmod-uninstaller.sh %COMMAND%'"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -9,7 +9,7 @@ get-framegen ACTION="prompt":
 
   if [ "$OPTION" == "prompt" ]; then
     echo "What would you like to do with FGmod?"
-    OPTION=$(ugum choose "Install FGmod" "Install Decky Framegen plugin" "Uninstall FGmod" "Exit without changes")
+    OPTION=$(ugum choose "Install Decky Framegen plugin" "Install FGmod" "Uninstall FGmod" "Exit without changes")
   elif [ "$OPTION" == "help" ]; then
     echo "Usage: ujust get-framegen <option>"
     echo "  <option>: Specify an action - 'install', 'install-decky-plugin', or 'uninstall'"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -1,0 +1,6 @@
+# vim: set ft=make :
+
+# set up DLSS-Enabler upscaling and framegen mod. Allows FSR3 upscaling and framegen via DLSS equivalents in supported games
+get-framegen:
+    #!/usr/bin/bash
+    TMP_DIR=$(mktemp -d) && cd "$TMP_DIR" && git clone https://github.com/xXJSONDeruloXx/fgmod-bazzite.git . && chmod +x prepare.sh && ./prepare.sh


### PR DESCRIPTION
# ujust command to automate creation of FGmod directory, which enables easy use of DLSS-Enabler in steam games. Also allows simple uninstallation of FGmod, or installation of Decky Framegen Plugin.

<img width="649" alt="image" src="https://github.com/user-attachments/assets/26d4253d-cf94-4a50-af2f-ae0f2144d50f" />


## Once installed:

- add launch option: '~/fgmod/fgmod %COMMAND%' to run fgmod script at game launch and enable FSR3 upscale and Framegen via in-game DLSS options

- add launch option: '~/fgmod/fgmod-uninstaller.sh %COMMAND%' to run uninstaller script at game launch to revert mod application, replace original game files, and pass through to execute game

- alternatively, use Decky Framegen to patch or unpatch steam games with a single click

Scripting sourced from https://github.com/xXJSONDeruloXx/fgmod-bazzite which is forked from https://github.com/FakeMichau/fgmod
