### PR TITLE
fix: rm sudo -A causing plugin install to root

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -26,7 +26,7 @@ screens:
           description: A Decky plugin that swaps DLSS for FSR 3 Upscaling and Framegen
           default: false
           packages:
-          - Retrieve Decky Framegen: sudo -A ujust get-framegen install-decky-plugin 
+          - Retrieve Decky Framegen: ujust get-framegen install-decky-plugin 
         EmuDeck:
           description: A utility for installing and configuring emulators on the Steam Deck
           default: false


### PR DESCRIPTION
simple fix, with sudo -A this adds plugin to root/homebrew/plugins, not user home directory. ujust in terminal works just fine, just the bazzite portal that has a minor issue