### PR TITLE
fix: Fix incorrect completions path

### DIFF
--- a/system_files/overrides/usr/share/fish/vendor_conf.d/brew.fish
+++ b/system_files/overrides/usr/share/fish/vendor_conf.d/brew.fish
@@ -4,7 +4,7 @@ if status --is-interactive
     if [ -d /home/linuxbrew/.linuxbrew ]
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         if [ -w /home/linuxbrew/.linuxbrew ]
-            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew ]
+            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew.fish ]
                 brew completions link > /dev/null
             end
         end


### PR DESCRIPTION
Modified `/usr/share/fish/vendor_conf.d/brew.fish` line 7 from `.../brew` to `.../brew.fish`. This prevents `brew completions link` from running unnecessarily and significantly affecting fish startup times.

Resolves https://github.com/ublue-os/bazzite/issues/2228

See https://github.com/ublue-os/bazzite/issues/2228#issuecomment-2646194992 for more info.