### PR TITLE
feat: improve Bazzite-rebase-helper with interactive TUI

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -49,17 +49,134 @@ List images with a specified tag
 
 INPUTS:
   \$1: branch   Branch we want to get tags from.
+                Use 'all' to show all available tags.
                 Fallbacks to \"$DEFAULT_BRANCH\"
 "
   if [[ $* =~ --help ]]; then
     echo "$_help" && return
   fi
   local branch=${1:-$DEFAULT_BRANCH}
-  local regex='.Tags[]'
-  regex="$regex"\ ' | select(test("^PLACEHOLDER|^PLACEHOLDER-(?:\\d+\\.\\d+|\\d+)"))'
-  regex=${regex//PLACEHOLDER/$branch}
-  echo -e >&2 "Listing images for $branch\nThis can take a bit of time..."
-  skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r "$regex"
+  
+  if [[ "$branch" == "all" ]]; then
+    echo -e >&2 "Listing all available images\nThis can take a bit of time..."
+    skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r '.Tags[]' | sort
+  else
+    local regex='.Tags[]'
+    regex="$regex"\ ' | select(test("^PLACEHOLDER|^PLACEHOLDER-(?:\\d+\\.\\d+|\\d+)"))'
+    regex=${regex//PLACEHOLDER/$branch}
+    echo -e >&2 "Listing images for $branch\nThis can take a bit of time..."
+    skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r "$regex"
+  fi
+}
+
+# Function to get available Bazzite image variants
+get_bazzite_variants() {
+  local provider=${1:-ublue-os}
+  
+  # Official Bazzite image variants based on README.md
+  local variants=(
+    "bazzite"
+    "bazzite-deck"
+    "bazzite-nvidia" 
+    "bazzite-deck-nvidia"
+    "bazzite-dx"
+    "bazzite-gdx"
+  )
+  
+  echo -e >&2 "Checking available variants from $provider..."
+  
+  # Verify which variants actually exist by checking if they have tags
+  for variant in "${variants[@]}"; do
+    if skopeo list-tags "docker://ghcr.io/$provider/$variant" >/dev/null 2>&1; then
+      echo "$variant"
+    fi
+  done
+}
+
+# Function for interactive image selection
+interactive_image_selection() {
+  local provider=${1:-ublue-os}
+  
+  # Clear screen for clean interface
+  clear
+  
+  echo
+  echo "${bold}Available Bazzite Images from ${green}$provider${normal}:"
+  echo
+  
+  # Get available image variants
+  local image_variants=$(get_bazzite_variants "$provider")
+  
+  if [ -z "$image_variants" ]; then
+    echo "${red}No Bazzite variants found for provider: $provider${normal}"
+    echo "This provider may not host Bazzite images."
+    return 1
+  fi
+  
+  # Convert to array for gum choose
+  local options=()
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      options+=("$line")
+    fi
+  done <<< "$image_variants"
+  
+  # Add special options
+  options+=("Back to Main Menu")
+  
+  echo "Choose an image to see available versions:"
+  local OPTION=$(Choose "${options[@]}")
+  
+  case "$OPTION" in
+    "Back to Main Menu")
+      if [[ "$provider" == "ublue-os" ]]; then
+        interactive_menu
+      else
+        custom_provider_menu "$provider"
+      fi
+      ;;
+    *)
+      if [[ -n "$OPTION" ]]; then
+        echo
+        echo "${bold}Available versions for ${green}$OPTION${normal}:"
+        echo
+        echo "Choose how to list versions:"
+        local list_option=$(Choose "List Stable Versions" "List Testing Versions" "List All Versions" "Back to Image List")
+        
+        case "$list_option" in
+          "List Stable Versions")
+            clear
+            echo "${bold}Stable versions for ${green}$OPTION${normal}:"
+            echo
+            local regex='.Tags[] | select(test("^stable"))'
+            skopeo list-tags "docker://ghcr.io/$provider/$OPTION" | jq -r "$regex" | sort
+            ;;
+          "List Testing Versions")  
+            clear
+            echo "${bold}Testing versions for ${green}$OPTION${normal}:"
+            echo
+            local regex='.Tags[] | select(test("^testing"))'
+            skopeo list-tags "docker://ghcr.io/$provider/$OPTION" | jq -r "$regex" | sort
+            ;;
+          "List All Versions")
+            clear
+            echo "${bold}All versions for ${green}$OPTION${normal}:"
+            echo
+            skopeo list-tags "docker://ghcr.io/$provider/$OPTION" | jq -r '.Tags[]' | sort
+            ;;
+          "Back to Image List")
+            interactive_image_selection "$provider"
+            return
+            ;;
+        esac
+        
+        echo
+        echo "Press Enter to continue..."
+        read -r
+        interactive_image_selection "$provider"
+      fi
+      ;;
+  esac
 }
 
 function current() {
@@ -174,6 +291,9 @@ show_current_status() {
 custom_provider_menu() {
   local provider="$1"
   
+  # Clear screen for clean interface
+  clear
+  
   echo
   echo "${bold}Custom Provider: ${green}$provider${normal}"
   echo
@@ -182,16 +302,7 @@ custom_provider_menu() {
   
   case "$OPTION" in
     "List Available Images")
-      echo
-      echo "Enter branch to list (or press Enter for '$DEFAULT_BRANCH'):"
-      read -r branch_input
-      branch_input=${branch_input:-$DEFAULT_BRANCH}
-      echo -e >&2 "Listing images for $branch_input from $provider\nThis can take a bit of time..."
-      skopeo list-tags "docker://ghcr.io/$provider/bazzite" | jq -r ".Tags[] | select(test(\"^$branch_input|^$branch_input-(?:\\\\d+\\\\.\\\\d+|\\\\d+)\"))"
-      echo
-      echo "Press Enter to continue..."
-      read -r
-      custom_provider_menu "$provider"
+      interactive_image_selection "$provider"
       ;;
     "Rebase to Specific Image")
       echo
@@ -243,6 +354,9 @@ custom_provider_menu() {
 
 # Interactive menu function
 interactive_menu() {
+  # Clear screen for clean interface
+  clear
+  
   # Show help text and current status
   echo "$helptext"
   show_current_status
@@ -252,17 +366,11 @@ interactive_menu() {
   
   case "$OPTION" in
     "List Images")
-      echo
-      echo "Enter branch to list (or press Enter for '$DEFAULT_BRANCH'):"
-      read -r branch_input
-      branch_input=${branch_input:-$DEFAULT_BRANCH}
-      list_images "$branch_input"
-      echo
-      echo "Press Enter to continue..."
-      read -r
-      interactive_menu
+      interactive_image_selection "ublue-os"
       ;;
     "Show Current Image")
+      clear
+      echo "${bold}Current System Information:${normal}"
       echo
       current
       echo
@@ -271,6 +379,8 @@ interactive_menu() {
       interactive_menu
       ;;
     "Rollback")
+      clear
+      echo "${bold}Rollback to Previous Image${normal}"
       echo
       echo "Are you sure you want to rollback to the previous image? ${yellow}(y/N)${normal}"
       read -r confirm
@@ -285,6 +395,8 @@ interactive_menu() {
       interactive_menu
       ;;
     "Rebase")
+      clear
+      echo "${bold}Rebase to Different Image${normal}"
       echo
       echo "Enter the image/tag to rebase to:"
       echo "Examples:"
@@ -306,6 +418,8 @@ interactive_menu() {
       interactive_menu
       ;;
     "Custom Image Provider")
+      clear
+      echo "${bold}Custom Image Provider${normal}"
       echo
       echo "Enter the custom provider/organization name:"
       echo "  - Default: ${bold}ublue-os${normal}"

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -170,6 +170,77 @@ show_current_status() {
   echo
 }
 
+# Function to handle custom provider rebase
+custom_provider_menu() {
+  local provider="$1"
+  
+  echo
+  echo "${bold}Custom Provider: ${green}$provider${normal}"
+  echo
+  echo "${bold}Choose an action:${normal}"
+  local OPTION=$(Choose "List Available Images" "Rebase to Specific Image" "Back to Main Menu")
+  
+  case "$OPTION" in
+    "List Available Images")
+      echo
+      echo "Enter branch to list (or press Enter for '$DEFAULT_BRANCH'):"
+      read -r branch_input
+      branch_input=${branch_input:-$DEFAULT_BRANCH}
+      echo -e >&2 "Listing images for $branch_input from $provider\nThis can take a bit of time..."
+      skopeo list-tags "docker://ghcr.io/$provider/bazzite" | jq -r ".Tags[] | select(test(\"^$branch_input|^$branch_input-(?:\\\\d+\\\\.\\\\d+|\\\\d+)\"))"
+      echo
+      echo "Press Enter to continue..."
+      read -r
+      custom_provider_menu "$provider"
+      ;;
+    "Rebase to Specific Image")
+      echo
+      echo "Enter the image:tag to rebase to:"
+      echo "Examples:"
+      echo "  - ${bold}bazzite:stable${normal}"
+      echo "  - ${bold}bazzite-deck:testing${normal}"
+      echo "  - ${bold}bazzite-gnome:40-stable-20240722${normal}"
+      echo
+      echo "Enter image:tag (or press Enter to cancel):"
+      read -r image_tag
+      if [ -n "$image_tag" ]; then
+        # Get current image prefix but replace the provider
+        local current_prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
+        local signing_scheme
+        if [[ "$current_prefix" == *"ostree-image-signed"* ]]; then
+          signing_scheme="ostree-image-signed:docker://ghcr.io"
+        else
+          signing_scheme="ostree-unverified-registry:docker://ghcr.io"
+        fi
+        
+        local custom_ref="$signing_scheme/$provider/$image_tag"
+        echo
+        echo "Rebasing to: ${bold}$custom_ref${normal}"
+        echo "Are you sure? ${yellow}(y/N)${normal}"
+        read -r confirm
+        if [[ "${confirm,,}" =~ ^y ]]; then
+          rpm-ostree rebase "$custom_ref" || echo "Failed to rebase. The image may not exist or be accessible."
+        else
+          echo "Rebase cancelled."
+        fi
+      else
+        echo "Rebase cancelled."
+      fi
+      echo
+      echo "Press Enter to continue..."
+      read -r
+      custom_provider_menu "$provider"
+      ;;
+    "Back to Main Menu")
+      interactive_menu
+      ;;
+    *)
+      echo "Invalid option selected."
+      custom_provider_menu "$provider"
+      ;;
+  esac
+}
+
 # Interactive menu function
 interactive_menu() {
   # Show help text and current status
@@ -177,7 +248,7 @@ interactive_menu() {
   show_current_status
   
   echo "${bold}Choose an action:${normal}"
-  local OPTION=$(Choose "List Images" "Show Current Image" "Rollback" "Rebase" "Exit")
+  local OPTION=$(Choose "List Images" "Show Current Image" "Rollback" "Rebase" "Custom Image Provider" "Exit")
   
   case "$OPTION" in
     "List Images")
@@ -233,6 +304,22 @@ interactive_menu() {
       echo "Press Enter to continue..."
       read -r
       interactive_menu
+      ;;
+    "Custom Image Provider")
+      echo
+      echo "Enter the custom provider/organization name:"
+      echo "  - Default: ${bold}ublue-os${normal}"
+      echo "  - Examples: ${bold}my-org${normal}, ${bold}custom-builder${normal}, ${bold}fork-maintainer${normal}"
+      echo
+      echo "Enter provider name (or press Enter for 'ublue-os'):"
+      read -r provider_input
+      provider_input=${provider_input:-ublue-os}
+      # Convert to lowercase for ghcr.io compatibility
+      provider_input=$(echo "$provider_input" | tr '[:upper:]' '[:lower:]')
+      
+      echo
+      echo "Using provider: ${bold}$provider_input${normal}"
+      custom_provider_menu "$provider_input"
       ;;
     "Exit")
       echo "Exiting..."

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -514,7 +514,7 @@ custom_provider_menu() {
       echo "Examples:"
       echo "  - ${bold}bazzite:stable${normal}"
       echo "  - ${bold}bazzite-deck:testing${normal}"
-      echo "  - ${bold}bazzite-gnome:40-stable-20240722${normal}"
+      echo "  - ${bold}bazzite-deck:40-stable-20240722${normal}"
       echo
       echo "Enter image:tag (or press Enter to cancel):"
       read -r image_tag

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -271,7 +271,206 @@ Rebasing to $img_ref. Continue? [Y/n]: "
   esac
 }
 
