### PR TITLE
fix: Hide emudeck in ujust and yafti

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -55,10 +55,10 @@ install-openrazer:
     echo "$OPENRAZER_CONFIGURATOR_APP is installed"
     echo "Please reboot to apply needed changes."
 
-alias get-emudeck := install-emudeck
+alias _get-emudeck := _install-emudeck
 
 # Install EmuDeck (https://www.emudeck.com/)
-install-emudeck:
+_install-emudeck:
     #!/usr/bin/bash
     set -eo pipefail
     remote_appimage_url="$(

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -18,11 +18,6 @@ screens:
         description: "A Decky plugin that swaps DLSS for FSR and adds framegen to non-framegen games"
         default: false
         script: "ujust get-framegen install-decky-plugin"
-      - id: "emudeck"
-        title: "EmuDeck"
-        description: "A utility for installing and configuring emulators on the Steam Deck"
-        default: false
-        script: "ujust get-emudeck"
       - id: "sunshine"
         title: "Sunshine"
         description: "A self-hosted game stream host for Moonlight"


### PR DESCRIPTION
hide emu deck in ujust and yafti for now, closes #2432

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
