### PR TITLE
feat: Oxidize

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -118,6 +118,17 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf5 -y config-manager setopt "*staging*".exclude="scx-scheds kf6-* mesa* mutter* rpm-ostree* systemd* gnome-shell gnome-settings-daemon gnome-control-center gnome-software libadwaita tuned*" && \
     /ctx/cleanup
 
+# Oxidize
+RUN --mount=type=cache,dst=/var/cache \
+    --mount=type=cache,dst=/var/log \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=tmpfs,dst=/tmp \
+    dnf5 -y install sudo-rs && \
+    ln -sf /usr/bin/su-rs /usr/bin/su && \
+    ln -sf /usr/bin/sudo-rs /usr/bin/sudo && \
+    ln -sf /usr/bin/visudo-rs /usr/bin/visudo && \
+    /ctx/cleanup
+
 # Install kernel
 RUN --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \


### PR DESCRIPTION
This commit swaps us to sudo-rs, following Ubuntu's lead. This is something I've been testing a long while now with no regressions. This only covers sudo as the coreutils swap is not yet ready for mainstream use.

See: https://thehackernews.com/2025/07/critical-sudo-vulnerabilities-let-local.html for reasoning as to why we might want to do this ahead of our upstream.