### PR TITLE
fix: remove --no-lock from ujust bazzite-cli brew command

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -333,7 +333,7 @@ bazzite-cli:
     # Brew Bundle Install
     function brew-bundle(){
     echo 'Installing bling from Homebrew 🍻🍻🍻'
-    brew bundle --file /usr/share/ublue-os/homebrew/bazzite-cli.Brewfile --no-lock
+    brew bundle --file /usr/share/ublue-os/homebrew/bazzite-cli.Brewfile
     }
 
     # Check if bling is already sourced


### PR DESCRIPTION
`--no-lock` was recently removed from brew-bundle and is no longer valid.

See [Homebrew/homebrew-bundle@98d8ad7#diff-2ba13d1d1d9b7abcde49568b7aec20c97f4541f44f6befd62ac6a4d820ddb7ccL96-L98](https://github.com/Homebrew/homebrew-bundle/commit/98d8ad7ddcca7e7b700cd496207d51fa042c0b00#diff-2ba13d1d1d9b7abcde49568b7aec20c97f4541f44f6befd62ac6a4d820ddb7ccL96-L98)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
