### PR TITLE
feat: add udev rules to just recipe opentabletdriver

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -147,36 +147,33 @@ install-scrcpy: distrobox-check-fedora
       distrobox-export --app scrcpy'
 
 # Install OpenTabletDriver, an open source, cross-platform, user-mode tablet driver
-[group('Apps')]
 install-opentabletdriver:
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    echo "Installer for OpenTabletDriver..."
-    echo "${bold}Install or Remove OpenTabletDriver${normal}"
-    OPTION=$(Choose "Install" "Uninstall" "Exit")
-    if [[ "${OPTION,,}" =~ ^install ]]; then
-        echo "Installing OpenTabletDriver..."
-        curl -s https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest \
-        | jq -r '.assets | sort_by(.created_at) | .[] | select (.name|test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
-        | wget -qi - -O /tmp/OpenTabletDriver/opentabletdriver.tar.gz && \
-        tar --strip-components=1 -xvzf /tmp/OpenTabletDriver/opentabletdriver.tar.gz -C /tmp/OpenTabletDriver && \
-        pkexec cp /tmp/OpenTabletDriver/etc/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/71-opentabletdriver.rules && \
-        rm -rf /tmp/OpenTabletDriver && \
-        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
-        flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver && \
-        mkdir -p $HOME/.config/OpenTabletDriver && \
-        flatpak override --user --filesystem=xdg-config/OpenTabletDriver net.opentabletdriver.OpenTabletDriver && \
-        mkdir -p $HOME/.config/systemd/user && \
-        curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > $HOME/.config/systemd/user/opentabletdriver.service  && \
-        systemctl --user daemon-reload && \
-        systemctl enable --user --now opentabletdriver.service
-    elif [[ "${OPTION,,}" =~ ^uninstall ]]; then
-        echo "Uninstalling OpenTabletDriver..."
-        pkexec rm /etc/udev/rules.d/71-opentabletdriver.rules && \
-        flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver
-    else
-        echo "Have a good day :)!"
-    fi
+    echo "Installing OpenTabletDriver..."
+    curl -s https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest \
+    | jq -r '.assets | sort_by(.created_at) | .[] | select (.name|test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
+    | wget -qi - -O /tmp/OpenTabletDriver/opentabletdriver.tar.gz && \
+    tar --strip-components=1 -xvzf /tmp/OpenTabletDriver/opentabletdriver.tar.gz -C /tmp/OpenTabletDriver && \
+    sudo -A cp /tmp/OpenTabletDriver/etc/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/71-opentabletdriver.rules && \
+    rm -rf /tmp/OpenTabletDriver && \
+    flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+    flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver && \
+    mkdir -p $HOME/.config/OpenTabletDriver && \
+    flatpak override --user --filesystem=xdg-config/OpenTabletDriver net.opentabletdriver.OpenTabletDriver && \
+    mkdir -p $HOME/.config/systemd/user && \
+    curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > $HOME/.config/systemd/user/opentabletdriver.service  && \
+    systemctl --user daemon-reload && \
+    systemctl enable --user --now opentabletdriver.service
+
+# Remove OpenTabletDriver
+remove-opentabletdriver:
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    echo "Uninstalling OpenTabletDriver..."
+    sudo -A rm /etc/udev/rules.d/71-opentabletdriver.rules && \
+    flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver && \ 
+    systemctl disable --user --now opentabletdriver.service
 
 
 # Install Docker, a platform designed to help developers build, share, and run container applications

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -155,7 +155,7 @@ install-opentabletdriver:
     | jq -r '.assets | sort_by(.created_at) | .[] | select (.name|test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
     | wget -qi - -O /tmp/OpenTabletDriver/opentabletdriver.tar.gz && \
     tar --strip-components=1 -xvzf /tmp/OpenTabletDriver/opentabletdriver.tar.gz -C /tmp/OpenTabletDriver && \
-    sudo -A cp /tmp/OpenTabletDriver/etc/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/71-opentabletdriver.rules && \
+    sudo cp /tmp/OpenTabletDriver/etc/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/71-opentabletdriver.rules && \
     rm -rf /tmp/OpenTabletDriver && \
     flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
     flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver && \

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -147,19 +147,37 @@ install-scrcpy: distrobox-check-fedora
       distrobox-export --app scrcpy'
 
 # Install OpenTabletDriver, an open source, cross-platform, user-mode tablet driver
+[group('Apps')]
 install-opentabletdriver:
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    echo "Installing OpenTabletDriver..."
-    flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
-    flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver && \
-    mkdir -p $HOME/.config/OpenTabletDriver && \
-    flatpak override --user --filesystem=xdg-config/OpenTabletDriver net.opentabletdriver.OpenTabletDriver && \
-    mkdir -p $HOME/.config/systemd/user && \
-    curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > $HOME/.config/systemd/user/opentabletdriver.service  && \
-    systemctl --user daemon-reload && \
-    systemctl enable --user --now arch-opentabletdriver.service && \
-    distrobox enter -n arch -- bash -c 'distrobox-export --app otd-gui'
+    echo "Installer for OpenTabletDriver..."
+    echo "${bold}Install or Remove OpenTabletDriver${normal}"
+    OPTION=$(Choose "Install" "Uninstall" "Exit")
+    if [[ "${OPTION,,}" =~ ^install ]]; then
+        echo "Installing OpenTabletDriver..."
+        curl -s https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest \
+        | jq -r '.assets | sort_by(.created_at) | .[] | select (.name|test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
+        | wget -qi - -O /tmp/OpenTabletDriver/opentabletdriver.tar.gz && \
+        tar --strip-components=1 -xvzf /tmp/OpenTabletDriver/opentabletdriver.tar.gz -C /tmp/OpenTabletDriver && \
+        pkexec cp /tmp/OpenTabletDriver/etc/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/71-opentabletdriver.rules && \
+        rm -rf /tmp/OpenTabletDriver && \
+        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+        flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver && \
+        mkdir -p $HOME/.config/OpenTabletDriver && \
+        flatpak override --user --filesystem=xdg-config/OpenTabletDriver net.opentabletdriver.OpenTabletDriver && \
+        mkdir -p $HOME/.config/systemd/user && \
+        curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > $HOME/.config/systemd/user/opentabletdriver.service  && \
+        systemctl --user daemon-reload && \
+        systemctl enable --user --now opentabletdriver.service
+    elif [[ "${OPTION,,}" =~ ^uninstall ]]; then
+        echo "Uninstalling OpenTabletDriver..."
+        pkexec rm /etc/udev/rules.d/71-opentabletdriver.rules && \
+        flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver
+    else
+        echo "Have a good day :)!"
+    fi
+
 
 # Install Docker, a platform designed to help developers build, share, and run container applications
 install-docker:


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

udev rules is gone from image so this pr will add udev rules for opentabletdriver