### PR TITLE
feat: Add gameclass tool for arbitrary game icons

### DIFF
--- a/system_files/desktop/shared/usr/bin/gameclass
+++ b/system_files/desktop/shared/usr/bin/gameclass
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if (( $# == 0 )); then
-	echo -e "No arguments provided.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
+	echo -e "No arguments provided.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass \033[1m[COMMAND]\033[0m..."
 	exit 1
 else
 	if [[ -z ${GAMECLASS} ]]; then
-		echo -e "No environment variable set.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
+		echo -e "No environment variable set.\n\nUsage: env \033[1mGAMECLASS='<executable>=<window class>'\033[0m gameclass [COMMAND]..."
 		exit 1
 	fi
 fi
@@ -14,7 +14,7 @@ EXE="$( echo "$GAMECLASS" | awk 'BEGIN { FS = "=" } ; { print $1 }' )"
 WM_CLASS="$( echo "$GAMECLASS" | awk 'BEGIN { FS = "=" } ; { print $2 }' )"
 
 if [[ -z "$EXE" ]] || [[ -z "$WM_CLASS" ]]; then
-	echo -e "Incorrect environment variable formatting.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
+	echo -e "Incorrect environment variable formatting.\n\nUsage: env GAMECLASS='\033[1m<executable>=<window class>\033[0m' gameclass [COMMAND]..."
 	exit 1
 fi
 

--- a/system_files/desktop/shared/usr/bin/gameclass
+++ b/system_files/desktop/shared/usr/bin/gameclass
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z $( echo "$@" ) ]]; then
+if [[ $# -eq 0 ]]; then
 	echo -e "No arguments provided.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
 	exit 1
 else

--- a/system_files/desktop/shared/usr/bin/gameclass
+++ b/system_files/desktop/shared/usr/bin/gameclass
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if [[ -z $( echo "$@" ) ]]; then
+	echo -e "No arguments provided.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
+	exit 1
+else
+	if [[ -z ${GAMECLASS} ]]; then
+		echo -e "No environment variable set.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
+		exit 1
+	fi
+fi
+
+EXE="$( echo "$GAMECLASS" | awk 'BEGIN { FS = "=" } ; { print $1 }' )"
+WM_CLASS="$( echo "$GAMECLASS" | awk 'BEGIN { FS = "=" } ; { print $2 }' )"
+
+if [[ -z "$EXE" ]] || [[ -z "$WM_CLASS" ]]; then
+	echo -e "Incorrect environment variable formatting.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
+	exit 1
+fi
+
+# Adapted from — https://github.com/tactikauan/thcrap-steam-proton-wrapper/blob/3adb608f7aa58323f441aedbe40a3b5096fe9d23/thcrap_proton
+if [[ -z "$COMMAND" ]]; then
+	shift $((OPTIND -1))
+        COMMAND=''
+        # Quote all arguments which contain whitespace
+        for i in "$@"; do
+            [[ $i =~ ( ) ]] && i=${i@Q}
+            COMMAND="$COMMAND $i"
+        done
+fi
+COMMAND=$(printf %s "$COMMAND")
+
+function get_exe_window {
+	local windowlist ; windowlist=$( wmctrl -l -p )
+	local windowcount ; windowcount=$( echo "$windowlist" | wc -l )
+
+	for (( n = 1 ; n <= windowcount ; n++ )); do
+		local window ; window=$( echo "$windowlist" | sed -n "$n"p )
+
+		local wid ; wid=$( echo "$window" | awk '{ print $1 }' )
+		local pid ; pid=$( echo "$window" | awk '{ print $3 }' )
+
+		local cmd ; cmd=$( cat /proc/"$pid"/cmdline | tr -d '\0' )
+		unset -v WID
+		if [[ "$cmd" =~ $EXE ]]; then
+			WID="$wid"
+		fi
+	done
+}
+
+function set_class {
+	if [[ -z $WID ]]; then
+		:
+	else
+		if [[ $( xdotool getwindowclassname "$WID" ) = $WM_CLASS ]]; then
+			:
+		else
+			xdotool set_window --class "$WM_CLASS" "$WID"
+			echo "Set WM_CLASS."
+		fi
+	fi
+}
+
+function window_watcher {
+	while sleep 1; do
+		get_exe_window
+		set_class
+	done
+}
+
+set -m
+
+window_watcher &
+GAMECLASS_PID="$!"
+
+# Let it rip.
+sh -c "$COMMAND"
+
+# Let it die.
+kill -- -$GAMECLASS_PID

--- a/system_files/desktop/shared/usr/bin/gameclass
+++ b/system_files/desktop/shared/usr/bin/gameclass
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $# -eq 0 ]]; then
+if (( $# == 0 )); then
 	echo -e "No arguments provided.\n\nUsage: env GAMECLASS='<executable>=<window class>' gameclass [COMMAND]..."
 	exit 1
 else


### PR DESCRIPTION
### Background

This tool is a hacky workaround for this issue, particularly plaguing GNOME:

![Image showing a missing window icon](https://github.com/user-attachments/assets/774a301d-ade6-45d1-bb99-32cb4f58537d)

Because GNOME has deprecated and removed icon hints, to my knowledge, all windows missing a matching `StartupWMClass` in a `.desktop` file will use this default icon and a generic app name. 

While this is also the case with the shortcuts Steam creates by default (during installation or by right-clicking the game > Manage > Add desktop shortcut), it can be manually fixed. For native games, you can add a `StartupWMClass=<executable-name>` line to a `.desktop`. For Proton games, you can add `StartupWMClass=steam_app_<appid>`, due to Proton automatically setting this `WM_CLASS` with the game's native Steam `appid`.

The problem arises on non-Steam Windows games, installed through Lutris or Heroic. As they're not Steam apps, they do not possess an `appid` for Proton to source, so they'll usually have a window with a `steam_app_default` or `steam_app_0` generic `WM_CLASS`. Because they're not individualized, from what I can gather, it's impossible to have a matching `.desktop` for more than one game — meaning no game window icons at all on your desktop, at least under GNOME.

### The "Solution"

To work around that, this tool queries the window list every second using `wmctrl`, reads the `cmdline` for a given window PID, and then applies an arbitrary `WM_CLASS` using `xdotool`, if the `cmdline` has a match for a given string. I have no idea if this is a good way of doing this, but it seems to work — at least for X11 applications.

Do note that I have no experience writing tools like this with Bash, so this may be naive or poorly written. If this isn't fit for Bazzite due to that, or unfit in general, I'll happily modify this PR or retract it altogether.

## Example Usage

![Image showing an example .desktop file, with the StartupWMClass property highlighted](https://github.com/user-attachments/assets/898f5e0b-a988-40fd-8d2a-3c03736f1109)
![Image showing the setup for gameclass under Lutris](https://github.com/user-attachments/assets/fa0dd774-829d-43fa-8969-b6b6853c8d15)
![Image showing the setup for gameclass under Heroic](https://github.com/user-attachments/assets/528b7ad2-604c-4dad-8738-3988445b8124)

## Result

![Image showing Thief Gold with a matching window icon](https://github.com/user-attachments/assets/03901eb5-5ac3-441c-b430-fc7eb94766eb)
![Image showing Thief Gold with a matching icon and app name in the GNOME Dash](https://github.com/user-attachments/assets/c5ecedc3-536b-43e3-8b65-9c55ea5eaeb3)