### PR TITLE
chore:Removed emacs and neovide from blocklist

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/blocklist.txt
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/blocklist.txt
@@ -15,8 +15,6 @@ com.jetbrains.RubyMine
 com.jetbrains.RustRover
 io.neovim.nvim
 org.vim.Vim
-dev.neovide.neovide
 io.github.zyedidia.micro
 com.helix_editor.Helix
-org.gnu.emacs
 app.devsuite.Ptyxis


### PR DESCRIPTION
Neovide is a UI and absolutly should not be installed from Brew, zero reason to make it blocked as its not a terminal editor 

Emacs has a UI as well, which some people use

(Vim has a UI but maybe that one can stay blocked)