### PR TITLE
fix(ayaneo): workaround for buggy wifi/sleep interaction on first-gen Ayaneo Air

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/kmod-sleep-workaround@.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/kmod-sleep-workaround@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Unloads/reloads %i kernel module before/after sleep for devices where it cause sleep/wake issues
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/bin/rmmod %i
+ExecStop=-/usr/bin/modprobe %i
+
+[Install]
+WantedBy=sleep.target

--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -218,6 +218,11 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   systemctl enable --now ds-inhibit.service
 fi
 
+# Enable workaround for buggy wifi sleep interaction on first gen Ayaneo Air devices
+if [[ ":AIR Pro:AIR:" =~ ":$SYS_ID:" ]]; then
+  systemctl enable --now kmod-sleep-workaround@mt7921e.service
+fi
+
 # FSTAB CONFIGURATION
 if [[ ! -e /etc/ublue-os/.fstab_adjusted.flag && $(grep "compress=zstd" /etc/fstab) ]]; then
     echo "Applying fstab param adjustments"


### PR DESCRIPTION
First-gen Ayaneo Air devices appear to have a bug where their BIOS doesn't interact well with the Wi-Fi chip around sleep and wake. Sleeping and waking the device will cause error messages in dmesg and unreliable and buggy wakeup, and after wakeup the wifi interface will appear to have dissappeared.

The workaround for this issue is to remove the Wi-Fi driver's kernel module just before going to sleep and readding it when waking.This PR adds this workaround and enables it automatically on these affected devices. A version of this workaround [exists in ChimeraOS as well](https://github.com/ChimeraOS/device-quirks/blob/ee8e66690eb460ec8b13b56eabb7388298e0972f/etc/device-quirks/systemd-suspend-mods.conf#L3).

I tested this on a Ayaneo Air Pro (5560U model) and this enables sleep to work reliably! 

Fixes #2134 