### PR TITLE
fix: force-wol script can handle multiple network interfaces

### DIFF
--- a/system_files/desktop/shared/usr/libexec/force-wol
+++ b/system_files/desktop/shared/usr/libexec/force-wol
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
-INTERFACE=$(ip link show | awk '/state UP/ {print $2}' | tr -d ':' | grep -E '^(en|eth)')
-if [ -n "$INTERFACE" ]; then
-  /sbin/ethtool -s $INTERFACE wol g
+INTERFACES=$(ip link show | awk '/state UP/ {print $2}' | tr -d ':' | grep -E '^(en|eth)')
+if [ -n "$INTERFACES" ]; then
+  for INTERFACE in $INTERFACES; do
+    /sbin/ethtool -s $INTERFACE wol g
+  done
 fi


### PR DESCRIPTION
The current script fails if there are multiple connected networks because $INTERFACE contains a string with all connected networks. Therefore I've changed the script to iterate all detected interfaces and enable wol for each of them.