### PR TITLE
feat: Expose more HDMI-CEC options

### DIFF
--- a/system_files/desktop/shared/usr/bin/cec-control
+++ b/system_files/desktop/shared/usr/bin/cec-control
@@ -9,15 +9,40 @@ CEC_WAKE=${CEC_WAKE:-true}
 CEC_SETSOURCE=${CEC_SETSOURCE:-true}
 CEC_ONPOWEROFF_STANDBY=${CEC_ONPOWEROFF_STANDBY:-true}
 CEC_ONSLEEP_STANDBY=${CEC_ONSLEEP_STANDBY:-false}
+CEC_OSD_NAME=${CEC_OSD_NAME:-$(hostname)}
+
+args=()
+args+=( "--single-command" )
+args+=( "--log-level 1" )
+args+=( "--osd-name $CEC_OSD_NAME" )
+
+# Conditionally apply a port number override if one is set
+[[ -n "$CEC_PORT_NUMBER" ]] && args+=( "--port $CEC_PORT_NUMBER" )
+
+# Helper functions to send activate and standby messages to the CEC bus
+# We loop through TVIDs to cover cases where you might have multiple devices
+# to control (eg: a TV, an audio system, and some sort of tuner device)
+function perform_standby {
+    for id in $CEC_TVID; do
+        echo "standby $id" | cec-client ${args[@]}
+    done
+}
+
+function perform_activate {
+    for id in $CEC_TVID; do
+        echo "on $id" | cec-client ${args[@]}
+    done
+
+    if [ "$CEC_SETSOURCE" = true ]; then
+        echo "as" | cec-client ${args[@]}
+    fi
+}
 
 # Run specified actions
 if [ "${ACTION}" = "onboot" ] && [ "$CEC_WAKE" = true ]; then
-    echo "on $CEC_TVID" | cec-client -s -d 1
-    if [ "$CEC_SETSOURCE" = true ]; then
-            echo "as" | cec-client -s -d 1
-    fi
+    perform_activate
 elif [ "${ACTION}" = "onpoweroff" ] && [ "$CEC_ONPOWEROFF_STANDBY" = true ]; then
-    echo "standby $CEC_TVID" | cec-client -s -d 1
+    perform_standby
 elif [ "${ACTION}" = "onsleep" ] && [ "$CEC_ONSLEEP_STANDBY" = true ]; then
-    echo "standby $CEC_TVID" | cec-client -s -d 1
+    perform_standby
 fi


### PR DESCRIPTION
This PR exposes some of the options that are available to `cec-client` via the config file in `/etc/default/cec-control` so that you can control more aspects of your CEC settings without needing to fork the project and maintain your own image.

Namely, I'm doing the following:

- Exposing a new option, `CEC_OSD_NAME`. This controls what your TV will display when following commands from your device. In my case, this defaults to `CECTester` for my PulseEight adaptor module. By default, this new setting will use the system's hostname, falling back to the word "bazzite".

  This is nifty as now, when navigating around your TV settings, "bazzite" will be shown alongside the input bound to your HTPC.

- Exposing a new option, `CEC_PORT_NUMBER`. This setting tells `cec-client` to override the learned HMDI port number. This is critical for the `as` command as it's telling your TV which port to activate. Sometimes your CEC adaptor will get this wrong (looking at you, PulseEight module), and the `as` command will activate the wrong source. If this value is empty, it will be omitted from the `cec-client` arguments list.

- Allow `CEC_TVID` to accept multiple space-separated values. If you have a complex AV system, you may have multiple devices you need to `on` or `standby` in concert, like a separate audio system or tuner.

Lastly, this includes a couple of quality of life improvements:

- The arguments list for `cec-client` has been swapped for a Bash array using long-form argument names so that anyone reading the source doesn't need to have a copy of `cec-client` handy to understand what the `-s` and `-d 1` arguments do.

- The commands to issue wake and sleep commands have been moved to Bash functions to keep the chained set of conditionals at the end of the file easy to understand.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
