### PR TITLE
feat(bazaar): add LACT to utilities

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -181,6 +181,7 @@ sections:
       - io.github.rfrench3.scopebuddy-gui
       - io.github.trigg.discover_overlay
       - com.github.Alcaro.Flips
+      - io.github.ilya_zlobintsev.LACT
       - io.github.thetumultuousunicornofdarkness.cpu-x
       - io.github.arunsivaramanneo.GPUViewer
       - dev.deedles.Trayscale


### PR DESCRIPTION
Adds LACT to utilities section of bazaar

------------------------------------------

Wasn't sure if LACT was omitted because of the ujust command but figured I would raise this in case it was. Will close if that was indeed the case.

If LACT isn't added because of what I mentioned above maybe it makes sense to investigate if bazaar could include a way to add pre/post install actions where we can emulate the ujust command.