### PR TITLE
fix: downgrade to mutter-48.1-1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -454,6 +454,7 @@ RUN --mount=type=cache,dst=/var/cache \
         dnf5 -y swap \
         --repo copr:copr.fedorainfracloud.org:bazzite-org:bazzite-multilib \
             mutter mutter && \
+        : "DELETEME: fix mutter breaking flatpaks" && dnf5 -y swap mutter mutter-0:48.1-1.fc42 && \
         dnf5 versionlock add \
             mutter && \
         dnf5 -y install \


### PR DESCRIPTION
Solves
https://discussion.fedoraproject.org/t/latest-fedora-update-broke-snap-and-flatpak-apps/154650/22