### PR TITLE
fix: correctly quote KVMFR_MODPROBE heredoc and remove virtqemud_t from type enforcement

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -250,9 +250,6 @@ setup-virtualization ACTION="":
 
     #============= svirt_t ==============
     allow svirt_t device_t:chr_file { open read write map };
-
-    #============= virtqemud_t ==============
-    allow virtqemud_t device_t:chr_file { read write };
     KVMFR_SELINUX"
       echo "This is the type enforcement we wrote for SELinux and you can find it in $HOME/.config/selinux_te/kvmfr.te"
       echo "#======= start of kvmfr.te ======="

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -194,13 +194,13 @@ setup-virtualization ACTION="":
         echo "Re-creating dummy kvmfr modprobe file"
         sudo rm /etc/modprobe.d/kvmfr.conf
       fi
-      sudo bash -c "cat << KVMFR_MODPROBE > /etc/modprobe.d/kvmfr.conf
+      sudo bash -c 'cat << KVMFR_MODPROBE > /etc/modprobe.d/kvmfr.conf
     # This is a dummy file and changing it does nothing
     # If you want to change the kvmfr static_size_mb
     # Run "rpm-ostree kargs --replace=kvmfr.static_size_mb=oldvalue=newvalue"
     # Default value set by us is 128 which is enough for 4k SDR
     # Find the current value by running "rpm-ostree kargs"
-    KVMFR_MODPROBE"
+    KVMFR_MODPROBE'
       rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128"
       if [ -f "/etc/udev/rules.d/99-kvmfr.rules" ]; then
         echo "Re-creating kvmfr udev rules"


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