-# Function to show current system status
+# Function for guided rebase selection
+guided_rebase_selection() {
+  local provider=${1:-ublue-os}
+  local from_custom=${2:-false}
+  
+  clear
+  echo "${bold}Select Image for Rebase - Provider: ${green}$provider${normal}"
+  echo
+  
+  # Get available image variants
+  local image_variants=$(get_bazzite_variants "$provider")
+  
+  if [ -z "$image_variants" ]; then
+    echo "${red}No Bazzite variants found for provider: $provider${normal}"
+    echo "This provider may not host Bazzite images."
+    echo
+    echo "Press Enter to continue..."
+    read -r
+    if [[ "$from_custom" == "true" ]]; then
+      custom_provider_menu "$provider"
+    else
+      interactive_menu
+    fi
+    return 1
+  fi
+  
+  # Convert to array for gum choose
+  local options=()
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      options+=("$line")
+    fi
+  done <<< "$image_variants"
+  
+  # Add back option
+  options+=("Back to Previous Menu")
+  
+  echo "Choose an image variant:"
+  local OPTION=$(Choose "${options[@]}")
+  
+  case "$OPTION" in
+    "Back to Previous Menu")
+      if [[ "$from_custom" == "true" ]]; then
+        custom_provider_menu "$provider"
+      else
+        interactive_menu
+      fi
+      ;;
+    *)
+      if [[ -n "$OPTION" ]]; then
+        guided_version_selection "$provider" "$OPTION" "$from_custom"
+      fi
+      ;;
+  esac
+}
+
+# Function for guided version selection
+guided_version_selection() {
+  local provider="$1"
+  local image_name="$2"
+  local from_custom="$3"
+  
+  clear
+  echo "${bold}Select Version for ${green}$image_name${normal} - Provider: ${green}$provider${normal}"
+  echo
+  
+  echo "Choose version type:"
+  local version_type=$(Choose "Stable Versions" "Testing Versions" "All Versions" "Back to Image Selection")
+  
+  case "$version_type" in
+    "Back to Image Selection")
+      guided_rebase_selection "$provider" "$from_custom"
+      ;;
+    "Stable Versions")
+      show_version_menu "$provider" "$image_name" "stable" "$from_custom"
+      ;;
+    "Testing Versions")
+      show_version_menu "$provider" "$image_name" "testing" "$from_custom"
+      ;;
+    "All Versions")
+      show_version_menu "$provider" "$image_name" "all" "$from_custom"
+      ;;
+  esac
+}
+
+# Function to show version menu and handle selection
+show_version_menu() {
+  local provider="$1"
+  local image_name="$2"
+  local version_type="$3"
+  local from_custom="$4"
+  
+  clear
+  echo "${bold}${version_type^} versions for ${green}$image_name${normal}:"
+  echo
+  
+  # Get versions based on type
+  local versions=()
+  case "$version_type" in
+    "stable")
+      local regex='.Tags[] | select(test("^stable"))'
+      ;;
+    "testing")
+      local regex='.Tags[] | select(test("^testing"))'
+      ;;
+    "all")
+      local regex='.Tags[]'
+      ;;
+  esac
+  
+  # Get the versions and convert to array
+  local version_list=$(skopeo list-tags "docker://ghcr.io/$provider/$image_name" | jq -r "$regex" | sort)
+  
+  if [ -z "$version_list" ]; then
+    echo "${red}No $version_type versions found for $image_name${normal}"
+    echo
+    echo "Press Enter to continue..."
+    read -r
+    guided_version_selection "$provider" "$image_name" "$from_custom"
+    return
+  fi
+  
+  local options=()
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      options+=("$line")
+    fi
+  done <<< "$version_list"
+  
+  # Add navigation options
+  options+=("Back to Version Type Selection")
+  
+  echo "Choose a version to rebase to:"
+  local OPTION=$(Choose "${options[@]}")
+  
+  case "$OPTION" in
+    "Back to Version Type Selection")
+      guided_version_selection "$provider" "$image_name" "$from_custom"
+      ;;
+    *)
+      if [[ -n "$OPTION" ]]; then
+        # Perform the rebase
+        perform_rebase "$provider" "$image_name" "$OPTION" "$from_custom"
+      fi
+      ;;
+  esac
+}
+
+# Function to perform the actual rebase
+perform_rebase() {
+  local provider="$1"
+  local image_name="$2"
+  local version="$3"
+  local from_custom="$4"
+  
+  clear
+  echo "${bold}Confirm Rebase${normal}"
+  echo
+  
+  # Get current image prefix but replace the provider if needed
+  local current_prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
+  local signing_scheme
+  if [[ "$current_prefix" == *"ostree-image-signed"* ]]; then
+    signing_scheme="ostree-image-signed:docker://ghcr.io"
+  else
+    signing_scheme="ostree-unverified-registry:docker://ghcr.io"
+  fi
+  
+  local target_ref="$signing_scheme/$provider/$image_name:$version"
+  
+  echo "Rebasing to: ${bold}$target_ref${normal}"
+  echo
+  echo "Are you sure? ${yellow}(y/N)${normal}"
+  read -r confirm
+  
+  if [[ "${confirm,,}" =~ ^y ]]; then
+    echo
+    echo "Performing rebase..."
+    if rpm-ostree rebase "$target_ref"; then
+      echo
+      echo "${green}Rebase successful!${normal}"
+      echo "Reboot for changes to take effect."
+    else
+      echo
+      echo "${red}Failed to rebase.${normal} The image may not exist or be accessible."
+    fi
+  else
+    echo "Rebase cancelled."
+  fi
+  
+  echo
+  echo "Press Enter to continue..."
+  read -r
+  
+  if [[ "$from_custom" == "true" ]]; then
+    custom_provider_menu "$provider"
+  else
+    interactive_menu
+  fi
+}
 show_current_status() {
   echo "${bold}Current System Status:${normal}"
   echo
@@ -298,13 +497,18 @@ custom_provider_menu() {
   echo "${bold}Custom Provider: ${green}$provider${normal}"
   echo
   echo "${bold}Choose an action:${normal}"
-  local OPTION=$(Choose "List Available Images" "Rebase to Specific Image" "Back to Main Menu")
+  local OPTION=$(Choose "List Available Images" "Select from List for Rebase" "Manual Rebase Entry" "Back to Main Menu")
   
   case "$OPTION" in
     "List Available Images")
       interactive_image_selection "$provider"
       ;;
-    "Rebase to Specific Image")
+    "Select from List for Rebase")
+      guided_rebase_selection "$provider" "true"
+      ;;
+    "Manual Rebase Entry")
+      clear
+      echo "${bold}Manual Rebase Entry - Provider: ${green}$provider${normal}"
       echo
       echo "Enter the image:tag to rebase to:"
       echo "Examples:"
