### PR TITLE
feat: add exit and open web portal opts to ujust setup-sunshine

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -16,13 +16,21 @@ setup-sunshine ACTION="":
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'enable' to enable the Sunshine service"
       echo "  Use 'disable' to disable the Sunshine service"
+      echo "  Use 'portal' to open the Sunshine management portal"
+      echo "  Use 'exit' to exit without making changes"
       exit 0
     elif [ "$OPTION" == "" ]; then
       echo "Service is $SERVICE_STATE"
-      OPTION=$(Choose "Enable" "Disable")
+      OPTION=$(Choose "Enable" "Disable" "Open Portal" "Exit")
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then
       systemctl enable --user --now sunshine.service
     elif [[ "${OPTION,,}" =~ ^(remove|uninstall|disable) ]]; then
       systemctl disable --user --now sunshine.service 
+    elif [[ "${OPTION,,}" =~ ^(portal|open) ]]; then
+      echo "Opening Sunshine management portal..."
+      xdg-open https://localhost:47990
+    elif [[ "${OPTION,,}" =~ ^exit ]]; then
+      echo "Exiting without making changes."
+      exit 0
     fi


### PR DESCRIPTION
add two new options to `ujust setup-sunshine`

<img width="203" alt="image" src="https://github.com/user-attachments/assets/14a00f44-643c-4452-8d97-8a9e757bd755" />

- Open Portal: Launches users default browser to https://localhost:47990 to manage sunshine settings and add clients
- exit: easy exit option so user doesnt have to ctrl c

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
