### PR TITLE
feat: add ujust toggle-steamdeck-alias to prevent games from force downloading low quality assets

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -75,7 +75,6 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
 
   # File toggle to override default Steam Deck flag behavior
   DECK_OVERRIDE_FLAG="$HOME/.config/bazzite/disable_steamdeck_flag"
-  mkdir -p "$(dirname "$DECK_OVERRIDE_FLAG")"
 
   # Required to maintain the Steam update branch between desktop & Steam Game Mode
   if [[ ! -f "$DECK_OVERRIDE_FLAG" ]]; then

--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -10,8 +10,8 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   if [ ! -d $HOME/.local/share/Steam ]; then
     # Set up steam with the bootstrap before starting it, this allows steam to run for the first time even with no network access
     if [[ -f "/usr/share/gamescope-session-plus/bootstrap_steam.tar.gz" ]]; then
-        mkdir -p ~/.local/share
-        tar xf /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz -C ~/.local/share
+      mkdir -p ~/.local/share
+      tar xf /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz -C ~/.local/share
     fi
   fi
 
@@ -73,12 +73,20 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
 
   fi
 
+  # File toggle to override default Steam Deck flag behavior
+  DECK_OVERRIDE_FLAG="$HOME/.config/bazzite/disable_steamdeck_flag"
+  mkdir -p "$(dirname "$DECK_OVERRIDE_FLAG")"
+
   # Required to maintain the Steam update branch between desktop & Steam Game Mode
-  DECK_OPTION="-steamdeck"
+  if [[ ! -f "$DECK_OVERRIDE_FLAG" ]]; then
+    DECK_OPTION="-steamdeck"
+  else
+    DECK_OPTION=""
+  fi
 
   # HHD Support
   if ! /usr/libexec/hwsupport/valve-hardware; then
-      export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
+    export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
   fi
 fi
 

--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -10,8 +10,8 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   if [ ! -d $HOME/.local/share/Steam ]; then
     # Set up steam with the bootstrap before starting it, this allows steam to run for the first time even with no network access
     if [[ -f "/usr/share/gamescope-session-plus/bootstrap_steam.tar.gz" ]]; then
-      mkdir -p ~/.local/share
-      tar xf /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz -C ~/.local/share
+        mkdir -p ~/.local/share
+        tar xf /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz -C ~/.local/share
     fi
   fi
 
@@ -86,7 +86,7 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
 
   # HHD Support
   if ! /usr/libexec/hwsupport/valve-hardware; then
-    export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
+      export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
   fi
 fi
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -596,7 +596,7 @@ get-decky-bazzite-buddy:
     fi
 
 # Toggle whether Steam launches with the -steamdeck flag, which causes Big Picture / Game Mode to emulate Steam Deck behavior. Disabling this can prevent games from forcing Steam Deck-specific assets, such as lower-resolution textures.
-toggle-steamdeck-mode:
+toggle-steamdeck-alias:
     #!/usr/bin/bash
     # Toggles whether Steam presents the system as a Steam Deck via -steamdeck
     override_flag="$HOME/.config/bazzite/disable_steamdeck_flag"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -595,6 +595,39 @@ get-decky-bazzite-buddy:
       echo "Plugin folder could not be found as expected."
     fi
 
+# Toggle whether Steam launches with the -steamdeck flag, which causes Big Picture / Game Mode to emulate Steam Deck behavior. Disabling this can prevent games from forcing Steam Deck-specific assets, such as lower-resolution textures.
+toggle-steamdeck-mode:
+    #!/usr/bin/bash
+    # Toggles whether Steam presents the system as a Steam Deck via -steamdeck
+    override_flag="$HOME/.config/bazzite/disable_steamdeck_flag"
+    mkdir -p "$(dirname "$override_flag")"
+    current_status="Enabled"
+    if [[ -f "$override_flag" ]]; then
+      current_status="Disabled"
+    fi
+    echo -e "\nCurrent Steam Deck presentation mode: $current_status\n"
+    CHOICE=$(ugum choose "Present as Steam Deck (Enable -steamdeck)" "Do Not Present as Steam Deck (Disable -steamdeck)" "Exit without changes")
+    case "$CHOICE" in
+      "Present as Steam Deck (Enable -steamdeck)")
+        if [[ -f "$override_flag" ]]; then
+          rm -f "$override_flag"
+          echo -e "\nSteam Deck presentation ENABLED. (-steamdeck will be passed to Steam)\n"
+        else
+          echo -e "\nAlready enabled.\n"
+        fi
+        ;;
+      "Do Not Present as Steam Deck (Disable -steamdeck)")
+        touch "$override_flag"
+        echo -e "\nSteam Deck presentation DISABLED. (-steamdeck will NOT be passed to Steam)\n"
+        ;;
+      "Exit without changes")
+        echo "No changes made."
+        ;;
+      *)
+        echo "Invalid choice. Exiting."
+        ;;
+    esac
+
 # get logs for this boot and last boot, cleanly output in terminal as pastebin links, to simplify troubleshooting and issue reporting.
 get-logs:
     #!/bin/bash


### PR DESCRIPTION
im fixing it out of sheer anger at Square Enix. Should let you still use -deck image and have game mode but not be forced to download the low quality asset version of rebirth, I believe theres a few other games like this as well, where SteamDeck=0 launch option wont suffice, as its the game files downloaded and depot chosen itself that is the issue


Discussion on the issue here:

https://github.com/ValveSoftware/Proton/issues/8408#issuecomment-2754226829

Here you can see Steam DB Depots for Deck which enforce lower quality assets on the install, which can not be overcome with launch args as the content is prevented from being installed in the first place:

https://steamdb.info/app/2909400/depots/

<img width="549" alt="image" src="https://github.com/user-attachments/assets/9fe5b0d3-84e7-456a-b994-39ec3d7701af" />


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
