### PR TITLE
 fix(deck): move hid preload from ds-inhibit to sysfiles and add hid-nintendo

### DIFF
--- a/spec_files/ds-inhibit/10-modprobe-ds.conf
+++ b/spec_files/ds-inhibit/10-modprobe-ds.conf
@@ -1,2 +1,0 @@
-# autoload hid-playstation so ds-inhibit works correctly
-hid-playstation

--- a/spec_files/ds-inhibit/ds-inhibit.spec
+++ b/spec_files/ds-inhibit/ds-inhibit.spec
@@ -53,7 +53,6 @@ cp -v systemd.service %{buildroot}%{_unitdir}/ds-inhibit.service
 %license LICENSE
 %{_bindir}/ds-inhibit
 %{_unitdir}/ds-inhibit.service
-%{_sysconfdir}/modules-load.d/10-modprobe-ds.conf
 
 # Finally, changes from the latest release of your application are generated from
 # your project's Git history. It will be empty until you make first annotated Git tag.

--- a/spec_files/ds-inhibit/ds-inhibit.spec
+++ b/spec_files/ds-inhibit/ds-inhibit.spec
@@ -1,12 +1,11 @@
 Name:           ds-inhibit
 Version:        {{{ git_dir_version }}}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        DualShock 4/DualSense mouse inhibitor
 License:        BSD-2-Clause
 URL:            https://github.com/ublue-os/bazzite
 
 Source0:         https://gitlab.com/evlaV/%{name}/-/archive/main/%{name}-main.tar.gz
-Source1:        10-modprobe-ds.conf
 BuildArch:      noarch
 
 Patch0:         fedora.patch
@@ -35,7 +34,6 @@ mkdir -p %{buildroot}%{_unitdir}/
 mkdir -p %{buildroot}%{_sysconfdir}/modules-load.d
 cp -v ds_inhibit.py %{buildroot}%{_bindir}/ds-inhibit
 cp -v systemd.service %{buildroot}%{_unitdir}/ds-inhibit.service
-cp %{SOURCE1} %{buildroot}%{_sysconfdir}/modules-load.d
 
 # Do post-installation
 %post

--- a/system_files/deck/shared/etc/modules-load.d/hid-steaminput-preload.conf
+++ b/system_files/deck/shared/etc/modules-load.d/hid-steaminput-preload.conf
@@ -1,0 +1,3 @@
+# Preload some HID drivers to work around racy Steam Input behavior
+hid_nintendo
+hid_playstation


### PR DESCRIPTION
this matches SteamOS and will work around racy behavior with Nintendo Switch controllers
