### PR TITLE
fix: rm decky ujust default to enable choose TUI

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -271,7 +271,7 @@ configure-watchdog ACTION="":
     fi
 
 # Install and configure Decky Loader (https://github.com/SteamDeckHomebrew/decky-loader) and plugins for alternative handhelds
-setup-decky ACTION="install":
+setup-decky ACTION="":
     #!/usr/bin/bash
     if [[ $(id -u) -eq 0 ]]; then
         echo >&2 "ERROR: Do not run this with sudo"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -13,9 +13,9 @@ screens:
         description: "A Decky plugin that lets you see Bazzite changelogs in Game Mode."
         default: false
         script: "ujust get-decky-bazzite-buddy"
-      - id: "decky-framegen-plus"
-        title: "Decky Framegen Plus"
-        description: "A Decky plugin that swaps DLSS for FSR and adds framegen to non-framegen games"
+      - id: "decky-framegen"
+        title: "Decky Framegen"
+        description: "A Decky plugin that uses OptiScaler to improve upscaling and add framegen to non-framegen games"
         default: false
         script: "ujust get-framegen install-decky-plugin"
       - id: "decky-lossless-scaling"


### PR DESCRIPTION
We have a `ugum` choose TUI menu for decky ujust, but we had a default action of "install" which prevented exposing it to the user

simple adj to allow users to see the menu, but they can still pass in an arg to expedite uninstall or prerelease install

<img width="345" height="156" alt="image" src="https://github.com/user-attachments/assets/f238ac82-9b16-44e8-827e-24722e821815" />

Also, ensured yafti still works (already passes install arg), and rm the "Plus" ref from decky framegen while I am at it, as that alt version no longer applies to optiscaler based version. Updated description accordingly

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
