### PR TITLE
feat(fastfetch): Hide overlay composefs volume

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazzite/fastfetch.jsonc
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazzite/fastfetch.jsonc
@@ -67,7 +67,8 @@
         },
         {
             "type": "disk",
-            "key": " "
+            "key": " ",
+            "hideFS": "overlay"
         },
         {
             "type": "display",


### PR DESCRIPTION
This PR uses the new fastfetch [feature](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.44.0) that allows to hide specific filesystems.

This should replace #2648 

Requires fastfetch 2.44, however the parameter is ignored by previous fastfetch versions.
