### PR TITLE
chore: Update Wootility URL

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -105,7 +105,7 @@ install-boxtron: distrobox-check-fedora
 alias get-wootility := install-wootility
 
 # Install Wootility for configuring Wooting Keyboards
-install-wootility: (_install_appimage_file "https://api.wooting.io/public/wootility/download?os=linux&branch=lekker" "wootility.Appimage")
+install-wootility: (_install_appimage_file "https://api.wooting.io/public/wootility/download?os=linux" "wootility.Appimage")
 
 # Install Adwaita-for-Steam theme for CSS Loader (https://github.com/tkashkin/Adwaita-for-Steam)
 install-adwaita-for-steam:


### PR DESCRIPTION
Wooting no longer uses the lekker branch as part of their URL. This results in:

https://api.wooting.io/public/wootility/download?os=linux&branch=lekker downloading 4.7.4

whereas

https://api.wooting.io/public/wootility/download?os=linux&branch=lekker downloads 5.6 which is the latest.

This changes fixes that issue to default to latest instead.

