### PR TITLE
feat: add libinput-utils (#2838)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -240,6 +240,7 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
     dnf5 -y install \
+        libinput-utils \
         bazaar \
         iwd \
         twitter-twemoji-fonts \


### PR DESCRIPTION
Allows for easy measurement of input events and aids in calibration of touchscreens and other input devices.

Extremely small package with all dependencies included.