### PR TITLE
fix: hide composefs volume in fastfetch

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazzite/fastfetch.jsonc
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazzite/fastfetch.jsonc
@@ -67,7 +67,8 @@
         },
         {
             "type": "disk",
-            "key": " "
+            "key": " ",
+            "showReadOnly": false
         },
         {
             "type": "display",


### PR DESCRIPTION
This PR hides the 100% full read-only composefs mount that keeps confusing users.

### Before
![Screenshot_20250517_093613](https://github.com/user-attachments/assets/dec00b27-1a85-408c-8707-f7d67625e9b1)

### After
![Screenshot_20250517_093557](https://github.com/user-attachments/assets/68517b4d-1063-493c-9906-8df120d77a00)
