### PR TITLE
feat(media-apps): use vacuumtube flatpak for Youtube

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -93,7 +93,7 @@ get-media-app service="":
         # Only proceed with Steam integration if installation was successful
         if [ "$installed" = true ]; then
             # Create launcher script for Steam
-            local script_path="$HOME/Applications/streaming_scripts/vacuumtube.sh"
+            local script_path="$HOME/Applications/streaming_scripts/Youtube.sh"
             echo "#!/bin/bash" > "$script_path"
             echo "flatpak run rocks.shy.VacuumTube" >> "$script_path"
             chmod +x "$script_path"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -75,6 +75,35 @@ get-media-app service="":
         steamos-add-to-steam "$script_path"
         echo "Added $1 to Steam successfully!"
     }
+    install_vacuumtube() {
+        local installed=false
+        if grep -q 'rocks.shy.VacuumTube' <<< $(flatpak list); then
+            echo "VacuumTube is already installed"
+            installed=true
+        else
+            echo "Installing VacuumTube..."
+            if flatpak install --user -y flathub rocks.shy.VacuumTube; then
+                echo "VacuumTube installed successfully"
+                installed=true
+            else
+                echo "Failed to install VacuumTube. Please try installing manually with:"
+                echo "flatpak install --user flathub rocks.shy.VacuumTube"
+            fi
+        fi
+        # Only proceed with Steam integration if installation was successful
+        if [ "$installed" = true ]; then
+            # Create launcher script for Steam
+            local script_path="$HOME/Applications/streaming_scripts/vacuumtube.sh"
+            echo "#!/bin/bash" > "$script_path"
+            echo "flatpak run rocks.shy.VacuumTube" >> "$script_path"
+            chmod +x "$script_path"
+            # Add to Steam
+            steamos-add-to-steam "$script_path"
+            echo "Added VacuumTube to Steam successfully!"
+        else
+            echo "Skipping Steam integration due to installation failure."
+        fi
+    }
     install_crunchyroll() {
         if grep -q 'it.mijorus.gearlever' <<< $(flatpak list); then
             wget \
@@ -183,7 +212,7 @@ get-media-app service="":
     # }
     # Process user choice
     case "$CHOICE" in
-        "YouTube") create_script "youtube" "youtube" ;;
+        "YouTube") install_vacuumtube ;;
         "Netflix") create_script "netflix" "netflix" ;;
         "Amazon Luna") create_script "amazon-luna" "amazonLuna" ;;
         "Disney Plus") create_script "disney-plus" "disneyPlus" ;;

--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -68,7 +68,7 @@ get-media-app service="":
     [ "$CHOICE" = "Exit" ] && { echo "Exiting..."; exit 0; }
     # Create webapp script and add to Steam
     create_script() {
-        local script_path="$HOME/Applications/streaming_scripts/$1.sh"
+        local script_path="$HOME/Applications/streaming_scripts/$1"
         echo "#!/bin/bash" > "$script_path"
         echo "\"$HOME/.local/bin/streaming-service-launcher\" \"$2\"" >> "$script_path"
         chmod +x "$script_path"
@@ -93,7 +93,7 @@ get-media-app service="":
         # Only proceed with Steam integration if installation was successful
         if [ "$installed" = true ]; then
             # Create launcher script for Steam
-            local script_path="$HOME/Applications/streaming_scripts/Youtube.sh"
+            local script_path="$HOME/Applications/streaming_scripts/Youtube"
             echo "#!/bin/bash" > "$script_path"
             echo "flatpak run rocks.shy.VacuumTube" >> "$script_path"
             chmod +x "$script_path"
@@ -138,7 +138,7 @@ get-media-app service="":
         # Only proceed with Steam integration if installation was successful
         if [ "$installed" = true ]; then
             # Create launcher script for Steam
-            local script_path="$HOME/Applications/streaming_scripts/plex-htpc.sh"
+            local script_path="$HOME/Applications/streaming_scripts/plex-htpc"
             echo "#!/bin/bash" > "$script_path"
             echo "flatpak run tv.plex.PlexHTPC" >> "$script_path"
             chmod +x "$script_path"
@@ -167,7 +167,7 @@ get-media-app service="":
         # Only proceed with Steam integration if installation was successful
         if [ "$installed" = true ]; then
             # Create launcher script for Steam
-            local script_path="$HOME/Applications/streaming_scripts/jellyfin-media-player.sh"
+            local script_path="$HOME/Applications/streaming_scripts/jellyfin-media-player"
             echo "#!/bin/bash" > "$script_path"
             echo "flatpak run com.github.iwalton3.jellyfin-media-player" >> "$script_path"
             chmod +x "$script_path"


### PR DESCRIPTION
replaces web app YouTube wrapper in `ujust get-media-app` with vacuumtube flatpak, and adds to steam.

also cleaned up names of scripts created to drop .sh so they look better in steam bpm

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
