### PR TITLE
feat: Bruh moment

### DIFF
--- a/system_files/desktop/shared/usr/bin/bruh
+++ b/system_files/desktop/shared/usr/bin/bruh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Check for special case "bruh moment"
+if [[ "$1" == "moment" ]]; then
+  exec bazzite-rollback-helper rollback "$@"
+  exit
+fi
+
+# Otherwise, pass all arguments to bazzite-rollback-helper
+exec bazzite-rollback-helper "$@"


### PR DESCRIPTION
bazzite-rollback-helper too long and hard to remember??? whats brh even mean?? the hells a rollback???


this PR makes it so much simpler to roll back when bazzite team has a bruh moment on a deploy

now users can just enter `bruh moment` to perform `bazzite-rollback-helper rollback`

also bruh functions as similar alias to brh.

lesgooo

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
