### PR TITLE
chore(KDE): remove patched kf6-kio from terra

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -425,17 +425,6 @@ RUN --mount=type=cache,dst=/var/cache \
             gnome-disk-utility \
             krunner-bazaar \
             ptyxis && \
-        dnf5 -y swap \
-        --repo=terra-extras \
-            kf6-kio kf6-kio && \
-        dnf5 versionlock add \
-            kf6-kio-core \
-            kf6-kio-core-libs \
-            kf6-kio-doc \
-            kf6-kio-file-widgets \
-            kf6-kio-gui \
-            kf6-kio-widgets \
-            kf6-kio-widgets-libs && \
         dnf5 -y remove \
             plasma-welcome \
             plasma-welcome-fedora \


### PR DESCRIPTION
this patch is upstream now and included in frameworks 6.16
https://invent.kde.org/frameworks/kio/-/commits/v6.16.0?ref_type=tags

switcheroo-control has to stay for now as upstream hasn't made a release in 3 years, but this finally got merged
https://gitlab.freedesktop.org/hadess/switcheroo-control/-/merge_requests/69