### PR TITLE
fix(deck): Update videos for latest Steam client.

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -172,11 +172,15 @@ configure-override-videos ACTION="":
     elif [[ "${OPTION,,}" =~ ^disable ]]; then
       echo "Adding $NO_VIDEO"
       touch $NO_VIDEO
+      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/steam_os_startup.webm
+      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/steam_os_suspend.webm
+      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/steam_os_suspend_from_throbber.webm
       rm -f $HOME/.local/share/Steam/config/uioverrides/movies/deck_startup.webm
       rm -f $HOME/.local/share/Steam/config/uioverrides/movies/deck-suspend-animation.webm
       rm -f $HOME/.local/share/Steam/config/uioverrides/movies/deck-suspend-animation-from-throbber.webm
-      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/steam_os_suspend.webm
-      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/steam_os_suspend_from_throbber.webm
+      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/oled_startup.webm
+      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/oled-suspend-animation.webm
+      rm -f $HOME/.local/share/Steam/config/uioverrides/movies/oled-suspend-animation-from-throbber.webm
     fi
 
 # Restores the stock virtual keyboard under KDE & GNOME

--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -45,12 +45,19 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
 
   if ! $SKIP_VIDEOS; then
 
-    LOCATION_STARTUP=$HOME/.local/share/Steam/config/uioverrides/movies/deck_startup.webm
+    LOCATION_STARTUP=$HOME/.local/share/Steam/config/uioverrides/movies/steam_os_startup.webm
     LOCATION_SUSPEND=$HOME/.local/share/Steam/config/uioverrides/movies/steam_os_suspend.webm
-    LOCATION_SUSPEND_OLD=$HOME/.local/share/Steam/config/uioverrides/movies/deck-suspend-animation.webm
     LOCATION_THROBBER=$HOME/.local/share/Steam/config/uioverrides/movies/steam_os_suspend_from_throbber.webm
-    LOCATION_THROBBER_OLD=$HOME/.local/share/Steam/config/uioverrides/movies/deck-suspend-animation-from-throbber.webm
 
+    LOCATION_STARTUP_DECK=$HOME/.local/share/Steam/config/uioverrides/movies/deck_startup.webm
+    LOCATION_SUSPEND_DECK=$HOME/.local/share/Steam/config/uioverrides/movies/deck-suspend-animation.webm
+    LOCATION_THROBBER_DECK=$HOME/.local/share/Steam/config/uioverrides/movies/deck-suspend-animation-from-throbber.webm
+
+    LOCATION_STARTUP_OLED=$HOME/.local/share/Steam/config/uioverrides/movies/oled_startup.webm
+    LOCATION_SUSPEND_OLED=$HOME/.local/share/Steam/config/uioverrides/movies/oled-suspend-animation.webm
+    LOCATION_THROBBER_OLED=$HOME/.local/share/Steam/config/uioverrides/movies/oled-suspend-animation-from-throbber.webm
+
+    # Steam OS
     if ! cmp --silent $VIDEO_STARTUP $LOCATION_STARTUP; then
       cp $VIDEO_STARTUP $LOCATION_STARTUP
     fi
@@ -59,16 +66,34 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
       cp $VIDEO_SUSPEND $LOCATION_SUSPEND
     fi
 
-    if ! cmp --silent $VIDEO_SUSPEND $LOCATION_SUSPEND_OLD; then
-      cp $VIDEO_SUSPEND $LOCATION_SUSPEND_OLD
-    fi
-
     if ! cmp --silent $VIDEO_SUSPEND $LOCATION_THROBBER; then
       cp $VIDEO_SUSPEND $LOCATION_THROBBER
     fi
 
-    if ! cmp --silent $VIDEO_SUSPEND $LOCATION_THROBBER_OLD; then
-      cp $VIDEO_SUSPEND $LOCATION_THROBBER_OLD
+    # Deck
+    if ! cmp --silent $VIDEO_STARTUP $LOCATION_STARTUP_DECK; then
+      cp $VIDEO_STARTUP $LOCATION_STARTUP_DECK
+    fi
+
+    if ! cmp --silent $VIDEO_SUSPEND $LOCATION_SUSPEND_DECK; then
+      cp $VIDEO_SUSPEND $LOCATION_SUSPEND_DECK
+    fi
+
+    if ! cmp --silent $VIDEO_SUSPEND $LOCATION_THROBBER_DECK; then
+      cp $VIDEO_SUSPEND $LOCATION_THROBBER_DECK
+    fi
+
+    # OLED
+    if ! cmp --silent $VIDEO_STARTUP $LOCATION_STARTUP_OLED; then
+      cp $VIDEO_STARTUP $LOCATION_STARTUP_OLED
+    fi
+
+    if ! cmp --silent $VIDEO_SUSPEND $LOCATION_SUSPEND_OLED; then
+      cp $VIDEO_SUSPEND $LOCATION_SUSPEND_OLED
+    fi
+
+    if ! cmp --silent $VIDEO_SUSPEND $LOCATION_THROBBER_OLED; then
+      cp $VIDEO_SUSPEND $LOCATION_THROBBER_OLED
     fi
 
   fi


### PR DESCRIPTION
Valve has decided to suddenly want to use the Steam OS variant of the startup movies.

It appears that Steam's Deck and OLED override is currently broken, but we are going to set up all of the different video variants just in case they decide to fix it.