### PR TITLE
fix: don't show discover search results

### DIFF
--- a/system_files/desktop/kinoite/etc/xdg/krunnerrc
+++ b/system_files/desktop/kinoite/etc/xdg/krunnerrc
@@ -1,0 +1,3 @@
+[Plugins]
+krunner_appstreamEnabled=false
+bazaarrunnerEnabled=true


### PR DESCRIPTION
This is the same as toggling the button in Plasma Search settings

related:
https://github.com/ublue-os/aurora/pull/585/commits/06d32d548ec726e03034a422c40ddf6d1851d357

![image](https://github.com/user-attachments/assets/eeefc099-5d8a-4293-883c-9c585a89b7c6)

