### PR TITLE
fix(deck): Fix Ally / Ally X HDMI audio cutting out.

### DIFF
--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally rc71l_rc71l/wireplumber.conf.d/51-preferHDMI.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally rc71l_rc71l/wireplumber.conf.d/51-preferHDMI.conf
@@ -9,6 +9,7 @@ monitor.alsa.rules = [
       update-props = {
          priority.driver = 1100
          priority.session = 1100
+         api.alsa.headroom = 1024
       }
     }
   }

--- a/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/51-preferHDMI.conf
+++ b/system_files/deck/shared/usr/share/wireplumber/hardware-profiles/asustek computer inc.-rog ally x rc72la_rc72la/wireplumber.conf.d/51-preferHDMI.conf
@@ -9,6 +9,7 @@ monitor.alsa.rules = [
       update-props = {
          priority.driver = 1100
          priority.session = 1100
+         api.alsa.headroom = 1024
       }
     }
   }


### PR DESCRIPTION
Add headroom to the HDMI configs to prevent audio from cutting out.