### PR TITLE
feat: Ujust toggle updates for upcoming yafti replacement

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -81,6 +81,7 @@ regenerate-grub:
 # Configure grub bootmenu visibility. pass action 'help' for more info.
 configure-grub ACTION="":
     #!/usr/bin/bash
+    source /usr/libexec/bazzite-boot-remount
     source /usr/lib/ujust/ujust.sh
     # Function to display usage/help with some color
     print_help() {
@@ -110,12 +111,12 @@ configure-grub ACTION="":
             echo "  - ${bold}0${normal}: GRUB always shows on boot."
             ;;
           1)
-            echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
+            echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot, except when Dual Booting)${normal}"
             echo "Explanation:"
             echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
             ;;
           2)
-            echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
+            echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Hide After Successful Boot)${normal}"
             echo "Explanation:"
             echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
             ;;
@@ -130,8 +131,8 @@ configure-grub ACTION="":
     # Interactive menu for choosing the new behavior
     interactive_menu() {
       local options=(
-        "Always Hide Grub (menu_auto_hide=2)"
-        "Hide After Successful Boot (menu_auto_hide=1)"
+        "Hide After Successful Boot (menu_auto_hide=2)"
+        "Same except when Dual Booting (menu_auto_hide=1)"
         "Always Show Grub (menu_auto_hide=0)"
         "Exit without changes"
       )
@@ -142,15 +143,16 @@ configure-grub ACTION="":
     # Function to apply the selected setting
     apply_setting() {
       local selected_option="$1"
+      remount_boot_rw
       # Support the interactive strings as well as short commands
       case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
         *"(menu_auto_hide=2)"*|hide)
           sudo grub2-editenv - set menu_auto_hide=2
-          echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
+          echo "GRUB menu is now set to ${bold}${cyan}Hide After Successful Boot${normal}."
           ;;
         *"(menu_auto_hide=1)"*|unhide)
           sudo grub2-editenv - set menu_auto_hide=1
-          echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
+          echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot except when Dual Booting${normal}."
           ;;
         *"(menu_auto_hide=0)"*|show)
           sudo grub2-editenv - set menu_auto_hide=0
@@ -166,6 +168,7 @@ configure-grub ACTION="":
           echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
           ;;
       esac
+      remount_boot_ro
     }
     OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
     if [ "$OPTION" == "help" ]; then
@@ -185,6 +188,7 @@ configure-grub ACTION="":
     else
       apply_setting "$OPTION"
     fi
+
 
 # Add user to "input" group required by certain controller drivers
 add-user-to-input-group:

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -66,6 +66,18 @@ toggle-ssh ACTION="":
         ;;
     esac
 
+# Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
+regenerate-grub:
+    #!/usr/bin/bash
+    source /usr/libexec/bazzite-boot-remount
+    remount_boot_rw
+    if [ -d /sys/firmware/efi ]; then
+      sudo grub2-mkconfig -o /etc/grub2-efi.cfg
+    else
+      sudo grub2-mkconfig -o /etc/grub2.cfg
+    fi
+    remount_boot_ro
+
 # Configure grub bootmenu visibility. pass action 'help' for more info.
 configure-grub ACTION="":
     #!/usr/bin/bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -14,7 +14,7 @@ _install-system-flatpaks:
     flatpak --system -y install --reinstall --or-update ${FLATPAK_LIST}
 
 # Toggle SSH availability on boot
-toggle-ssh:
+toggle-ssh ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     # Get hostname and IP address
@@ -25,19 +25,28 @@ toggle-ssh:
     if systemctl is-enabled sshd | grep -q enabled; then
       SSH_STATUS="Enabled"
     fi
-    # Display current status
-    echo -e "\n${bold}Hostname:${normal} $HOSTNAME"
-    echo -e "${bold}IP Address:${normal} $IP_ADDRESS"
-    if [ "$SSH_STATUS" == "Enabled" ]; then
-      echo -e "${bold}SSH Availability on Boot:${normal} ${green}$SSH_STATUS${normal}\n"
-    else
-      echo -e "${bold}SSH Availability on Boot:${normal} ${yellow}$SSH_STATUS${normal}\n"
+    OPTION="{{ ACTION }}"
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-ssh <option>"
+      echo "  <option>: Specify the option to skip the interactive prompt"
+      echo "  Use 'enable' to enable SSH on boot"
+      echo "  Use 'disable' to disable SSH on boot"
+      exit 0
+    elif [ "$OPTION" == "" ]; then
+      # Display current status
+      echo -e "\n${bold}Hostname:${normal} $HOSTNAME"
+      echo -e "${bold}IP Address:${normal} $IP_ADDRESS"
+      if [ "$SSH_STATUS" == "Enabled" ]; then
+        echo -e "${bold}SSH Availability on Boot:${normal} ${green}$SSH_STATUS${normal}\n"
+      else
+        echo -e "${bold}SSH Availability on Boot:${normal} ${yellow}$SSH_STATUS${normal}\n"
+      fi
+      # Prompt user for action
+      echo "Choose an option:"
+      OPTION=$(ugum choose "Enable SSH" "Disable SSH" "Exit without saving")
     fi
