### PR TITLE
fix: Use bootc kargs to mount rootfs with zstd compression

### DIFF
--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -40,7 +40,7 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2
         with:
           name: ${{ steps.generate-release.outputs.title }}
           tag_name: ${{ steps.generate-release.outputs.tag }}

--- a/Containerfile
+++ b/Containerfile
@@ -714,6 +714,7 @@ RUN --mount=type=cache,dst=/var/cache \
         acpica-tools \
         vpower \
         ublue-update \
+        glorpfetch \
         ds-inhibit \
         steam_notif_daemon \
         sdgyrodsu \

--- a/system_files/desktop/shared/usr/lib/bootc/kargs/20-rootfs.toml
+++ b/system_files/desktop/shared/usr/lib/bootc/kargs/20-rootfs.toml
@@ -1,0 +1,6 @@
+# Enable zstd compression in rootfs.
+# See:
+#   - https://bootc-dev.github.io/bootc/building/kernel-arguments.html#usrlibbootckargsd
+kargs = [
+    "rootflags=subvol=root,noatime,lazytime,discard=sync,compress-force=zstd:3,space_cache=v2",
+]


### PR DESCRIPTION
See:
https://discussion.fedoraproject.org/t/root-mount-options-are-ignored-in-fedora-atomic-desktops-42/148562/1