### PR TITLE
fix: Fetch nct6687 RPM from akmods-extra repository

### DIFF
--- a/build_files/install-kernel-akmods
+++ b/build_files/install-kernel-akmods
@@ -16,7 +16,6 @@ dnf5 -y install \
 
 dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 
-shopt -s nullglob
 dnf5 -y install \
     /tmp/akmods-rpms/kmods/*kvmfr*.rpm \
     /tmp/akmods-rpms/kmods/*xone*.rpm \

--- a/build_files/install-kernel-akmods
+++ b/build_files/install-kernel-akmods
@@ -23,8 +23,8 @@ dnf5 -y install \
     /tmp/akmods-rpms/kmods/*openrazer*.rpm \
     /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
     /tmp/akmods-rpms/kmods/*wl*.rpm \
-    /tmp/akmods-rpms/kmods/*nct6687*.rpm \
     /tmp/akmods-rpms/kmods/*framework-laptop*.rpm \
+    /tmp/akmods-extra-rpms/kmods/*nct6687*.rpm \
     /tmp/akmods-extra-rpms/kmods/*gcadapter_oc*.rpm \
     /tmp/akmods-extra-rpms/kmods/*zenergy*.rpm \
     /tmp/akmods-extra-rpms/kmods/*vhba*.rpm \


### PR DESCRIPTION
Change the installation source for the nct6687 RPM to the akmods-extra repository to ensure proper fetching of the package.

This fixes #2318