### PR TITLE
fix(just): Initialize brew into PATH in ujust update

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
@@ -5,6 +5,10 @@ alias upgrade := update
 # Update system, flatpaks, and containers all at once
 update:
     #!/usr/bin/bash
+
+    # Source brew if we are not in an interactive session
+    [[ $- != *i* ]] && source <(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+
     /usr/bin/topgrade --config /usr/share/ublue-os/topgrade.toml --keep
 
 alias auto-update := toggle-updates


### PR DESCRIPTION
This fixes brew apps not being updated when launching the update recipe from a desktop shortcut