@@ -398,24 +602,40 @@ interactive_menu() {
       clear
       echo "${bold}Rebase to Different Image${normal}"
       echo
-      echo "Enter the image/tag to rebase to:"
-      echo "Examples:"
-      echo "  - ${bold}stable${normal} (rebase to stable branch)"
-      echo "  - ${bold}testing${normal} (rebase to testing branch)"
-      echo "  - ${bold}bazzite-deck:stable${normal} (specific image and tag)"
-      echo "  - ${bold}40-stable-20240722${normal} (specific tag)"
-      echo
-      echo "Enter rebase target (or press Enter to cancel):"
-      read -r rebase_input
-      if [ -n "$rebase_input" ]; then
-        rebase "$rebase_input" -y
-      else
-        echo "Rebase cancelled."
-      fi
-      echo
-      echo "Press Enter to continue..."
-      read -r
-      interactive_menu
+      echo "Choose rebase method:"
+      local rebase_method=$(Choose "Select from List" "Manual Entry" "Back to Main Menu")
+      
+      case "$rebase_method" in
+        "Select from List")
+          guided_rebase_selection "ublue-os" "false"
+          ;;
+        "Manual Entry")
+          clear
+          echo "${bold}Manual Rebase Entry${normal}"
+          echo
+          echo "Enter the image/tag to rebase to:"
+          echo "Examples:"
+          echo "  - ${bold}stable${normal} (rebase to stable branch)"
+          echo "  - ${bold}testing${normal} (rebase to testing branch)"
+          echo "  - ${bold}bazzite-deck:stable${normal} (specific image and tag)"
+          echo "  - ${bold}40-stable-20240722${normal} (specific tag)"
+          echo
+          echo "Enter rebase target (or press Enter to cancel):"
+          read -r rebase_input
+          if [ -n "$rebase_input" ]; then
+            rebase "$rebase_input" -y
+          else
+            echo "Rebase cancelled."
+          fi
+          echo
+          echo "Press Enter to continue..."
+          read -r
+          interactive_menu
+          ;;
+        "Back to Main Menu")
+          interactive_menu
+          ;;
+      esac
       ;;
     "Custom Image Provider")
       clear

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Source ujust library for colors and gum functionality
+source /usr/lib/ujust/ujust.sh
+
 image="$(echo "$2" | cut -d ':' -f1)"
 branch="$(echo "$2" | cut -d ':' -f2)"
 
