### PR TITLE
feat(nvidia): add CachyOS script to switch to latest dlss preset

### DIFF
--- a/system_files/nvidia/shared/usr/bin/dlss-swapper
+++ b/system_files/nvidia/shared/usr/bin/dlss-swapper
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# Licensed under the GNU General Public License v3.0
 # Script from CachyOS
 # This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + updates the dlss dlls via ngx
 

--- a/system_files/nvidia/shared/usr/bin/dlss-swapper
+++ b/system_files/nvidia/shared/usr/bin/dlss-swapper
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+# Script from CachyOS
+# This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + updates the dlss dlls via ngx
+
+export PROTON_ENABLE_NGX_UPDATER=1
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+
+# applied variables, now execute the rest of the command
+exec "$@"

--- a/system_files/nvidia/shared/usr/bin/dlss-swapper-dll
+++ b/system_files/nvidia/shared/usr/bin/dlss-swapper-dll
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# Licensed under the GNU General Public License v3.0
 # Script from CachyOS
 # This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + skips ngx updater
 

--- a/system_files/nvidia/shared/usr/bin/dlss-swapper-dll
+++ b/system_files/nvidia/shared/usr/bin/dlss-swapper-dll
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# Script from CachyOS
+# This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + skips ngx updater
+
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+
+# applied variables, now execute the rest of the command
+exec "$@"


### PR DESCRIPTION
Adds CachyOS scripts ([1](https://github.com/CachyOS/CachyOS-Settings/blob/c60a32513719d8edc32182b739e501a9350c00e0/usr/bin/dlss-swapper)/[2](https://github.com/CachyOS/CachyOS-Settings/blob/c60a32513719d8edc32182b739e501a9350c00e0/usr/bin/dlss-swapper-dll)) to condense the launch command needed to update DLSS in proton games.

**from this:**
`PROTON_ENABLE_NGX_UPDATER=1 DXVK_NVAPI_DRS_SETTINGS=NGX_DLSS_SR_OVERRIDE=on,NGX_DLSS_RR_OVERRIDE=on,NGX_DLSS_FG_OVERRIDE=on,NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest,NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest %command%`

**to this:**
`dlss-swapper %command%`

------------------------------------------

`dlss-swapper %command%` - This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + updates the dlss dlls via ngx
`dlss-swapper-dll %command%` - This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + skips ngx updater

------------------------------------------
Please let me know if this script is in the wrong place or if I did not properly give credit.