### PR TITLE
fix: Add window icon for gamescope in GNOME

### DIFF
--- a/system_files/desktop/silverblue/usr/share/applications/gamescope.desktop
+++ b/system_files/desktop/silverblue/usr/share/applications/gamescope.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Icon=input-gaming-symbolic
+Name=Gamescope
+NoDisplay=true
+StartupWMClass=gamescope


### PR DESCRIPTION
While icon hints aren't currently supported by GNOME, we can still set a generic 'game' icon through a `.desktop` file with `NoDisplay=true`. See the Dash screenshots below:

## Before

<img width="215" height="169" alt="image" src="https://github.com/user-attachments/assets/a31fa77b-120b-40d2-a990-6baa0c03463a" />

## After

<img width="215" height="169" alt="image" src="https://github.com/user-attachments/assets/39aea1b9-d193-41cb-8188-7db2f9a3bd02" />