### PR TITLE
fix: enable get-decky-bazzite-buddy ujust to fetch latest, handle conflicting plugin names, clean old installs

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -80,10 +80,18 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   if ! /usr/libexec/hwsupport/valve-hardware; then
       export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
   fi
-
-elif [ -f $HOME/.local/share/Steam/ubuntu12_32/steamui.so ]; then
-  :
 fi
+
+switcheroo_state="$(switcherooctl list)"
+DGPU_OPTION=""
+# If we're running this on a dGPU in a multi-gpu AMD/Intel system, apply a workaround for the blank Steam window bug
+if [[ $(echo "${switcheroo_state}" | grep -o 'Device:' | wc -l) -gt 1 ]]; then
+  # TODO: Check if -system-composer is needed with nvidia >=555 driver
+  if ! grep -Pq 'Name:\s+NVIDIA' <<< "$switcheroo_state"; then
+    DGPU_OPTION="-system-composer"
+  fi
+fi
+unset -v switcheroo_state
 
 if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
   # https://github.com/Supreeeme/extest
@@ -94,5 +102,5 @@ if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
   # Also supports Steam Input as a whole.
   env LD_PRELOAD=/usr/lib/extest/libextest.so /usr/bin/steam "$DECK_OPTION" "$DGPU_OPTION" "$@"
 else
-  /usr/bin/steam "$DECK_OPTION" "$@"
+  /usr/bin/steam "$DECK_OPTION" "$DGPU_OPTION" "$@"
 fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -506,9 +506,24 @@ toggle-password-feedback ACTION="":
 # Install Bazzite Buddy plugin to easily access changelogs in game mode!
 get-decky-bazzite-buddy:
     #!/bin/bash
-    PLUGIN_URL="https://github.com/xXJSONDeruloXx/bazzite-buddy/releases/download/stable/bazzite-buddy.zip"
+    REPO_OWNER="xXJSONDeruloXx"
+    REPO_NAME="bazzite-buddy"
     PLUGIN_NAME="bazzite-buddy"
     PLUGIN_DIR="$HOME/homebrew/plugins"
+    # Get the latest release information
+    echo "Fetching latest release information..."
+    RELEASE_INFO=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest")
+    # Extract the download URL for the zip file
+    DOWNLOAD_URLS=$(echo "$RELEASE_INFO" | grep -o '"browser_download_url": "[^"]*\.zip"' | cut -d'"' -f4)
+    # Check if any zip files were found
+    if [ -z "$DOWNLOAD_URLS" ]; then
+      echo "No zip files found in the latest release. Falling back to stable URL..."
+      PLUGIN_URL="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/stable/bazzite-buddy.zip"
+    else
+      # Pick the first zip file (usually there's only one)
+      PLUGIN_URL=$(echo "$DOWNLOAD_URLS" | head -n 1)
+      echo "Found latest release: $PLUGIN_URL"
+    fi
     if [ ! -d "$PLUGIN_DIR" ]; then
       echo "Creating plugins directory with sudo..."
       sudo mkdir -p "$PLUGIN_DIR"
@@ -521,31 +536,51 @@ get-decky-bazzite-buddy:
       sudo rm -rf "$PLUGIN_NAME"
     fi
     # Download the zip file
-    echo "Downloading $PLUGIN_NAME from $PLUGIN_URL..."
-    sudo curl -L -o "${PLUGIN_NAME}.zip" "$PLUGIN_URL"
+    echo "Downloading plugin from $PLUGIN_URL..."
+    TEMP_ZIP="temp_plugin.zip"
+    sudo curl -L -o "$TEMP_ZIP" "$PLUGIN_URL"
     if [ $? -ne 0 ]; then
       echo "Download failed!"
       exit 1
     fi
-    echo "Extracting $PLUGIN_NAME..."
-    sudo unzip -o "${PLUGIN_NAME}.zip" -d .
+    echo "Extracting plugin..."
+    sudo unzip -o "$TEMP_ZIP" -d .
     if [ $? -ne 0 ]; then
       echo "Extraction failed!"
       exit 1
     fi
-    # Move the extracted files to the correct location if nested
+    # Handle different extracted folder names
+    # Look for any extracted folders that might contain the plugin
+    EXTRACTED_FOLDERS=$(find . -maxdepth 1 -type d -name "bazzite*" -o -name "Bazzite*" | grep -v "^\./$")
+    # If we found a folder but it's not the expected name
+    if [ -n "$EXTRACTED_FOLDERS" ] && [ ! -d "./$PLUGIN_NAME" ]; then
+      FOUND_FOLDER=$(echo "$EXTRACTED_FOLDERS" | head -n 1)
+      echo "Found plugin folder with different name: $FOUND_FOLDER"
+      echo "Renaming to $PLUGIN_NAME..."
+      sudo mv "$FOUND_FOLDER" "./$PLUGIN_NAME"
+    fi
+    # Handle nested folders structure if needed
     if [ -d "./${PLUGIN_NAME}/${PLUGIN_NAME}" ]; then
-      echo "Fixing folder structure..."
+      echo "Fixing nested folder structure..."
       sudo mv ./${PLUGIN_NAME}/${PLUGIN_NAME}/* ./${PLUGIN_NAME}/
       sudo rm -rf ./${PLUGIN_NAME}/${PLUGIN_NAME}
     fi
+    # Check if we have a plugin with capital letters
+    if [ ! -d "./$PLUGIN_NAME" ] && [ -d "./Bazzite.Buddy" ]; then
+      echo "Found Bazzite.Buddy folder, renaming to $PLUGIN_NAME..."
+      sudo mv "./Bazzite.Buddy" "./$PLUGIN_NAME"
+    fi
     # Clean up the downloaded ZIP file
     echo "Cleaning up..."
-    sudo rm -f "${PLUGIN_NAME}.zip"
+    sudo rm -f "$TEMP_ZIP"
     # Confirm installation
-    echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
-    # Prompt user to restart Decky Loader
-    echo "Please restart Decky Loader to activate the plugin."
+    if [ -d "./$PLUGIN_NAME" ]; then
+      echo "$PLUGIN_NAME has been installed successfully to $PLUGIN_DIR!"
+      echo "Please restart Decky Loader to activate the plugin."
+    else
+      echo "Installation may have failed. Please check if the plugin is installed correctly."
+      echo "Plugin folder could not be found as expected."
+    fi
 
 # get logs for this boot and last boot, cleanly output in terminal as pastebin links, to simplify troubleshooting and issue reporting.
 get-logs:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -16,7 +16,6 @@ install-lact:
 install-coolercontrol:
     #!/usr/bin/bash
     ublue-update --wait
-    sudo wget https://copr.fedorainfracloud.org/coprs/codifryed/CoolerControl/repo/fedora-$(rpm -E %fedora)/codifryed-CoolerControl-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_codifryed-CoolerControl.repo
     rpm-ostree install -y liquidctl coolercontrol
     echo 'Complete, please reboot to apply changes.'
 


### PR DESCRIPTION
So we can get the new new

<img width="713" alt="image" src="https://github.com/user-attachments/assets/4befec37-6a9f-422e-85c1-7e1260f0cfe9" />

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
