### PR TITLE
fix(pin): downgrade libdex to 0.9.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -242,6 +242,7 @@ RUN --mount=type=cache,dst=/var/cache \
         https://github.com/bazzite-org/cicpoffs/releases/download/master/cicpoffs.rpm && \
     dnf5 -y install \
         bazaar \
+        libdex-0.9.1 \
         iwd \
         twitter-twemoji-fonts \
         google-noto-sans-cjk-fonts \


### PR DESCRIPTION
fix bazaar crashes under VMs and low spec PCs

https://github.com/ublue-os/aurora/pull/713/
https://github.com/ublue-os/bluefin/pull/2794

feel free to move somewhere else in the file...          

