### PR TITLE
fix: discover desktop entry exclusive flatpak backend enablement

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -438,6 +438,7 @@ RUN --mount=type=cache,dst=/var/cache \
         sed -i '/^Comment/d' /usr/share/applications/org.gnome.Ptyxis.desktop && \
         sed -i 's@Exec=ptyxis@Exec=kde-ptyxis@g' /usr/share/applications/org.gnome.Ptyxis.desktop && \
         sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop && \
+        sed -i 's/^Exec=plasma-discover/& --backends flatpak-backend/' /usr/share/applications/org.kde.discover.desktop && \
         cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop && \
         setcap 'cap_net_raw+ep' /usr/libexec/ksysguard/ksgrd_network_helper \
     ; else \


### PR DESCRIPTION
the arguments gets essentially prepended now

see: 832cf110f6edc6da3b2c720c76e89656a47455bd

the final line looks like this then:
`Exec=plasma-discover --backends flatpak-backend --mode update`
