### PR TITLE
fix: Correctly detect if WOL is enabled and correctly create force-wol service file when create-service is choosen

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -101,7 +101,7 @@ toggle-wol:
     fi
     CONFIG_FILE="/etc/udev/rules.d/81-wol.rules"
     SERVICE_FILE="/etc/systemd/system/force-wol.service"
-    WOL_STATUS=$(sudo ethtool $INTERFACE | grep "Wake-on" | awk '{print $2}')
+    WOL_STATUS=$(sudo ethtool $INTERFACE | grep -P "^\s+Wake-on" | awk '{print $2}')
     CURRENT_STATE="Disabled"
     if [[ "$WOL_STATUS" == "g" ]]; then
       CURRENT_STATE="Enabled"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -91,6 +91,7 @@ toggle-bt-mic:
 # enable or disable wake-on-lan functionality
 toggle-wol:
     #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
     INTERFACE=$(ip link show | awk '/state UP/ {print $2}' | tr -d ':' | grep -E '^(en|eth)')
     if [[ -z "$INTERFACE" ]]; then
       echo -e "${bold}No active Ethernet interface found.${normal}"
@@ -127,10 +128,10 @@ toggle-wol:
         sudo rm -f "$CONFIG_FILE"
       fi
       echo "Wake-on-LAN has been ${red}${bold}disabled${normal}."
-    elif [[ "${OPTION,,}" == "Create-Service" ]]; then
+    elif [[ "${OPTION,,}" == "create-service" ]]; then
       echo "You chose to create a systemd service for enabling WOL at boot."
       echo "Requesting root privileges..."
-      sudo bash -c "cat > $SERVICE_FILE" <<EOF
+      sudo bash -c "cat > $SERVICE_FILE <<EOF
     [Unit]
     Description=Force Enable Wake-on-LAN
     After=network-online.target
@@ -139,9 +140,9 @@ toggle-wol:
     ExecStart=/sbin/ethtool -s $INTERFACE wol g
     [Install]
     WantedBy=network-online.target
-    EOF
+    EOF"
       sudo systemctl daemon-reload
-      sudo systemctl enable force-wol.service
+      sudo systemctl enable --now force-wol.service
       echo "Systemd service created and enabled at boot: ${green}${bold}force-wol.service${normal}"
     else
       echo "No changes were made."


### PR DESCRIPTION
noticed there were some minor issues in this ujust as my new motherboard had one of the network cards where the WOL bit gets reset randomly at boot, meaning i needed to force enable this with a service file which then did not match the if condition in the script.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
