### PR TITLE
fix(desktop): correctly set DefaultTimeoutStopSec

### DIFF
--- a/system_files/desktop/shared/etc/systemd/system.conf.d/timeout.conf
+++ b/system_files/desktop/shared/etc/systemd/system.conf.d/timeout.conf
@@ -1,1 +1,2 @@
+[Manager]
 DefaultTimeoutStopSec=15s

--- a/system_files/desktop/shared/etc/systemd/user.conf.d/timeout.conf
+++ b/system_files/desktop/shared/etc/systemd/user.conf.d/timeout.conf
@@ -1,1 +1,2 @@
+[Manager]
 DefaultTimeoutStopSec=15s


### PR DESCRIPTION
The main systemd config requires the options to be set under the [Manager] section. without this the option is ignored and systemd logs a warning in the journal:
systemd[1]: /etc/systemd/system.conf.d/timeout.conf:1: Assignment outside of section. Ignoring.

Fixes: 3576341 ("chore: Move default timeout config to /etc for easy customization")

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
