### PR TITLE
fix(bazaar): Run bazaar with the opengl backend

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -923,7 +923,7 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
-    sed -i 's|^Exec=bazaar window --auto-service$|Exec=env GDK_BACKEND=x11 bazaar window --auto-service|' /usr/share/applications/io.github.kolunmi.Bazaar.desktop && \
+    sed -i 's|^Exec=bazaar window --auto-service$|Exec=env GSK_RENDERER=opengl bazaar window --auto-service|' /usr/share/applications/io.github.kolunmi.Bazaar.desktop && \
     echo "import \"/usr/share/ublue-os/just/95-bazzite-nvidia.just\"" >> /usr/share/ublue-os/justfile && \
     if grep -q "silverblue" <<< "${BASE_IMAGE_NAME}"; then \
       mkdir -p "/usr/share/ublue-os/dconfs/nvidia-silverblue/" && \


### PR DESCRIPTION
This allows to use by default the bazaar wayland backend which doesn't work on nvidia + vulkan
Instead of forcing the x11 backend.

