### PR TITLE
fix: Modify topgrade to only do a very limited subset of actions

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/topgrade.toml
+++ b/system_files/desktop/shared/usr/share/ublue-os/topgrade.toml
@@ -3,8 +3,8 @@ paths = ["/etc/ublue-os/topgrade.toml"]
 
 [misc]
 no_self_update = true
-disable = ["self_update", "toolbx", "containers", "shell", "waydroid", "git_repos", "chezmoi"]
-ignore_failures = ["distrobox", "flatpak", "brew_cask", "brew_formula", "nix", "pip3", "helm", "home_manager", "firmware"]
+only = ["system", "flatpak", "brew_cask", "brew_formula", "firmware", "custom_commands"]
+ignore_failures = ["flatpak", "brew_cask", "brew_formula", "firmware", "custom_commands"]
 assume_yes = true
 no_retry = false
 


### PR DESCRIPTION
Makes topgrade only update the system (via rpm-ostree), flatpak, brew, fwupd, and the custom commands we set up.
All but system are marked as non-fatal for updates.