### PR TITLE
fix: bazzite-yafti-launcher pointing to non-existent file

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-yafti-launcher
+++ b/system_files/desktop/shared/usr/libexec/bazzite-yafti-launcher
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Start yafti-go in background
-~/.local/bin/yafti-go &
+/usr/bin/yafti-go &
 
 # Launch browser using xdg-open, which will use the system's default browser
 xdg-open http://localhost:3169


### PR DESCRIPTION
Script /usr/libexec/bazzite-yafti-launcher pointing to ~/.local/bin/yafti-go (which doesn't exist) instead of /usr/bin/yafti-go

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
