### PR TITLE
feat: Replace old media-automount-generator package working one

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -514,16 +514,13 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     curl -Lo /usr/share/bash-prexec https://raw.githubusercontent.com/ublue-os/bash-preexec/master/bash-preexec.sh &&\
     /ctx/cleanup
 
-# media-automount-generator, mount non-removable device partitions automatically under /media/media-automount/
+# ublue-os-media-automount-udev, mount non-removable device partitions automatically under /media/media-automount/
 RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=cache,dst=/var/cache/rpm-ostree \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
-    cd $(mktemp -d) && \
-    curl -fsSLo - https://github.com/Zeglius/media-automount-generator/archive/refs/tags/v0.2.6.tar.gz | \
-        tar -xz --strip-components=1 && \
-    ./install.sh && \
-    cd / && \
+    dnf5 install -y --enable-repo=copr:copr.fedorainfracloud.org:ublue-os:packages \
+        install ublue-os-media-automount-udev && \
     /ctx/cleanup
 
 # Cleanup & Finalize


### PR DESCRIPTION
Behavior is slightly different, now it will only mount labeled partitions. Mountpoint name no longer will be named after partition UUID, instead by the partition label.