### PR TITLE
fix: Use bootc kargs to mount rootfs with zstd compression

### DIFF
--- a/system_files/desktop/shared/usr/lib/bootc/kargs/20-rootfs.toml
+++ b/system_files/desktop/shared/usr/lib/bootc/kargs/20-rootfs.toml
@@ -1,0 +1,6 @@
+# Enable zstd compression in rootfs.
+# See:
+#   - https://bootc-dev.github.io/bootc/building/kernel-arguments.html#usrlibbootckargsd
+kargs = [
+    "rootflags=subvol=root,noatime,lazytime,discard=sync,compress-force=zstd:3,space_cache=v2",
+]


### PR DESCRIPTION
See:
https://discussion.fedoraproject.org/t/root-mount-options-are-ignored-in-fedora-atomic-desktops-42/148562/1