### PR TITLE
feat: unset net.core.default_qdisc=fq sysctl

### DIFF
--- a/system_files/desktop/shared/usr/lib/sysctl.d/75-networking.conf
+++ b/system_files/desktop/shared/usr/lib/sysctl.d/75-networking.conf
@@ -1,4 +1,3 @@
-net.core.default_qdisc=fq
 net.ipv4.tcp_congestion_control=bbr
 net.ipv4.tcp_mtu_probing=1
 net.ipv6.conf.all.use_tempaddr=2


### PR DESCRIPTION
Remove the sysctl configuration setting the default `qdisc` to `fq`. For general purpose computers, the default `fq_codel` is recommended over `fq`. The `fq` qdisc is more suited to TCP-heavy, high-bandwidth servers (https://www.bufferbloat.net/projects/codel/wiki/#Binary:~:text=net.core.default_qdisc,fq_codel%20for%20routers.).

The `fq` qdisc was likely set as this used to be a requirement for the `bbr` tcp congestion control algorithm that Bazzite uses, but this hasn't been the case since Linux kernel 4.20
(https://github.com/google/bbr/blob/master/Documentation/bbr-quick-start.md#obtain-kernel-sources-with-tcp-bbr).

Leaving this field unset will cause the system to use the systemd default, which is currently `fq_codel`.