### PR TITLE
fix(kde): set bazzite wallpaper on SDDM

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -717,7 +717,10 @@ RUN --mount=type=cache,dst=/var/cache \
             gnome-shell-extension-caribou-blocker \
             sddm && \
         dnf5 -y remove \
-            malcontent-control \
+            malcontent-control && \
+        ln -sf /usr/share/wallpapers/convergence.png /usr/share/backgrounds/default.jxl && \
+        ln -sf /usr/share/wallpapers/convergence.png /usr/share/backgrounds/default-dark.jxl && \
+        rm -f /usr/share/backgrounds/default.xml \
     ; fi && \
     /ctx/cleanup
 


### PR DESCRIPTION
This replaces the symlinks for the default Fedora wallpapers.
Fedora's SDDM config uses `/usr/share/backgrounds/default.jxl`,
they changed this to jxl with F42.

gnome-deck also uses SDDM so I did the same thing there as well

![image](https://github.com/user-attachments/assets/0d198cd7-0dec-47f2-85ab-3fc8a815e36d)
