### PR TITLE
Fix: Set -steamdeck alias in gamemode as well as desktop via ujust toggle-steamdeck-alias

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -600,18 +600,34 @@ toggle-steamdeck-alias:
     #!/usr/bin/bash
     # Toggles whether Steam presents the system as a Steam Deck via -steamdeck
     override_flag="$HOME/.config/bazzite/disable_steamdeck_flag"
+    session_dir="$HOME/.config/gamescope-session-plus/sessions.d"
+    session_file="$session_dir/steam"
     mkdir -p "$(dirname "$override_flag")"
+    mkdir -p "$session_dir"
+    cat > "$session_file" <<'EOF'
+    # Respect Bazzite's disable_steamdeck_flag for game mode
+    DECK_OVERRIDE_FLAG="$HOME/.config/bazzite/disable_steamdeck_flag"
+    if [[ ! -f "$DECK_OVERRIDE_FLAG" ]]; then
+      export CLIENTCMD="steam -gamepadui -steamos3 -steampal -steamdeck"
+    else
+      export CLIENTCMD="steam -gamepadui -steamos3 -steampal"
+    fi
+    EOF
     current_status="Enabled"
     if [[ -f "$override_flag" ]]; then
       current_status="Disabled"
     fi
     echo -e "\nCurrent Steam Deck presentation mode: $current_status\n"
-    CHOICE=$(ugum choose "Present as Steam Deck (Enable -steamdeck)" "Do Not Present as Steam Deck (Disable -steamdeck)" "Exit without changes")
+    CHOICE=$(ugum choose \
+      "Present as Steam Deck (Enable -steamdeck)" \
+      "Do Not Present as Steam Deck (Disable -steamdeck)" \
+      "Exit without changes")
     case "$CHOICE" in
       "Present as Steam Deck (Enable -steamdeck)")
         if [[ -f "$override_flag" ]]; then
           rm -f "$override_flag"
           echo -e "\nSteam Deck presentation ENABLED. (-steamdeck will be passed to Steam)\n"
+          echo "Reboot your system for the change to take effect."
         else
           echo -e "\nAlready enabled.\n"
         fi
@@ -619,6 +635,7 @@ toggle-steamdeck-alias:
       "Do Not Present as Steam Deck (Disable -steamdeck)")
         touch "$override_flag"
         echo -e "\nSteam Deck presentation DISABLED. (-steamdeck will NOT be passed to Steam)\n"
+        echo "Reboot your system for the change to take effect."
         ;;
       "Exit without changes")
         echo "No changes made."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -605,7 +605,6 @@ toggle-steamdeck-alias:
     mkdir -p "$(dirname "$override_flag")"
     mkdir -p "$session_dir"
     cat > "$session_file" <<'EOF'
-    # Respect Bazzite's disable_steamdeck_flag for game mode
     DECK_OVERRIDE_FLAG="$HOME/.config/bazzite/disable_steamdeck_flag"
     if [[ ! -f "$DECK_OVERRIDE_FLAG" ]]; then
       export CLIENTCMD="steam -gamepadui -steamos3 -steampal -steamdeck"


### PR DESCRIPTION
I discovered if using ujust toggle-steamdeck-alias on Bazzite to disable the -steamdeck launch flag, this works in desktop mode, but not in game mode (Gamescope session), where Steam still launches with -steamdeck.

In game mode, the CLIENTCMD variable is set in:

```/usr/share/gamescope-session-plus/sessions.d/steam```

as 

```export CLIENTCMD="steam -gamepadui -steamos3 -steampal -steamdeck"```

This setting ignores the flag file that desktop mode checks, so Steam is always launched with -steamdeck in game mode.


This update enhances the toggle-steamdeck-alias ujust recipe to fully support Bazzite’s immutable filesystem by using a writable override in ~/.config/gamescope-session-plus/sessions.d/steam.

Changes:
	•	Automatically creates the sessions.d override directory if it doesn’t exist.
	•	Writes a small shell script to ~/.config/gamescope-session-plus/sessions.d/steam that respects the ~/.config/bazzite/disable_steamdeck_flag file.
	•	Ensures CLIENTCMD is correctly set to include or exclude -steamdeck based on user choice.
	•	Informs user when a reboot is required to apply changes.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
