### PR TITLE
feat: Gigabyte motherboard wake hw fix, ujust for manual overrides

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/gigabyte-sleep-fix.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/gigabyte-sleep-fix.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Workaround for Gigabyte BIOS sleep/wakeup bug
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'if grep "GPP0" /proc/acpi/wakeup | grep -q "enabled"; then echo "GPP0" > /proc/acpi/wakeup; fi'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -7,7 +7,7 @@ IMAGE_FLAVOR=$(jq -r '."image-flavor"' < $IMAGE_INFO)
 FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 
 # SCRIPT VERSION
-HWS_VER=59
+HWS_VER=60
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VER_FILE)
 
@@ -307,6 +307,23 @@ EOF
       surface_kbd
 EOF
   fi
+fi
+
+# GIGABYTE MOTHERBOARD SLEEP/WAKEUP FIX
+# Fix for Gigabyte motherboards where GPP0 ACPI wakeup source causes sleep/wake issues
+# The original fix was discovered by DAK404 and can be found at:
+# https://github.com/DAK404/OpenSUSE-Setup-Scripts/blob/main/Scriptlets/Fixes-and-Tweaks/Fix-GigabyteDesktopSleepFix.sh#L14
+BOARD_VENDOR="$(cat /sys/devices/virtual/dmi/id/board_vendor 2>/dev/null || echo "")"
+if [[ ! -f /etc/bazzite/fixups/gigabyte_sleep_fix ]] && [[ "$BOARD_VENDOR" =~ [Gg]igabyte ]]; then
+  echo "Gigabyte motherboard detected, checking for GPP0 sleep/wakeup issue"
+  if [[ -f /proc/acpi/wakeup ]] && grep -q "GPP0.*enabled" /proc/acpi/wakeup 2>/dev/null; then
+    echo "GPP0 wakeup source is enabled, applying Gigabyte sleep fix"
+    systemctl enable gigabyte-sleep-fix.service
+    echo "Gigabyte sleep/wakeup fix will be applied on next boot"
+  else
+    echo "GPP0 wakeup source not found or already disabled, no fix needed"
+  fi
+  touch /etc/bazzite/fixups/gigabyte_sleep_fix
 fi
 
 # WAYDROID FIX

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -397,3 +397,51 @@ disable-steamos-automount:
 # Enable SteamOS automount.
 enable-steamos-automount:
     pkexec rm -f /etc/udev/rules.d/99-steamos-automount.rules
+
+alias fix-gpp0-sleep := fix-gigabyte-sleep
+alias fix-sleep-wakeup := fix-gigabyte-sleep
+
+# Fix GPP0 ACPI wakeup source that causes instant wake from sleep/suspend
+fix-gigabyte-sleep:
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    echo "${b}GPP0 Sleep/Wake Fix${n}"
+    echo "This fix addresses systems that instantly wake up when trying to sleep/suspend."
+    echo "It disables the GPP0 ACPI wakeup source that commonly causes this issue."
+    echo ""
+    # Check if GPP0 wakeup source exists
+    if [[ ! -f /proc/acpi/wakeup ]] || ! grep -q "GPP0" /proc/acpi/wakeup 2>/dev/null; then
+      echo "${yellow}${b}GPP0 wakeup source not found.${n}"
+      echo "Your system doesn't appear to be affected by this issue."
+      exit 0
+    fi
+    # Show current status
+    GPP0_STATUS=$(grep "GPP0" /proc/acpi/wakeup | awk '{print $3}')
+    SERVICE_STATUS="Disabled"
+    if systemctl is-enabled gigabyte-sleep-fix.service &>/dev/null; then
+      SERVICE_STATUS="Enabled"
+    fi
+    echo "${b}GPP0 Sleep/Wake Fix Status:${n}"
+    echo "GPP0 wakeup source: $GPP0_STATUS"
+    echo "Fix service: $SERVICE_STATUS"
+    echo ""
+    if [[ "$GPP0_STATUS" == "*enabled" ]]; then
+      echo "${yellow}${b}GPP0 is enabled and may cause instant wake from sleep.${n}"
+    else
+      echo "${green}${b}GPP0 is disabled - no sleep issues expected.${n}"
+    fi
+    # Simple menu
+    CHOICE=$(ugum choose "Enable Fix Service" "Disable Fix Service" "Exit")
+    case "$CHOICE" in
+      "Enable Fix Service")
+        sudo systemctl enable --now gigabyte-sleep-fix.service
+        echo "${green}${b}Fix service enabled.${n} GPP0 will be disabled on boot."
+        ;;
+      "Disable Fix Service")
+        sudo systemctl disable --now gigabyte-sleep-fix.service
+        echo "${red}${b}Fix service disabled.${n}"
+        ;;
+      "Exit"|*)
+        echo "No changes made."
+        ;;
+    esac


### PR DESCRIPTION
for HTPCs and desktops with gigabyte motherboards, on linux there is an issue causing them to immediately wake from suspend, which can be fixed by disabling GPP0 ACPI wakeup source

This PR adds an automatic check and fix if a gigabyte mobo is detected, and for other mobo brands that may be similarly affected, add a ujust with ugum choose menu to enable and disable the service manually.


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
