### PR TITLE
fix(just): disable split_lock_detect when using kvmfr

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -203,7 +203,7 @@ setup-virtualization ACTION="":
     # Default value set by us is 128 which is enough for 4k SDR
     # Find the current value by running "rpm-ostree kargs"
     KVMFR_MODPROBE'
-      rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128"
+      rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128" --append-if-missing="split_lock_detect=off"
       if [ -f "/etc/udev/rules.d/99-kvmfr.rules" ]; then
         echo "Re-creating kvmfr udev rules"
         sudo rm /etc/udev/rules.d/99-kvmfr.rules


### PR DESCRIPTION
the issue is being worked on upstream since february see https://lore.kernel.org/all/20250227222411.3490595-1-seanjc@google.com/, however it seems to still be an issue so this will change the ujust to disable split lock detection which will cause looking-glass work properly.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