@@ -151,6 +154,97 @@ Rebasing to $img_ref. Continue? [Y/n]: "
   esac
 }
 
+# Function to show current system status
+show_current_status() {
+  echo "${bold}Current System Status:${normal}"
+  echo
+  local current_deployment=$(rpm-ostree status --json | jq -r '.deployments[] | select(.booted == true) | .["container-image-reference"]')
+  if [ -n "$current_deployment" ]; then
+    echo "  ${bold}Active Image:${normal} ${green}$current_deployment${normal}"
+  fi
+  
+  local pending_deployment=$(rpm-ostree status --json | jq -r '.deployments[] | select(.booted != true) | .["container-image-reference"]' | head -1)
+  if [ -n "$pending_deployment" ] && [ "$pending_deployment" != "null" ]; then
+    echo "  ${bold}Pending Image:${normal} ${yellow}$pending_deployment${normal} ${yellow}(will boot next)${normal}"
+  fi
+  echo
+}
+
+# Interactive menu function
+interactive_menu() {
+  # Show help text and current status
+  echo "$helptext"
+  show_current_status
+  
+  echo "${bold}Choose an action:${normal}"
+  local OPTION=$(Choose "List Images" "Show Current Image" "Rollback" "Rebase" "Exit")
+  
+  case "$OPTION" in
+    "List Images")
+      echo
+      echo "Enter branch to list (or press Enter for '$DEFAULT_BRANCH'):"
+      read -r branch_input
+      branch_input=${branch_input:-$DEFAULT_BRANCH}
+      list_images "$branch_input"
+      echo
+      echo "Press Enter to continue..."
+      read -r
+      interactive_menu
+      ;;
+    "Show Current Image")
+      echo
+      current
+      echo
+      echo "Press Enter to continue..."
+      read -r
+      interactive_menu
+      ;;
+    "Rollback")
+      echo
+      echo "Are you sure you want to rollback to the previous image? ${yellow}(y/N)${normal}"
+      read -r confirm
+      if [[ "${confirm,,}" =~ ^y ]]; then
+        rollback
+      else
+        echo "Rollback cancelled."
+      fi
+      echo
+      echo "Press Enter to continue..."
+      read -r
+      interactive_menu
+      ;;
+    "Rebase")
+      echo
+      echo "Enter the image/tag to rebase to:"
+      echo "Examples:"
+      echo "  - ${bold}stable${normal} (rebase to stable branch)"
+      echo "  - ${bold}testing${normal} (rebase to testing branch)"
+      echo "  - ${bold}bazzite-deck:stable${normal} (specific image and tag)"
+      echo "  - ${bold}40-stable-20240722${normal} (specific tag)"
+      echo
+      echo "Enter rebase target (or press Enter to cancel):"
+      read -r rebase_input
+      if [ -n "$rebase_input" ]; then
+        rebase "$rebase_input" -y
+      else
+        echo "Rebase cancelled."
+      fi
+      echo
+      echo "Press Enter to continue..."
+      read -r
+      interactive_menu
+      ;;
+    "Exit")
+      echo "Exiting..."
+      exit 0
+      ;;
+    *)
+      echo "Invalid option selected."
+      interactive_menu
+      ;;
+  esac
+}
+
 if [[ "$1" == "list" ]]; then
   list_images "${@:2}"
   exit
@@ -167,9 +261,9 @@ elif [[ "$1" == "rebase" ]]; then
   rebase "${@:2}"
   exit
 
-# display the helptext
+# display the helptext and start interactive mode
 elif [[ "$1" == "-h" || "$1" == "--h" || "$1" == "-help" || "$1" == "--help" || "$1" == "help" || -z "$1" ]]; then
- echo "$helptext"
+ interactive_menu
 else
  echo "Unsupported Option: $1"
  echo "run 'bazzite-rollback-helper help' for more details"


### PR DESCRIPTION
This PR transforms the `bazzite-rollback-helper` tool into a comprehensive, interactive system that provides guided menu selections for listing images, rebasing, and rollbacks. The enhancement maintains full backward compatibility while adding ugum choose options and menus similar to other `ujust` commands.

![brh-interactive](https://github.com/user-attachments/assets/88978020-0d21-42bd-b725-65cb5e10912c)


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
