### PR TITLE
chore: add just syntax check on PRs

### DIFF
--- a/.github/workflows/just-syntax-check.yml
+++ b/.github/workflows/just-syntax-check.yml
@@ -1,0 +1,14 @@
+name: Just Syntax Check
+
+on: [pull_request]
+
+jobs:
+  just-syntax-check:
+    name: Check Just Syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check just syntax
+        uses: ublue-os/just-action@bda593098a84a84973b002b4377709166a68be52 # v2


### PR DESCRIPTION
With this action, all PRs and subsequent commits are subject to just syntax checks.

Fixes an issue where build action stops auto running after a few commits after PR is opened, and a PR could merge when subsequent commits break just syntax, causing testing / main branch builds to fail.

Now, this should prevent broken just syntax from merging in all cases.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
