### PR TITLE
fix: restore-gnome-de-settings - indent syntax, handle empty dirs, add error checks

### DIFF
--- a/system_files/deck/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
+++ b/system_files/deck/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
@@ -3,7 +3,6 @@
 # Restore Bazzite customized DE settings
 restore-gnome-de-settings:
     #!/bin/bash
-    set -e
     shopt -s nullglob
     for file in /usr/share/ublue-os/dconfs/desktop-silverblue/*; do
       echo "Loading dconf settings from: $file"

--- a/system_files/deck/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
+++ b/system_files/deck/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
@@ -2,11 +2,16 @@
 
 # Restore Bazzite customized DE settings
 restore-gnome-de-settings:
+    #!/bin/bash
+    set -e
+    shopt -s nullglob
     for file in /usr/share/ublue-os/dconfs/desktop-silverblue/*; do
-    dconf load / < "${file}"
+      echo "Loading dconf settings from: $file"
+      dconf load / < "$file"
     done
     for file in /usr/share/ublue-os/dconfs/deck-silverblue/*; do
-    dconf load / < "${file}"
+      echo "Loading dconf settings from: $file"
+      dconf load / < "$file"
     done
 
 # Restore Bazzite customized applications folders


### PR DESCRIPTION
seems just syntax caused issues with recipe, also took the opportunity to improve error handling

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/cc42487a-9320-4dc0-b9b4-5c428ad2eb76" />
