### PR TITLE
feat: Prevent setup-decky with sudo

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/deck/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -21,7 +21,7 @@ screens:
           description: A plugin loader for the Steam Deck
           default: false
           packages:
-          - Retrieve Decky: sudo -A ujust setup-decky install
+          - Retrieve Decky: ujust setup-decky install
         Decky Framegen:
           description: A Decky plugin that swaps DLSS for FSR 3 Upscaling and Framegen
           default: false

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -247,6 +247,10 @@ configure-watchdog ACTION="":
 # Install and configure Decky Loader (https://github.com/SteamDeckHomebrew/decky-loader) and plugins for alternative handhelds
 setup-decky ACTION="install":
     #!/usr/bin/bash
+    if [[ $(id -u) -eq 0 ]]; then
+        echo >&2 "ERROR: Do not run this with sudo"
+        exit 1
+    fi
     source /usr/lib/ujust/ujust.sh
     DECKY_STATE="${b}${red}Not Installed${n}"
     if [[ -d $HOME/homebrew/plugins ]]; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -270,7 +270,8 @@ setup-decky ACTION="install":
         echo "Making a /home/deck symlink to fix plugins that do not use environment variables."
         sudo ln -sf "$HOME" /home/deck
       fi
-      curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh
+      curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh |
+        sed 's|sudo|sudo -A |g' | sh
       sudo chcon -R -t bin_t $HOME/homebrew/services/PluginLoader
     fi
     if [[ "${OPTION,,}" =~ prerelease ]]; then


### PR DESCRIPTION
Sudo calls are getting chained and thus SUDO_USER gets set as `root`

![image](https://github.com/user-attachments/assets/1cbfef14-4fb0-4561-8dbb-3105d5310ccc)
[The explanation](https://discord.com/channels/1072614816579063828/1087140957096517672/1358230705351426098)