### PR TITLE
chore(just): Remove CoolerControl Copr import

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -16,7 +16,6 @@ install-lact:
 install-coolercontrol:
     #!/usr/bin/bash
     ublue-update --wait
-    sudo wget https://copr.fedorainfracloud.org/coprs/codifryed/CoolerControl/repo/fedora-$(rpm -E %fedora)/codifryed-CoolerControl-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_codifryed-CoolerControl.repo
     rpm-ostree install -y liquidctl coolercontrol
     echo 'Complete, please reboot to apply changes.'
 


### PR DESCRIPTION
CoolerControl is packaged in Terra, which is now included by default in all images; as that was already taking priority in release revisions anyway due to a higher number, it's probably better to remove this.
