### PR TITLE
fix: move waydroid script repo to upstream, implement renovate with specific commit pin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,5 +17,16 @@
       "matchDepTypes": ["container"],
       "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
     },
+    {
+      "description": "Track waydroid_script upstream commits",
+      "matchFileNames": ["**/82-bazzite-waydroid.just"],
+      "customType": "regex",
+      "matchStrings": [
+        "git checkout (?<currentValue>[a-f0-9]{7,40})"
+      ],
+      "datasourceTemplate": "github-commits",
+      "depNameTemplate": "casualsnek/waydroid_script",
+      "extractVersionTemplate": "^(?<version>.*)$"
+    }
   ]
 }

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -42,23 +42,23 @@ install-coolercontrol:
 
 # Install JetBrains Toolbox | https://www.jetbrains.com/toolbox-app/
 install-jetbrains-toolbox:
-     #!/usr/bin/env bash
-    pushd "$(mktemp -d)"
-    echo "Get latest JetBrains Toolbox version"
-    # Get the json with latest releases
-    curl -sSfL -o releases.json "https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release"
-    # Extract information
-    BUILD_VERSION=$(jq -r '.TBA[0].build' ./releases.json)
-    DOWNLOAD_LINK=$(jq -r '.TBA[0].downloads.linux.link' ./releases.json)
-    CHECKSUM_LINK=$(jq -r '.TBA[0].downloads.linux.checksumLink' ./releases.json)
-    echo "Installing JetBrains Toolbox ${BUILD_VERSION}"
-    curl -sSfL -O "${DOWNLOAD_LINK}"
-    curl -sSfL "${CHECKSUM_LINK}" | sha256sum -c
-    tar zxf jetbrains-toolbox-"${BUILD_VERSION}".tar.gz
-    mkdir -p $HOME/.local/share/JetBrains/ToolboxApp/
-    mv jetbrains-toolbox-"${BUILD_VERSION}"/* $HOME/.local/share/JetBrains/ToolboxApp/
-    echo "Launching JetBrains Toolbox"
-    $HOME/.local/share/JetBrains/ToolboxApp/bin/jetbrains-toolbox &
+    #!/usr/bin/env bash
+     pushd "$(mktemp -d)"
+     echo "Get latest JetBrains Toolbox version"
+     # Get the json with latest releases
+     curl -sSfL -o releases.json "https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release"
+     # Extract information
+     BUILD_VERSION=$(jq -r '.TBA[0].build' ./releases.json)
+     DOWNLOAD_LINK=$(jq -r '.TBA[0].downloads.linux.link' ./releases.json)
+     CHECKSUM_LINK=$(jq -r '.TBA[0].downloads.linux.checksumLink' ./releases.json)
+     echo "Installing JetBrains Toolbox ${BUILD_VERSION}"
+     curl -sSfL -O "${DOWNLOAD_LINK}"
+     curl -sSfL "${CHECKSUM_LINK}" | sha256sum -c
+     tar zxf jetbrains-toolbox-"${BUILD_VERSION}".tar.gz
+     mkdir -p $HOME/.local/share/JetBrains/ToolboxApp/
+     mv jetbrains-toolbox-"${BUILD_VERSION}"/* $HOME/.local/share/JetBrains/ToolboxApp/
+     echo "Launching JetBrains Toolbox"
+     $HOME/.local/share/JetBrains/ToolboxApp/bin/jetbrains-toolbox &
 
 alias get-steamcmd := install-steamcmd
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
@@ -33,7 +33,8 @@ setup-waydroid ACTION="":
       cp /usr/share/applications/waydroid-container-restart.desktop ~/.local/share/applications
       echo "Waydroid has been initialized, please run waydroid once before you Configure Waydroid"
     elif [[ "${OPTION,,}" =~ ^configure ]]; then
-      git clone https://github.com/ublue-os/waydroid_script.git --depth 1 /tmp/waydroid_script
+      git clone https://github.com/casualsnek/waydroid_script.git /tmp/waydroid_script
+      cd /tmp/waydroid_script && git checkout 3e344b360f64f4a417c4f5e9a3b1aae3da9fdfb9
       python -m venv /tmp/waydroid_script/venv
       source /tmp/waydroid_script/venv/bin/activate
       sudo pip install -r /tmp/waydroid_script/requirements.txt


### PR DESCRIPTION
Closes #3006

Use upstream waydroid_script with pinned commit instead of ublue fork

- Updates `configure-waydroid` to clone and checkout a specific upstream commit
- Adds Renovate config to automate PRs for future commit updates via `github-commits` 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
