### PR TITLE
chore: Remove symlink to missing script /usr/share/ublue-os/firstboot/launcher/login-profile.sh

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -528,8 +528,6 @@ RUN --mount=type=cache,dst=/var/cache \
     rm -f /usr/share/vulkan/icd.d/lvp_icd.*.json && \
     rm -f /usr/lib/systemd/system/service.d/50-keep-warm.conf && \
     mkdir -p "/etc/profile.d/" && \
-    ln -s "/usr/share/ublue-os/firstboot/launcher/login-profile.sh" \
-    "/etc/profile.d/ublue-firstboot.sh" && \
     mkdir -p "/etc/xdg/autostart" && \
     cp "/usr/share/applications/discover_overlay.desktop" "/etc/xdg/autostart/discover_overlay.desktop" && \
     sed -i 's@Exec=discover-overlay@Exec=/usr/bin/bazzite-discover-overlay@g' /etc/xdg/autostart/discover_overlay.desktop && \

--- a/Containerfile
+++ b/Containerfile
@@ -461,6 +461,7 @@ RUN --mount=type=cache,dst=/var/cache \
             gnome-shell-extension-bazzite-menu \
             gnome-shell-extension-hotedge \
             gnome-shell-extension-caffeine \
+            gnome-shell-extension-restart-to \
             rom-properties-gtk3 \
             ibus-mozc \
             openssh-askpass \

--- a/spec_files/gnome-shell-extension-restart-to/gnome-shell-extension-restart-to.spec
+++ b/spec_files/gnome-shell-extension-restart-to/gnome-shell-extension-restart-to.spec
@@ -1,0 +1,40 @@
+%global uuid restartto@tiagoporsch.github.io
+
+Name:        gnome-shell-extension-restart-to
+Version:     8
+Release:     1%{?dist}
+Summary:     GNOME extension that adds a menu allowing to reboot into any existing UEFI boot entry 
+
+Group:       User Interface/Desktops
+License:     GPLv2
+URL:         https://github.com/tiagoporsch/restartto
+Source0:     %{url}/releases/download/%{version}/%{uuid}.shell-extension.zip
+BuildArch:   noarch
+
+BuildRequires: glib2
+
+Requires:    gnome-shell >= 3.12
+%description
+GNOME extension that adds a menu allowing to reboot into any existing UEFI boot entry 
+
+%prep
+%setup -q -T
+mkdir -p %{uuid}.shell-extension
+cd %{uuid}.shell-extension
+unzip %{SOURCE0}
+
+%build
+# Nothing to build
+
+%install
+rm README.md
+mkdir -p %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}
+cp -r * %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/
+glib-compile-schemas %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schemas/
+
+%files
+%license LICENSE
+%{_datadir}/gnome-shell/extensions/%{uuid}/
+
+%changelog
+{{{ git_dir_changelog }}}

--- a/system_files/deck/silverblue/usr/share/glib-2.0/schemas/zz0-10-bazzite-deck-silverblue-global.gschema.override
+++ b/system_files/deck/silverblue/usr/share/glib-2.0/schemas/zz0-10-bazzite-deck-silverblue-global.gschema.override
@@ -35,7 +35,7 @@ snap-assistant-threshold=25
 override-window-menu=false
 
 [org.gnome.shell] 
-enabled-extensions=['logomenu@aryan_k', 'appindicatorsupport@rgcjonas.gmail.com', 'user-theme@gnome-shell-extensions.gcampax.github.com', 'gsconnect@andyholmes.github.io', 'just-perfection-desktop@just-perfection', 'blur-my-shell@aunetx', 'CoverflowAltTab@palatis.blogspot.com', 'hotedge@jonathan.jdoda.ca', 'caffeine@patapon.info', 'block-caribou-36@lxylxy123456.ercli.dev']
+enabled-extensions=['logomenu@aryan_k', 'appindicatorsupport@rgcjonas.gmail.com', 'user-theme@gnome-shell-extensions.gcampax.github.com', 'gsconnect@andyholmes.github.io', 'just-perfection-desktop@just-perfection', 'blur-my-shell@aunetx', 'CoverflowAltTab@palatis.blogspot.com', 'hotedge@jonathan.jdoda.ca', 'caffeine@patapon.info', 'block-caribou-36@lxylxy123456.ercli.dev', 'restartto@tiagoporsch.github.io']
 disabled-extensions=['background-logo@fedorahosted.org']
 
 [org.gnome.mutter]

--- a/system_files/desktop/silverblue/etc/polkit-1/rules.d/50-efibootmgr.rules
+++ b/system_files/desktop/silverblue/etc/polkit-1/rules.d/50-efibootmgr.rules
@@ -1,0 +1,7 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" &&
+        subject.isInGroup("wheel") &&
+        action.lookup("program") == "/usr/bin/efibootmgr") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
yafti was removed, and the first boot script was also removed but we still have a symlink to it in the container file as reported here #2536