### PR TITLE
fix: kf6-kio package version mismatch due to renaming in Terra

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -418,8 +418,8 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
             kcm-fcitx5 \
             ptyxis && \
         dnf5 -y swap \
-        --repo terra-extras \
-            kf6-kio-core kf6-kio-core && \
+        --repo=terra-extras \
+            kf6-kio kf6-kio.switcheroo-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}') \
         dnf5 versionlock add \
             kf6-kio-core \
             kf6-kio-core-libs \

--- a/Containerfile
+++ b/Containerfile
@@ -419,7 +419,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
             ptyxis && \
         dnf5 -y swap \
         --repo=terra-extras \
-            kf6-kio kf6-kio.switcheroo-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}') \
+            kf6-kio kf6-kio.switcheroo-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}') && \
         dnf5 versionlock add \
             kf6-kio-core \
             kf6-kio-core-libs \


### PR DESCRIPTION
This package was renamed to add the switcheroo component to its name. This resulted in the old version 6.11 being picked up and downgrading from 6.12.

See latest Bazzite build logs:
```
2025-03-17T05:02:51.7115710Z Package "kf6-kio-core-6.12.0-1.fc41.x86_64" is already installed.
2025-03-17T05:02:51.7116496Z Problem: cannot install the best candidate for the job
2025-03-17T05:02:51.7117060Z   - conflicting requests
2025-03-17T05:02:51.7117326Z 
2025-03-17T05:02:51.7120311Z Total size of inbound packages is 4 MiB. Need to download 4 MiB.
2025-03-17T05:02:51.7121309Z Package                           Arch   Version                  Repository        Size
2025-03-17T05:02:51.7122138Z After this operation, 38 KiB will be freed (install 18 MiB, remove 18 MiB).
2025-03-17T05:02:51.7122819Z Downgrading:
2025-03-17T05:02:51.7123370Z  kf6-kio-core                     x86_64 6.11.0-2.fc41.switcheroo terra-extras   2.2 MiB
2025-03-17T05:02:51.7124182Z    replacing kf6-kio-core         x86_64 6.12.0-1.fc41            <unknown>      2.2 MiB
2025-03-17T05:02:51.7125027Z  kf6-kio-core-libs                x86_64 6.11.0-2.fc41.switcheroo terra-extras   1.6 MiB
2025-03-17T05:02:51.7125889Z    replacing kf6-kio-core-libs    x86_64 6.12.0-1.fc41            <unknown>      1.6 MiB
2025-03-17T05:02:51.7127063Z  kf6-kio-doc                      noarch 6.11.0-2.fc41.switcheroo terra-extras  11.0 MiB
2025-03-17T05:02:51.7127895Z    replacing kf6-kio-doc          noarch 6.12.0-1.fc41            <unknown>     11.1 MiB
2025-03-17T05:02:51.7128516Z  kf6-kio-file-widgets             x86_64 6.11.0-2.fc41.switcheroo terra-extras   1.2 MiB
2025-03-17T05:02:51.7129092Z    replacing kf6-kio-file-widgets x86_64 6.12.0-1.fc41            <unknown>      1.2 MiB
2025-03-17T05:02:51.7129595Z  kf6-kio-gui                      x86_64 6.11.0-2.fc41.switcheroo terra-extras 487.0 KiB
2025-03-17T05:02:51.7130051Z    replacing kf6-kio-gui          x86_64 6.12.0-1.fc41            <unknown>    487.0 KiB
2025-03-17T05:02:51.7130522Z  kf6-kio-widgets                  x86_64 6.11.0-2.fc41.switcheroo terra-extras 251.2 KiB
2025-03-17T05:02:51.7130999Z    replacing kf6-kio-widgets      x86_64 6.12.0-1.fc41            <unknown>    251.1 KiB
2025-03-17T05:02:51.7131751Z  kf6-kio-widgets-libs             x86_64 6.11.0-2.fc41.switcheroo terra-extras   1.2 MiB
2025-03-17T05:02:51.7132263Z    replacing kf6-kio-widgets-libs x86_64 6.12.0-1.fc41            <unknown>      1.2 MiB
```

Related:
- https://github.com/ublue-os/aurora/pull/281
- https://github.com/terrapkg/packages/issues/3967