### PR TITLE
fix: block LVFS on the Legion Go S for now

### DIFF
--- a/system_files/deck/shared/fwupd/fwupd.conf
+++ b/system_files/deck/shared/fwupd/fwupd.conf
@@ -1,0 +1,5 @@
+[fwupd]
+# use `man 5 fwupd.conf` for documentation
+
+# Legion Go S controller (1,2) + BIOS (3)
+DisabledDevices=fa6f0df5-01fe-56ff-9ba1-04456503e674;65619675-fec6-5035-801d-7f5e59fd9749;36a4e61a-b574-4c07-b1e1-761f40d358ce


### PR DESCRIPTION
Let's give the updater some time to mature. Users can update from Windows/manually for now.