### PR TITLE
fix: revert native GFN installation for now

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -149,37 +149,38 @@ get-media-app service="":
             echo "Skipping Steam integration due to installation failure."
         fi
     }
-    install_geforce_now() {
-        local installed=false
-        if grep -q 'com.nvidia.geforcenow' <<< $(flatpak list); then
-            echo "GeForce NOW is already installed"
-            installed=true
-        else
-            echo "Installing GeForce NOW..."
-            # Add the NVIDIA GeForce NOW Flatpak repository if not already added
-            flatpak remote-add --user --if-not-exists GeForceNOW https://international.download.nvidia.com/GFNLinux/flatpak/geforcenow.flatpakrepo
-            if flatpak install -y --user GeForceNOW com.nvidia.geforcenow; then
-                echo "GeForce NOW installed successfully"
-                installed=true
-            else
-                echo "Failed to install GeForce NOW. Please try installing manually with:"
-                echo "flatpak install --user GeForceNOW com.nvidia.geforcenow"
-            fi
-        fi
-        # Only proceed with Steam integration if installation was successful
-        if [ "$installed" = true ]; then
-            # Create launcher script for Steam
-            local script_path="$HOME/Applications/streaming_scripts/geforce-now.sh"
-            echo "#!/bin/bash" > "$script_path"
-            echo "flatpak run com.nvidia.geforcenow" >> "$script_path"
-            chmod +x "$script_path"
-            # Add to Steam
-            steamos-add-to-steam "$script_path"
-            echo "Added GeForce NOW to Steam successfully!"
-        else
-            echo "Skipping Steam integration due to installation failure."
-        fi
-    }
+    # Commenting out for now as GeForce NOW native app is borked on non steam deck devices, even those running SteamOS.
+    # install_geforce_now() {
+    #     local installed=false
+    #     if grep -q 'com.nvidia.geforcenow' <<< $(flatpak list); then
+    #         echo "GeForce NOW is already installed"
+    #         installed=true
+    #     else
+    #         echo "Installing GeForce NOW..."
+    #         # Add the NVIDIA GeForce NOW Flatpak repository if not already added
+    #         flatpak remote-add --user --if-not-exists GeForceNOW https://international.download.nvidia.com/GFNLinux/flatpak/geforcenow.flatpakrepo
+    #         if flatpak install -y --user GeForceNOW com.nvidia.geforcenow; then
+    #             echo "GeForce NOW installed successfully"
+    #             installed=true
+    #         else
+    #             echo "Failed to install GeForce NOW. Please try installing manually with:"
+    #             echo "flatpak install --user GeForceNOW com.nvidia.geforcenow"
+    #         fi
+    #     fi
+    #     # Only proceed with Steam integration if installation was successful
+    #     if [ "$installed" = true ]; then
+    #         # Create launcher script for Steam
+    #         local script_path="$HOME/Applications/streaming_scripts/geforce-now.sh"
+    #         echo "#!/bin/bash" > "$script_path"
+    #         echo "flatpak run com.nvidia.geforcenow" >> "$script_path"
+    #         chmod +x "$script_path"
+    #         # Add to Steam
+    #         steamos-add-to-steam "$script_path"
+    #         echo "Added GeForce NOW to Steam successfully!"
+    #     else
+    #         echo "Skipping Steam integration due to installation failure."
+    #     fi
+    # }
     # Process user choice
     case "$CHOICE" in
         "YouTube") create_script "youtube" "youtube" ;;
@@ -190,7 +191,7 @@ get-media-app service="":
         "Apple TV") create_script "apple-tv" "appleTv" ;;
         "Curiosity Stream") create_script "curiosity-stream" "curiosityStream" ;;
         "Crunchyroll") install_crunchyroll ;;
-        "GeForce Now") install_geforce_now ;;
+        "GeForce Now") create_script "geforce-now" "geForceNow" ;;
         "HBO Max") create_script "hbo-max" "hboMax" ;;
         "Hulu") create_script "hulu" "hulu" ;;
         "Plex HTPC") install_plex_htpc ;;


### PR DESCRIPTION
commenting out script to install GeForce Now native app for the time being, reverting `ujust get-media-app` GeForce Now option to standard web app method. 

Also looking to prep this fix up ahead of a potential revision of streamingServiceLauncher targeting flatpaks as discussed [here](https://discord.com/channels/1072614816579063828/1341555164477128868)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
