### PR TITLE
feat: remove just recipe for docker

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -167,39 +167,6 @@ remove-opentabletdriver:
     flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver && \ 
     systemctl disable --user --now opentabletdriver.service
 
-# Install Docker, a platform designed to help developers build, share, and run container applications
-install-docker:
-    #!/usr/bin/bash
-    set -eo pipefail
-    [[ ${DEBUG:-} -eq 1 ]] && set -x
-    [[ $(id -u) -eq 0 ]] && {
-        echo >&2 "Dont run this as root"
-        exit 1
-    }
-    mkdir -p ~/.local/bin
-    brew install docker
-    # Handle plugins installation separately to handle file config collision
-    brew install docker-buildx docker-compose || {
-      brew link --overwrite docker-buildx docker-compose
-    }
-
-    [[ -e ~/.local/bin/docker ]] && {
-      gum confirm "There is a file in ~/.local/bin/docker. Do you wish to override it?" || exit 0
-    }
-    ln -sf $(which docker) ~/.local/bin/docker
-    [[ -e /usr/local/bin/docker ]] && {
-      gum confirm "There is a file in /usr/local/bin/docker. Do you wish to override it?" || exit 0
-    }
-    sudo ln -sf $(which docker) /usr/local/bin/docker
-    # Enable podman sockets
-    systemctl --user enable --now podman.socket
-    sudo systemctl enable --now podman.socket
-    # Add podman sockets to docker contexts
-    ctx=$(docker context create podman --docker "host=unix://$(podman system info  --format '{{{{.Host.RemoteSocket.Path}}')") && \
-      docker context use $ctx && unset -v ctx || true
-    ctx=$(sudo docker context create podman-rootful --docker "host=unix://$(sudo podman system info  --format '{{{{.Host.RemoteSocket.Path}}')") && \
-      sudo docker context use $ctx && unset -v ctx || true
-
 # Create fedora distrobox if it doesn't exist
 [private]
 distrobox-check-fedora:


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

this is cursed and people should use -dx image instead for docker