### PR TITLE
fix: only run bazzite-user-setup for human users

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/user/bazzite-user-setup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/user/bazzite-user-setup.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Configure Bazzite for current user
+ConditionUser=!@system
 
 [Service]
 Type=simple


### PR DESCRIPTION
Porting https://github.com/ublue-os/aurora/pull/206, which I believe affects Bazzite as well. I think this is the only `systemd --user` service but I'm not entirely sure.