### PR TITLE
fix(just): add correct path for libvirt hooks

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -66,8 +66,8 @@ setup-virtualization ACTION="":
             sudo wget 'https://raw.githubusercontent.com/PassthroughPOST/VFIO-Tools/master/libvirt_hooks/qemu' -O /etc/libvirt/hooks/qemu
             sudo chmod +x /etc/libvirt/hooks/qemu
             sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
-            if sudo test ! -d "/etc/libvirt/hooks/qemu/qemu.d"; then
-              sudo mkdir /etc/libvirt/hooks/qemu/qemu.d
+            if sudo test ! -d "/etc/libvirt/hooks/qemu.d"; then
+              sudo mkdir /etc/libvirt/hooks/qemu.d
             fi
           fi
           sudo systemctl enable bazzite-libvirtd-setup.service \


### PR DESCRIPTION
for some reason it was "autocorrected" to `/etc/libvirt/hooks/qemu/qemu.d` when it is supposed to be `/etc/libvirt/hooks/qemu.d`

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
