### PR TITLE
feat(just): Add setup-realtime

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
@@ -303,7 +303,7 @@ setup-realtime:
       rpm-ostree install realtime-setup --apply-live
       sudo systemctl enable realtime-entsk
       sudo systemctl enable realtime-setup
-      if ! grep -q realtime /etc/group; then
+      if ! [[ $( cat /etc/group ) =~ "realtime" ]]; then
         grep -E '^realtime:' /usr/lib/group | sudo tee -a /etc/group
       fi
       sudo usermod -aG realtime "$USER"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
@@ -297,3 +297,15 @@ setup-virtual-surround ACTION="":
 restart-pipewire:
     echo "Restarting pipewire..."
     systemctl --user restart pipewire.service
+
+# Setup system for realtime scheduling
+setup-realtime:
+      rpm-ostree install realtime-setup --apply-live
+      sudo systemctl enable realtime-entsk
+      sudo systemctl enable realtime-setup
+      if ! grep -q realtime /etc/group; then
+        grep -E '^realtime:' /usr/lib/group | sudo tee -a /etc/group
+      fi
+      sudo usermod -aG realtime "$USER"
+	  rpm-ostree kargs --append-if-missing=threadirqs
+      echo "Please reboot to apply your changes."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
@@ -303,6 +303,8 @@ setup-realtime:
       rpm-ostree install realtime-setup --apply-live
       sudo systemctl enable realtime-entsk
       sudo systemctl enable realtime-setup
+	  echo "dev.hpet.max-user-freq = 3072" | sudo tee /etc/sysctl.d/65-set-hpet.conf
+	  echo "w! /sys/class/rtc/rtc0/max_user_freq - - - - 3072" | sudo tee /etc/tmpfiles.d/clockrate.conf
       if ! [[ $( cat /etc/group ) =~ "realtime" ]]; then
         grep -E '^realtime:' /usr/lib/group | sudo tee -a /etc/group
       fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
@@ -303,8 +303,8 @@ setup-realtime:
       rpm-ostree install realtime-setup --apply-live
       sudo systemctl enable realtime-entsk
       sudo systemctl enable realtime-setup
-	  echo "dev.hpet.max-user-freq = 3072" | sudo tee /etc/sysctl.d/65-set-hpet.conf
-	  echo "w! /sys/class/rtc/rtc0/max_user_freq - - - - 3072" | sudo tee /etc/tmpfiles.d/clockrate.conf
+      echo "dev.hpet.max-user-freq = 3072" | sudo tee /etc/sysctl.d/65-set-hpet.conf
+      echo "w! /sys/class/rtc/rtc0/max_user_freq - - - - 3072" | sudo tee /etc/tmpfiles.d/clockrate.conf
       if ! [[ $( cat /etc/group ) =~ "realtime" ]]; then
         grep -E '^realtime:' /usr/lib/group | sudo tee -a /etc/group
       fi


### PR DESCRIPTION
### Background

Configures the system for realtime task scheduling, sacrificing some performance for consistent latencies — useful primarily for audio engineering and production applications on the desktop. This should allow audio processing to be scheduled with very tight latencies — in the single digit millisecond range — without crackling or other forms of distortion (known in the Linux audio space as Xruns).

In the aforementioned use cases, even just a dozen milliseconds could disrupt the user in playing a MIDI instrument for sequencing, monitoring a microphone's output through headphones, or simply playing back complex audio projects.

### Implementation

Fedora maintains a [realtime-setup package](https://src.fedoraproject.org/rpms/realtime-setup), layered by this script with `--apply-live` to enable its included systemd services. The udev rules added for threadirqs and `/dev/rtc` access are given to the `realtime` group, which currently needs to be [explicitly added](https://docs.fedoraproject.org/en-US/fedora-silverblue/troubleshooting/#_unable_to_add_user_to_group) to `/etc/groups` in Atomic Fedora.

As PREEMPT_RT has been in the mainline Linux kernel since 6.12, the only change required to equate modern kernels to the former RT kernel builds is the inclusion of the `threadirqs` kernel argument; given [Bazzite enables full preemption by default](https://github.com/ublue-os/bazzite/blob/6ee1967840f2707a14c03a26412181d46eaa6d78/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup#L176).

### Development Note (Work in Progress)

This is currently in a proof of concept stage. I still plan on adding an installation prompt along with a reversal script.

**Supersedes #1726.**