### PR TITLE
feat: Add ckb-next

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -302,6 +302,7 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
         cockpit-navigator \
         cockpit-storaged \
         topgrade \
+        ckb-next \
         ydotool \
         yafti \
         stress-ng \


### PR DESCRIPTION
ckb-next is an open-source driver for Corsair keyboards and mice.

Without including this in the base image usage of an rpm-ostree overlay would be required, as installing it via rootful systemd-enabled distrobox is not very straightforward or practical.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