-    # Prompt user for action
-    echo "Choose an option:"
-    CHOICE=$(ugum choose "Enable SSH" "Disable SSH" "Exit without saving")
-    case "$CHOICE" in
-      "Enable SSH")
+    case "$OPTION" in
+      "Enable SSH"|enable)
         echo "Enabling SSH on boot..."
         sudo systemctl enable sshd
         sudo systemctl start sshd
@@ -45,37 +54,21 @@ toggle-ssh:
         echo -e "${bold}${USER}@${IP_ADDRESS}${normal}"
         echo " "
         ;;
-      "Disable SSH")
+      "Disable SSH"|disable)
         echo "Disabling SSH on boot..."
         sudo systemctl disable sshd
         sudo systemctl stop sshd
         echo -e "SSH is now ${yellow}Disabled${normal}."
         echo " "
         ;;
-      "Exit without saving")
+      "Exit without saving"|*)
         echo "No changes made."
         ;;
-      *)
-        echo "Invalid choice. Exiting without changes."
-        ;;
     esac
-
-# Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
-regenerate-grub:
-    #!/usr/bin/bash
-    source /usr/libexec/bazzite-boot-remount
-    remount_boot_rw
-    if [ -d /sys/firmware/efi ]; then
-      sudo grub2-mkconfig -o /etc/grub2-efi.cfg
-    else
-      sudo grub2-mkconfig -o /etc/grub2.cfg
-    fi
-    remount_boot_ro
 
 # Configure grub bootmenu visibility. pass action 'help' for more info.
 configure-grub ACTION="":
     #!/usr/bin/bash
-    source /usr/libexec/bazzite-boot-remount
     source /usr/lib/ujust/ujust.sh
     # Function to display usage/help with some color
     print_help() {
@@ -105,12 +98,12 @@ configure-grub ACTION="":
             echo "  - ${bold}0${normal}: GRUB always shows on boot."
             ;;
           1)
-            echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot, except when Dual Booting)${normal}"
+            echo "Current GRUB menu_auto_hide setting: ${bold}${yellow}1 (Hide After Successful Boot)${normal}"
             echo "Explanation:"
             echo "  - ${bold}1${normal}: GRUB is hidden after a successful boot, but it will show if dual-booting."
             ;;
           2)
-            echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Hide After Successful Boot)${normal}"
+            echo "Current GRUB menu_auto_hide setting: ${bold}${cyan}2 (Always Hide)${normal}"
             echo "Explanation:"
             echo "  - ${bold}2${normal}: GRUB is hidden after a successful boot, even for dual-boot setups."
             ;;
@@ -125,8 +118,8 @@ configure-grub ACTION="":
     # Interactive menu for choosing the new behavior
     interactive_menu() {
       local options=(
-        "Hide After Successful Boot (menu_auto_hide=2)"
-        "Same except when Dual Booting (menu_auto_hide=1)"
+        "Always Hide Grub (menu_auto_hide=2)"
+        "Hide After Successful Boot (menu_auto_hide=1)"
         "Always Show Grub (menu_auto_hide=0)"
         "Exit without changes"
       )
@@ -137,16 +130,15 @@ configure-grub ACTION="":
     # Function to apply the selected setting
     apply_setting() {
       local selected_option="$1"
-      remount_boot_rw
       # Support the interactive strings as well as short commands
       case "$(echo "$selected_option" | tr '[:upper:]' '[:lower:]')" in
         *"(menu_auto_hide=2)"*|hide)
           sudo grub2-editenv - set menu_auto_hide=2
-          echo "GRUB menu is now set to ${bold}${cyan}Hide After Successful Boot${normal}."
+          echo "GRUB menu is now set to ${bold}${cyan}Always Hide${normal}."
           ;;
         *"(menu_auto_hide=1)"*|unhide)
           sudo grub2-editenv - set menu_auto_hide=1
-          echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot except when Dual Booting${normal}."
+          echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot${normal}."
           ;;
         *"(menu_auto_hide=0)"*|show)
           sudo grub2-editenv - set menu_auto_hide=0
@@ -162,7 +154,6 @@ configure-grub ACTION="":
           echo "${bold}${red}Invalid option selected. No changes were made.${normal}"
           ;;
       esac
