### PR TITLE
fix: (#2626) steamos-update read uupd update-check

### DIFF
--- a/system_files/deck/shared/usr/bin/steamos-update
+++ b/system_files/deck/shared/usr/bin/steamos-update
@@ -41,8 +41,7 @@ if command -v uupd > /dev/null; then
       wget -q --spider https://github.com
       if [ $? -eq 0 ]; then
         # Check system state
-        uupd update-check
-        if [ $? -ne 0 ]; then
+        if uupd update-check | grep -q "Update Available"; then
           exit 0 # Upgrade available
         else
           exit 7 # Checks failed


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
since `uupd` exits with a `0` regardless of if there is an update or not, this change greps the output.

this change relates to https://github.com/ublue-os/uupd/pull/84 as currently `uupd` doesnt report correctly for `rpm-ostree`-based systems.

closes #2626 