### PR TITLE
fix(just): Identify GUI Edition using VARIANT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
             is_latest_version: true
             is_stable_version: true
             kernel_flavor: bazzite # must match a kernel_flavor from akmods repo
-            kernel_version: 6.14.6-102.bazzite.fc42.x86_64 # must match a cached version of the above flavor
+            kernel_version: 6.14.6-105.bazzite.fc42.x86_64 # must match a cached version of the above flavor
         exclude:
           - target_image_flavor: surface
           - base_name: bazzite

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cdemu.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cdemu.just
@@ -5,7 +5,7 @@ setup-cdemu ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     CDEMU_STATE="$(rpm -qa cdemu-daemon)"
-    GUI_EDITION="$(cat /etc/os-release | grep VARIANT_ID | sed 's/^.*=//')"
+    GUI_EDITION="$(cat /etc/os-release | grep -w VARIANT | sed 's/^.*=//; s/"//g')"
     OPTION={{ ACTION }}
     if [ "$CDEMU_STATE" == "" ]; then
         CDEMU_STATE="${red}${b}Not Installed${n}"
@@ -33,7 +33,7 @@ setup-cdemu ACTION="":
       fi
       sudo dnf5 -y copr enable rodoma92/kde-cdemu-manager
       sudo dnf5 -y copr enable rok/cdemu
-      if [[ "$GUI_EDITION" == "kinoite" ]]; then
+      if [[ "$GUI_EDITION" == "Kinoite" ]]; then
             # Install packages for KDE 6
             rpm-ostree install --apply-live -y cdemu-daemon cdemu-client kde-cdemu-manager-kf6
       else
@@ -48,7 +48,7 @@ setup-cdemu ACTION="":
         echo "${red} CDEmu has already been removed!"
         exit 0
       fi
-      if [[ "$GUI_EDITION" == "kinoite" ]]; then
+      if [[ "$GUI_EDITION" == "Kinoite" ]]; then
         # Remove packages for KDE 6
         GUI_STATE="$(rpm -qa kde-cdemu-manager-kf6)"
         #GUI already removed
@@ -71,7 +71,7 @@ setup-cdemu ACTION="":
       sudo dnf5 -y copr disable rok/cdemu
       echo "CDEmu has been uninstalled."
     elif [[ "${OPTION,,}" =~ helper ]]; then
-      if [[ "$GUI_EDITION" == "kinoite" ]]; then
+      if [[ "$GUI_EDITION" == "Kinoite" ]]; then
         GUI_STATE="$(rpm -qa kde-cdemu-manager-kf6)"
         if [["$GUI_STATE" == ""]]; then
           echo "GUI has already been removed or the package is not yet installed!"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cdemu.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cdemu.just
@@ -5,7 +5,7 @@ setup-cdemu ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     CDEMU_STATE="$(rpm -qa cdemu-daemon)"
-    GUI_EDITION="$(cat /etc/os-release | grep -w VARIANT | sed 's/^.*=//; s/"//g')"
+    GUI_EDITION="$(cat /etc/os-release | grep -w VARIANT | tr '[:upper:]' '[:lower:]' | sed 's/^.*=//; s/"//g')"
     OPTION={{ ACTION }}
     if [ "$CDEMU_STATE" == "" ]; then
         CDEMU_STATE="${red}${b}Not Installed${n}"
@@ -33,7 +33,7 @@ setup-cdemu ACTION="":
       fi
       sudo dnf5 -y copr enable rodoma92/kde-cdemu-manager
       sudo dnf5 -y copr enable rok/cdemu
-      if [[ "$GUI_EDITION" == "Kinoite" ]]; then
+      if [[ "$GUI_EDITION" == "kinoite" ]]; then
             # Install packages for KDE 6
             rpm-ostree install --apply-live -y cdemu-daemon cdemu-client kde-cdemu-manager-kf6
       else
@@ -48,7 +48,7 @@ setup-cdemu ACTION="":
         echo "${red} CDEmu has already been removed!"
         exit 0
       fi
-      if [[ "$GUI_EDITION" == "Kinoite" ]]; then
+      if [[ "$GUI_EDITION" == "kinoite" ]]; then
         # Remove packages for KDE 6
         GUI_STATE="$(rpm -qa kde-cdemu-manager-kf6)"
         #GUI already removed
@@ -71,7 +71,7 @@ setup-cdemu ACTION="":
       sudo dnf5 -y copr disable rok/cdemu
       echo "CDEmu has been uninstalled."
     elif [[ "${OPTION,,}" =~ helper ]]; then
-      if [[ "$GUI_EDITION" == "Kinoite" ]]; then
+      if [[ "$GUI_EDITION" == "kinoite" ]]; then
         GUI_STATE="$(rpm -qa kde-cdemu-manager-kf6)"
         if [["$GUI_STATE" == ""]]; then
           echo "GUI has already been removed or the package is not yet installed!"


### PR DESCRIPTION
Correct GUI_EDITION to match intended "Kinoite" value on non-gnome variants and install KDE6 packages.