### PR TITLE
chore: Remove hyfetch aliases since there's a Brew package for this now

### DIFF
--- a/system_files/desktop/shared/etc/profile.d/bazzite-neofetch.sh
+++ b/system_files/desktop/shared/etc/profile.d/bazzite-neofetch.sh
@@ -1,4 +1,3 @@
 alias neofetch='/usr/bin/fastfetch --color $(/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'
 alias neowofetch='/usr/bin/fastfetch --color $(/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'
-alias hyfetch='/usr/bin/fastfetch --color $(/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'
 alias fastfetch='/usr/bin/fastfetch --color $(/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'

--- a/system_files/overrides/usr/share/fish/vendor_conf.d/bazzite-neofetch.fish
+++ b/system_files/overrides/usr/share/fish/vendor_conf.d/bazzite-neofetch.fish
@@ -1,4 +1,3 @@
 alias neofetch='/usr/bin/fastfetch --color (/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'
 alias neowofetch='/usr/bin/fastfetch --color (/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'
-alias hyfetch='/usr/bin/fastfetch --color (/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'
 alias fastfetch='/usr/bin/fastfetch --color (/usr/libexec/bazzite-bling-fastfetch) -c /usr/share/ublue-os/bazzite/fastfetch.jsonc'


### PR DESCRIPTION
As requested by @adeliasvg:

This is to avoid issues entering `hyfetch` after installing the Homebrew package since the alias would return an error.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
