### PR TITLE
chore: fixed restore-gnome-de-settings using sh instead of bash

### DIFF
--- a/system_files/desktop/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
+++ b/system_files/desktop/silverblue/usr/share/ublue-os/just/90-bazzite-de.just
@@ -2,9 +2,12 @@
 
 # Restore Bazzite customized DE settings
 restore-gnome-de-settings:
+    #!/usr/bin/bash
     for file in /usr/share/ublue-os/dconfs/desktop-silverblue/*; do
-    dconf load / < "${file}"
+      echo "Loading dconf settings from: ${file}"
+      dconf load -f / < "${file}"
     done
+    echo You may need to log out and log in again for the changes to take effect.
 
 # Restore Bazzite customized applications folders
 restore-gnome-folders:


### PR DESCRIPTION
Looks like the `ujust restore-gnome-de-settings` was missing the shebang so it was running the script using sh rather than bash. This should fix #2577 