### PR TITLE
fix(deck): show oled startup properly

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -2,7 +2,6 @@
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 IMAGE_NAME=$(jq -r '."image-name"' < $IMAGE_INFO)
-SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 
 DECK_OPTION=""
 

--- a/system_files/desktop/shared/usr/bin/bazzite-steam-brand
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam-brand
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 # use our branding for steam
 
+SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 SKIP_VIDEOS=false
 
 # Check for the no video flag


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
This simple fix just moves `SYS_ID` to `bazzite-steam-brand`, since `SYS_ID` is simply not needed in `bazzite-steam` anymore, thanks to which a special startup is showing up for Steam Deck OLED again as before