### PR TITLE
fix: downgrade dnf5 to avoid regression exposed by Terra

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -175,6 +175,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     /ctx/install-firmware && \
     /ctx/cleanup
 
+
 # Install patched fwupd
 # Install Valve's patched Mesa, Pipewire, Bluez, and Xwayland
 # Install patched switcheroo control with proper discrete GPU support
@@ -188,6 +189,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
         ["terra-mesa"]="mesa-filesystem" \
         ["copr:copr.fedorainfracloud.org:ublue-os:staging"]="fwupd" \
     ) && \
+    dnf5 -y downgrade dnf5 && \
     for repo in "${!toswap[@]}"; do \
         for package in ${toswap[$repo]}; do dnf5 -y swap --repo=$repo $package $package; done; \
     done && unset -v toswap repo package && \

--- a/Containerfile
+++ b/Containerfile
@@ -78,6 +78,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
     dnf5 -y install dnf5-plugins && \
+    dnf5 -y downgrade dnf5 && \
     for copr in \
         bazzite-org/bazzite \
         bazzite-org/bazzite-multilib \
@@ -189,7 +190,6 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
         ["terra-mesa"]="mesa-filesystem" \
         ["copr:copr.fedorainfracloud.org:ublue-os:staging"]="fwupd" \
     ) && \
-    dnf5 -y downgrade dnf5 && \
     for repo in "${!toswap[@]}"; do \
         for package in ${toswap[$repo]}; do dnf5 -y swap --repo=$repo $package $package; done; \
     done && unset -v toswap repo package && \


### PR DESCRIPTION
Builds are failing right now because the latest dnf5 package version 5.2.11.0 has a regression that the Terra repos are exposing.

Related:
- https://github.com/ublue-os/aurora/pull/274
- https://github.com/rpm-software-management/dnf5/issues/2134
- https://github.com/ublue-os/aurora/issues/275