-      remount_boot_ro
     }
     OPTION="{{ ACTION }}"   # from “configure-grub ACTION=...”
     if [ "$OPTION" == "help" ]; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -189,7 +189,6 @@ configure-grub ACTION="":
       apply_setting "$OPTION"
     fi
 
-
 # Add user to "input" group required by certain controller drivers
 add-user-to-input-group:
     #!/usr/bin/bash

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -89,7 +89,7 @@ toggle-bt-mic:
     fi
 
 # enable or disable wake-on-lan functionality
-toggle-wol:
+toggle-wol ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     INTERFACE=$(ip link show | awk '/state UP/ {print $2}' | tr -d ':' | grep -E '^(en|eth)')
@@ -106,10 +106,20 @@ toggle-wol:
     if [[ "$WOL_STATUS" == "g" ]]; then
       CURRENT_STATE="Enabled"
     fi
-    echo "Wake-on-LAN is currently: ${bold}${CURRENT_STATE}${normal}"
-    echo "Enable, Disable Wake-on-LAN, Force-Enable, or Exit without saving?"
-    echo "Note: Force-Enable will make WOL persist across reboots"
-    OPTION=$(ugum choose Enable Disable Force-Enable Exit)
+    OPTION="{{ ACTION }}"
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-wol <option>"
+      echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'enable' to enable Wake-on-LAN"
+      echo "  Use 'disable' to disable Wake-on-LAN"
+      echo "  Use 'force-enable' to force-enable Wake-on-LAN (persists across reboots)"
+      exit 0
+    elif [ -z "$OPTION" ]; then
+      echo "Wake-on-LAN is currently: ${bold}${CURRENT_STATE}${normal}"
+      echo "Enable, Disable Wake-on-LAN, Force-Enable, or Exit without saving?"
+      echo "Note: Force-Enable will make WOL persist across reboots"
+      OPTION=$(ugum choose Enable Disable Force-Enable Exit)
+    fi
     if [[ "${OPTION,,}" == "enable" ]]; then
       echo "You chose to enable Wake-on-LAN."
       echo "Requesting root privileges..."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -53,6 +53,7 @@ get-webapp service="":
             "HBO Max" \
             "Hulu" \
             "Plex HTPC" \
+            "Jellyfin Media Player" \
             "Paramount Plus" \
             "Peacock" \
             "Sling TV" \
@@ -74,7 +75,6 @@ get-webapp service="":
         steamos-add-to-steam "$script_path"
         echo "Added $1 to Steam successfully!"
     }
-
     install_crunchyroll() {
         if grep -q 'it.mijorus.gearlever' <<< $(flatpak list); then
             wget \
@@ -91,7 +91,6 @@ get-webapp service="":
             chmod +x $HOME/Desktop/Crunchyroll.AppImage
         fi
     }
-
     install_plex_htpc(){
         if grep -q 'tv.plex.PlexHTPC' <<< $(flatpak list); then
             echo "Plex HTPC is already installed"
@@ -99,7 +98,13 @@ get-webapp service="":
             flatpak install --system -y tv.plex.PlexHTPC
         fi
     }
-
+    install_jellyfin_media_player() {
+        if grep -q 'com.github.iwalton3.jellyfin-media-player' <<< $(flatpak list); then
+            echo "Jellyfin Media Player is already installed"
+        else
+            flatpak install --system -y com.github.iwalton3.jellyfin-media-player
+        fi
+    }
     # Process user choice
     case "$CHOICE" in
         "YouTube") create_script "youtube" "youtube" ;;
@@ -114,6 +119,7 @@ get-webapp service="":
         "HBO Max") create_script "hbo-max" "hboMax" ;;
         "Hulu") create_script "hulu" "hulu" ;;
         "Plex HTPC") install_plex_htpc ;;
+        "Jellyfin Media Player") install_jellyfin_media_player ;;
         "Paramount Plus") create_script "paramount-plus" "paramountPlus" ;;
         "Peacock") create_script "peacock" "peacock" ;;
         "Sling TV") create_script "sling-tv" "slingTV" ;;


### PR DESCRIPTION
This PR adds parameter support to various ujust commands to facilitate programmatic toggling and configuration in the upcoming OOBE (Out-of-Box Experience) replacement. These modifications allow scripts to be called with direct parameters rather than requiring interactive prompts.

### Changes:

- **Added parameter support to key system configuration scripts:**
  - `toggle-ssh ACTION=""`: Enable/disable SSH with `enable`/`disable` parameters
  - `configure-grub ACTION=""`: Configure GRUB visibility with `show`/`hide`/`unhide` parameters
  - `toggle-wol ACTION=""`: Manage Wake-on-LAN with `enable`/`disable`/`force-enable` parameters

- **Added Jellyfin Media Player to streaming services:**
  - Implemented Jellyfin installation option in `get-webapp` service menu
  - Added proper Flatpak installation and verification


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
