### PR TITLE
fix: don't show discover search results

### DIFF
--- a/system_files/desktop/kinoite/etc/xdg/krunnerrc
+++ b/system_files/desktop/kinoite/etc/xdg/krunnerrc
@@ -1,0 +1,3 @@
+[Plugins]
+krunner_appstreamEnabled=false
+bazaarrunnerEnabled=true


### PR DESCRIPTION
This is the same as toggling the button in Plasma Search settings
![image](https://github.com/user-attachments/assets/181a79f9-11af-4aa3-b11d-148229d0336c)
