### PR TITLE
fix: bazzite-rollback-helper TUI refactor

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -163,12 +163,12 @@ rebase_to() {
   case "$target" in
     ostree-*) ;; # Already full ref
     *:*) 
-      local prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]' | sed "s|${DEFAULT_IMAGE}.*||")
-      full_ref="$prefix/$target"
+      local scheme=$(signing_scheme)
+      full_ref="$scheme/ublue-os/$target"
       ;;
     *)
-      local prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]' | sed "s|${DEFAULT_IMAGE}.*||")
-      full_ref="$prefix/$DEFAULT_IMAGE:$target"
+      local scheme=$(signing_scheme)
+      full_ref="$scheme/ublue-os/$DEFAULT_IMAGE:$target"
       ;;
   esac
   

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -8,917 +8,360 @@ fi
 # Source ujust library for colors and gum functionality
 source /usr/lib/ujust/ujust.sh
 
-image="$(echo "$2" | cut -d ':' -f1)"
-branch="$(echo "$2" | cut -d ':' -f2)"
-
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 DEFAULT_IMAGE=$(jq -r '."image-name"' < $IMAGE_INFO)
 DEFAULT_BRANCH=stable
 
-# Cache skopeo output if possible
-# shellcheck disable=SC1090
-[[ $- != *i* ]] && source <(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-if command -v >/dev/null 2>&1 bkt; then
+# Cache skopeo output if possible (only if bkt already exists)
+if command -v bkt >/dev/null 2>&1; then
     skopeo() { bkt --ttl=30m --stale=5m -- command skopeo "$@"; }
-else
-    nohup brew install bkt > /dev/null 2>&1 &
 fi
 
+# Help text
+helptext="====== Bazzite Rollback Helper Util ======
 
-helptext=$(cat << EOF
+This tool helps with rollbacks and rebases. Warns when switching between KDE and GNOME variants.
 
-====== Bazzite Rollback Helper Util ======
-
-This tool aims to help with rollbacks and rebases
-
-NOTE: Rebasing to different desktop environments usually breaks things and is unsupported.
-      The tool will warn you when switching between KDE and GNOME variants.
-
-Usage: bazzite-rollback-helper [OPTION] [ARGUMENT]
+Usage: $(basename "$0") [OPTION] [ARGUMENT]
 
 Options:
-  list [BRANCH]      List available Bazzite images, Default is "$DEFAULT_BRANCH"
-  rollback           Rolls back to previously installed Bazzite image. alias for "rpm-ostree rollback"
-  current            Show currently active Bazzite image
-  rebase             Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
+  list [BRANCH]      List available images (default: $DEFAULT_BRANCH)
+  rollback           Rollback to previous image
+  current            Show current image
+  rebase [TARGET]    Rebase to target (format: TAG, IMAGE:TAG, or full ostree ref)
 
 Examples:
-  bazzite-rollback-helper list stable
-  bazzite-rollback-helper rollback
-  bazzite-rollback-helper current
-  bazzite-rollback-helper rebase 40-stable-20240722
-  bazzite-rollback-helper rebase bazzite-deck:40-stable-20240722
-  bazzite-rollback-helper rebase bazzite-deck:stable
-  bazzite-rollback-helper rebase stable
-  bazzite-rollback-helper rebase testing
+  $(basename "$0") list stable
+  $(basename "$0") rebase testing
+  $(basename "$0") rebase bazzite-gnome:stable
 
-For more help, visit https://discord.bazzite.gg.
+For help: https://discord.bazzite.gg"
 
-EOF
+# Available Bazzite variants
+VARIANTS=(
+  "bazzite"
+  "bazzite-deck"
+  "bazzite-nvidia" 
+  "bazzite-deck-nvidia"
+  "bazzite-gnome"
+  "bazzite-gnome-nvidia"
+  "bazzite-deck-gnome"
+  "bazzite-dx"
+  "bazzite-dx-gnome"
+  "bazzite-dx-nvidia"
+  "bazzite-dx-nvidia-gnome"
 )
 
-
-function list_images() {
-  local _help="\
-List images with a specified tag
-
-INPUTS:
-  \$1: branch   Branch we want to get tags from.
-                Use 'all' to show all available tags.
-                Fallbacks to \"$DEFAULT_BRANCH\"
-"
-  if [[ $* =~ --help ]]; then
-    echo "$_help" && return
-  fi
-  local branch=${1:-$DEFAULT_BRANCH}
-  
-  if [[ "$branch" == "all" ]]; then
-    echo -e >&2 "Listing all available images\nThis can take a bit of time..."
-    skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r '.Tags[]' | sort
-  else
-    local regex='.Tags[]'
-    regex="$regex"\ ' | select(test("^PLACEHOLDER|^PLACEHOLDER-(?:\\d+\\.\\d+|\\d+)"))'
-    regex=${regex//PLACEHOLDER/$branch}
-    echo -e >&2 "Listing images for $branch\nThis can take a bit of time..."
-    skopeo list-tags docker://ghcr.io/ublue-os/bazzite | jq -r "$regex"
-  fi
+# Utility functions
+confirm() { 
+  local msg="$1"
+  echo -n "$msg ${yellow}(y/N)${normal} "
+  read -r reply
+  [[ "${reply,,}" =~ ^y ]]
 }
 
-# Function to detect current desktop environment
-detect_current_de() {
-  # Check for GNOME
+press_any_key() {
+  echo "Press Enter to continue..."
+  read -r
+}
+
+choose() { Choose "$@"; }
+
+current_de() {
   if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] || [[ "$DESKTOP_SESSION" == *"gnome"* ]] || command -v gnome-shell >/dev/null 2>&1; then
     echo "gnome"
-    return
-  fi
-  
-  # Check for KDE/Plasma
-  if [[ "$XDG_CURRENT_DESKTOP" == *"KDE"* ]] || [[ "$DESKTOP_SESSION" == *"plasma"* ]] || command -v plasmashell >/dev/null 2>&1; then
+  elif [[ "$XDG_CURRENT_DESKTOP" == *"KDE"* ]] || [[ "$DESKTOP_SESSION" == *"plasma"* ]] || command -v plasmashell >/dev/null 2>&1; then
     echo "kde"
-    return
-  fi
-  
-  # Default/unknown (assume KDE for Bazzite default)
-  echo "kde"
-}
-
-# Function to check if an image name indicates GNOME
-is_gnome_image() {
-  local image_name="$1"
-  [[ "$image_name" == *"gnome"* ]]
-}
-
-# Function to check if an image name indicates KDE (no explicit "kde" but absence of gnome)
-is_kde_image() {
-  local image_name="$1"
-  [[ "$image_name" != *"gnome"* ]]
-}
-
-# Function to show desktop environment warning
-show_de_warning() {
-  local current_de="$1"
-  local target_image="$2"
-  local target_de=""
-  
-  if is_gnome_image "$target_image"; then
-    target_de="GNOME"
   else
-    target_de="KDE/Plasma"
+    echo "unknown" # if either of the above are not detected, we can still serve warnings for custom image rebases
   fi
+}
+
+target_de() {
+  [[ "$1" == *"gnome"* ]] && echo "GNOME" || echo "KDE/Plasma"
+}
+
+signing_scheme() {
+  local current=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
+  [[ "$current" == *"ostree-image-signed"* ]] && echo "ostree-image-signed:ghcr.io" || echo "ostree-unverified-registry:ghcr.io"
+}
+
+warn_if_de_mismatch() {
+  local target_img="$1"
+  local current=$(current_de)
+  local target=$(target_de "$target_img")
   
-  local show_warning=false
-  local warning_msg=""
+  local warn=false
+  local msg=""
   
-  case "$current_de" in
-    "gnome")
-      if ! is_gnome_image "$target_image"; then
-        show_warning=true
-        warning_msg="You are currently running GNOME but switching to a $target_de image ($target_image)."
-      fi
-      ;;
-    "kde")
-      if ! is_kde_image "$target_image"; then
-        show_warning=true
-        warning_msg="You are currently running KDE/Plasma but switching to a $target_de image ($target_image)."
-      fi
-      ;;
+  case "$current" in
+    "gnome") [[ "$target_img" != *"gnome"* ]] && warn=true && msg="You're running GNOME but switching to $target ($target_img)" ;;
+    "kde") [[ "$target_img" == *"gnome"* ]] && warn=true && msg="You're running KDE/Plasma but switching to $target ($target_img)" ;;
   esac
   
-  if [[ "$show_warning" == true ]]; then
+  if [[ "$warn" == true ]]; then
     echo
     echo "${red}${bold}⚠️  DESKTOP ENVIRONMENT WARNING ⚠️${normal}"
-    echo "${yellow}$warning_msg${normal}"
-    echo "${yellow}Switching between different desktop environments may cause issues and is generally unsupported.${normal}"
-    echo "${yellow}Consider backing up your data before proceeding.${normal}"
+    echo "${yellow}$msg${normal}"
+    echo "${yellow}Switching DEs may cause issues and is unsupported. Consider backing up data.${normal}"
     echo
-    echo "Do you want to continue anyway? ${yellow}(y/N)${normal}"
-    read -r de_confirm
-    if [[ ! "${de_confirm,,}" =~ ^y ]]; then
-      echo "Rebase cancelled due to desktop environment mismatch."
-      return 1
-    fi
+    confirm "Continue anyway?" || return 1
   fi
-  
   return 0
 }
 
-# Function to detect current desktop environment
-detect_current_de() {
-  # Check for GNOME
-  if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] || [[ "$DESKTOP_SESSION" == *"gnome"* ]] || command -v gnome-shell >/dev/null 2>&1; then
-    echo "gnome"
-    return
-  fi
+skopeo_tags() {
+  local provider="$1"
+  local image="$2"
+  local filter="${3:-all}"
   
-  # Check for KDE/Plasma
-  if [[ "$XDG_CURRENT_DESKTOP" == *"KDE"* ]] || [[ "$DESKTOP_SESSION" == *"plasma"* ]] || command -v plasmashell >/dev/null 2>&1; then
-    echo "kde"
-    return
-  fi
-  
-  # Default/unknown (assume KDE for Bazzite default)
-  echo "kde"
-}
-
-# Function to check if an image name indicates GNOME
-is_gnome_image() {
-  local image_name="$1"
-  [[ "$image_name" == *"gnome"* ]]
-}
-
-# Function to check if an image name indicates KDE (no explicit "kde" but absence of gnome)
-is_kde_image() {
-  local image_name="$1"
-  [[ "$image_name" != *"gnome"* ]]
-}
-
-# Function to show desktop environment warning
-show_de_warning() {
-  local current_de="$1"
-  local target_image="$2"
-  local target_de=""
-  
-  if is_gnome_image "$target_image"; then
-    target_de="GNOME"
-  else
-    target_de="KDE/Plasma"
-  fi
-  
-  local show_warning=false
-  local warning_msg=""
-  
-  case "$current_de" in
-    "gnome")
-      if ! is_gnome_image "$target_image"; then
-        show_warning=true
-        warning_msg="You are currently running GNOME but switching to a $target_de image ($target_image)."
-      fi
-      ;;
-    "kde")
-      if ! is_kde_image "$target_image"; then
-        show_warning=true
-        warning_msg="You are currently running KDE/Plasma but switching to a $target_de image ($target_image)."
-      fi
-      ;;
+  local regex='.Tags[]'
+  case "$filter" in
+    stable) regex="$regex | select(test(\"^stable\"))" ;;
+    testing) regex="$regex | select(test(\"^testing\"))" ;;
   esac
   
-  if [[ "$show_warning" == true ]]; then
-    echo
-    echo "${red}${bold}⚠️  DESKTOP ENVIRONMENT WARNING ⚠️${normal}"
-    echo "${yellow}$warning_msg${normal}"
-    echo "${yellow}Switching between different desktop environments may cause issues and is generally unsupported.${normal}"
-    echo "${yellow}Consider backing up your data before proceeding.${normal}"
-    echo
-    echo "Do you want to continue anyway? ${yellow}(y/N)${normal}"
-    read -r de_confirm
-    if [[ ! "${de_confirm,,}" =~ ^y ]]; then
-      echo "Rebase cancelled due to desktop environment mismatch."
-      return 1
-    fi
-  fi
-  
-  return 0
+  skopeo list-tags "docker://ghcr.io/$provider/$image" | jq -r "$regex" | sort
 }
 
-# Function to get available Bazzite image variants
-get_bazzite_variants() {
-  local provider=${1:-ublue-os}
+available_variants() {
+  local provider="${1:-ublue-os}"
+  echo >&2 "Checking variants from $provider..."
   
-  # Official Bazzite image variants based on README.md and GitHub workflows
-  local variants=(
-    "bazzite"
-    "bazzite-deck"
-    "bazzite-nvidia" 
-    "bazzite-deck-nvidia"
-    "bazzite-gnome"
-    "bazzite-gnome-nvidia"
-    "bazzite-deck-gnome"
-    "bazzite-dx"
-    "bazzite-dx-gnome"
-    "bazzite-dx-nvidia"
-    "bazzite-dx-nvidia-gnome"
-  )
-  
-  echo -e >&2 "Checking available variants from $provider..."
-  
-  # Verify which variants actually exist by checking if they have tags
-  for variant in "${variants[@]}"; do
-    if skopeo list-tags "docker://ghcr.io/$provider/$variant" >/dev/null 2>&1; then
-      echo "$variant"
-    fi
+  for variant in "${VARIANTS[@]}"; do
+    skopeo list-tags "docker://ghcr.io/$provider/$variant" >/dev/null 2>&1 && echo "$variant"
   done
 }
 
-# Function for interactive image selection
-interactive_image_selection() {
-  local provider=${1:-ublue-os}
+print_status() {
+  echo "${bold}Current System Status:${normal}"
+  local current=$(rpm-ostree status --json | jq -r '.deployments[] | select(.booted == true) | .["container-image-reference"]')
+  local pending=$(rpm-ostree status --json | jq -r '.deployments[] | select(.booted != true) | .["container-image-reference"]' | head -1)
   
-  # Clear screen for clean interface
-  clear
-  
+  [[ -n "$current" ]] && echo "  ${bold}Active:${normal} ${green}$current${normal}"
+  [[ -n "$pending" && "$pending" != "null" ]] && echo "  ${bold}Pending:${normal} ${yellow}$pending${normal} ${yellow}(next boot)${normal}"
   echo
-  echo "${bold}Available Bazzite Images from ${green}$provider${normal}:"
-  echo
+}
+
+rebase_to() {
+  local target="$1"
+  local skip_confirm="${2:-false}"
   
-  # Get available image variants
-  local image_variants=$(get_bazzite_variants "$provider")
+  # Extract image name for DE checking
+  local img_name
+  case "$target" in
+    ostree-*) img_name=$(echo "$target" | sed 's/.*\/\([^:]*\).*/\1/') ;;
+    *:*) img_name=$(echo "$target" | cut -d':' -f1) ;;
+    *) img_name="$DEFAULT_IMAGE" ;;
+  esac
   
-  if [ -z "$image_variants" ]; then
-    echo "${red}No Bazzite variants found for provider: $provider${normal}"
-    echo "This provider may not host Bazzite images."
+  # Check DE compatibility
+  warn_if_de_mismatch "$img_name" || return 1
+  
+  # Build full ostree ref if needed
+  local full_ref="$target"
+  case "$target" in
+    ostree-*) ;; # Already full ref
+    *:*) 
+      local prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]' | sed "s|${DEFAULT_IMAGE}.*||")
+      full_ref="$prefix/$target"
+      ;;
+    *)
+      local prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]' | sed "s|${DEFAULT_IMAGE}.*||")
+      full_ref="$prefix/$DEFAULT_IMAGE:$target"
+      ;;
+  esac
+  
+  echo "Rebasing to: ${bold}$full_ref${normal}"
+  
+  if [[ "$skip_confirm" != true ]]; then
+    confirm "Continue?" || { echo "Cancelled."; return 1; }
+  fi
+  
+  echo "Performing rebase..."
+  if rpm-ostree rebase "$full_ref"; then
+    echo "${green}Rebase successful!${normal} Reboot to apply changes."
+  else
+    echo "${red}Rebase failed.${normal} Image may not exist or be accessible."
+    return 1
+  fi
+}
+
+pick_image() {
+  local provider="${1:-ublue-os}"
+  local variants=$(available_variants "$provider")
+  
+  if [[ -z "$variants" ]]; then
+    echo >&2 "${red}No variants found for provider: $provider${normal}"
     return 1
   fi
   
-  # Convert to array for gum choose
   local options=()
   while IFS= read -r line; do
-    if [[ -n "$line" ]]; then
-      options+=("$line")
-    fi
-  done <<< "$image_variants"
+    [[ -n "$line" ]] && options+=("$line")
+  done <<< "$variants"
+  options+=("Back")
   
-  # Add special options
-  options+=("Back to Main Menu")
-  
-  echo "Choose an image to see available versions:"
-  local OPTION=$(Choose "${options[@]}")
-  
-  case "$OPTION" in
-    "Back to Main Menu")
-      if [[ "$provider" == "ublue-os" ]]; then
-        interactive_menu
-      else
-        custom_provider_menu "$provider"
-      fi
-      ;;
-    *)
-      if [[ -n "$OPTION" ]]; then
-        echo
-        echo "${bold}Available versions for ${green}$OPTION${normal}:"
-        echo
-        echo "Choose how to list versions:"
-        local list_option=$(Choose "List Stable Versions" "List Testing Versions" "List All Versions" "Back to Image List")
-        
-        case "$list_option" in
-          "List Stable Versions")
-            clear
-            echo "${bold}Stable versions for ${green}$OPTION${normal}:"
-            echo
-            local regex='.Tags[] | select(test("^stable"))'
-            skopeo list-tags "docker://ghcr.io/$provider/$OPTION" | jq -r "$regex" | sort
-            ;;
-          "List Testing Versions")  
-            clear
-            echo "${bold}Testing versions for ${green}$OPTION${normal}:"
-            echo
-            local regex='.Tags[] | select(test("^testing"))'
-            skopeo list-tags "docker://ghcr.io/$provider/$OPTION" | jq -r "$regex" | sort
-            ;;
-          "List All Versions")
-            clear
-            echo "${bold}All versions for ${green}$OPTION${normal}:"
-            echo
-            skopeo list-tags "docker://ghcr.io/$provider/$OPTION" | jq -r '.Tags[]' | sort
-            ;;
-          "Back to Image List")
-            interactive_image_selection "$provider"
-            return
-            ;;
-        esac
-        
-        echo
-        echo "Press Enter to continue..."
-        read -r
-        interactive_image_selection "$provider"
-      fi
-      ;;
-  esac
+  echo >&2 "${bold}Available images from ${green}$provider${normal}:"
+  choose "${options[@]}"
 }
 
-function current() {
-  local _help="\
-Show currently active Bazzite image"
-  if [[ $* =~ --help ]]; then
-    echo "$_help" && return
+pick_version() {
+  local provider="$1"
+  local image="$2"
+  local filter="${3:-all}"
+  
+  local versions=$(skopeo_tags "$provider" "$image" "$filter")
+  if [[ -z "$versions" ]]; then
+    echo >&2 "${red}No $filter versions found for $image${normal}"
+    return 1
   fi
+  
+  local options=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && options+=("$line")
+  done <<< "$versions"
+  options+=("Back")
+  
+  echo >&2 "${bold}$filter versions for ${green}$image${normal}:"
+  choose "${options[@]}"
+}
 
+# Command functions
+list_images() {
+  local branch="${1:-$DEFAULT_BRANCH}"
+  
+  if [[ "$branch" == "all" ]]; then
+    echo >&2 "Listing all available images..."
+    skopeo_tags "ublue-os" "bazzite" "all"
+  else
+    echo >&2 "Listing $branch images..."
+    skopeo_tags "ublue-os" "bazzite" "$branch"
+  fi
+}
+
+current() {
   rpm-ostree status -vb
 }
 
-function rollback() {
-  local _help="Rolls back to previously installed Bazzite image. alias for \"rpm-ostree rollback\""
-  if [[ $* =~ --help ]]; then
-    echo "$_help" && return
+rollback() {
+  if confirm "Rollback to previous image?"; then
+    rpm-ostree rollback && echo >&2 "Reboot for changes to take effect"
+  else
+    echo "Cancelled."
   fi
-
-  rpm-ostree rollback && \
-    echo >&2 "Reboot for changes to take effect"
 }
 
-function rebase() {
-  local _help="\
-Rebase/rollback to specified Bazzite image, Default is $DEFAULT_IMAGE:$DEFAULT_BRANCH
-
-INPUTS:
-  \$1: branch   Branch we want to rebase. Format must be 
-                one of the following:
-                  - ostree-image (ex.: 'ostree-image-signed:docker://ghcr.io/ublue-os/bazzite:stable')
-                  - NAME:TAG (ex.: 'bazzite:stable-40')
-                  - TAG (ex.: 'testing')
-                Fallbacks to \"$DEFAULT_BRANCH\"\
-"
-  if [[ $* =~ --help ]]; then
-  local _help
-    echo "$_help" && return
+rebase() {
+  local target="$1"
+  local skip_confirm=false
+  
+  # Handle -y flag
+  if [[ "$2" == "-y" || "$2" == "--yes" ]]; then
+    skip_confirm=true
   fi
-
-  # Skip asking for confirmation by passing the '-y' flag
-  local CONFIRM_YES
-  CONFIRM_YES=$(
-    while (( $# )); do
-      case "$1" in
-        -y|--yes) echo 1; return ;;
-      esac
-      shift
-    done
-    echo 0
-  )
-
-  # Fetch our image reference prefix (ex.: ostree-image-signed:docker://ghcr.io/ublue-os)
-  # from rpm-ostree
-  local base_img_pfx
-  base_img_pfx=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
-  base_img_pfx=${base_img_pfx///${DEFAULT_IMAGE}*/}
-
-  local img_ref # Final image ref string to rebase
-  local usr_inpt="$1"
-  case "$usr_inpt" in
-  "") echo >&2 "$_help"; return ;;
-  ostree-image-*)
-    # ostree-image
-    # echo >&2 "Format detected"
-    img_ref=$usr_inpt
-  ;;
-  *:*)
-    # IMG_NAME:TAG
-    # echo >&2 "Format detected: IMG_NAME:TAG"
-    img_ref="$base_img_pfx"/"$usr_inpt"
-  ;;
-  *)
-    # TAG
-    # echo >&2 "Format detected: TAG"
-    img_ref="$base_img_pfx"/"$DEFAULT_IMAGE":"$usr_inpt"
-  ;;
-  esac
-
-  # Ask for confirmation. If is okay, rebase.
-  local question="\
-Rebasing to $img_ref. Continue? [Y/n]: "
-  local yn
-  if [[ $CONFIRM_YES -ne 1 ]]; then
-    # Extract image name from img_ref for DE checking
-    local image_name_for_check
-    if [[ "$img_ref" == *"/"* ]]; then
-      image_name_for_check=$(echo "$img_ref" | sed 's/.*\/\([^:]*\).*/\1/')
-    else
-      image_name_for_check="$DEFAULT_IMAGE"
-    fi
-    
-    # Check for desktop environment compatibility and show warning if needed
-    local current_de=$(detect_current_de)
-    if ! show_de_warning "$current_de" "$image_name_for_check"; then
-      return 1
-    fi
-    
-    read -rp "$question" yn
-    yn=${yn:=y} # Default to yes
-  else yn=y
-  fi
-  case $yn in
-    # Finally, rebase
-    [yY]) rpm-ostree rebase "$img_ref" || return 1 ;;
-    *) echo >&2 "Stopping rebase..."; return 1 ;;
-  esac
-}
-
-# Function for guided rebase selection
-guided_rebase_selection() {
-  local provider=${1:-ublue-os}
-  local from_custom=${2:-false}
   
-  clear
-  echo "${bold}Select Image for Rebase - Provider: ${green}$provider${normal}"
-  echo
-  
-  # Get available image variants
-  local image_variants=$(get_bazzite_variants "$provider")
-  
-  if [ -z "$image_variants" ]; then
-    echo "${red}No Bazzite variants found for provider: $provider${normal}"
-    echo "This provider may not host Bazzite images."
-    echo
-    echo "Press Enter to continue..."
-    read -r
-    if [[ "$from_custom" == "true" ]]; then
-      custom_provider_menu "$provider"
-    else
-      interactive_menu
-    fi
+  if [[ -z "$target" ]]; then
+    echo >&2 "Usage: rebase TARGET"
+    echo >&2 "Examples: rebase stable, rebase bazzite-gnome:testing"
     return 1
   fi
   
-  # Convert to array for gum choose
-  local options=()
-  while IFS= read -r line; do
-    if [[ -n "$line" ]]; then
-      options+=("$line")
-    fi
-  done <<< "$image_variants"
-  
-  # Add back option
-  options+=("Back to Previous Menu")
-  
-  echo "Choose an image variant:"
-  local OPTION=$(Choose "${options[@]}")
-  
-  case "$OPTION" in
-    "Back to Previous Menu")
-      if [[ "$from_custom" == "true" ]]; then
-        custom_provider_menu "$provider"
-      else
-        interactive_menu
-      fi
-      ;;
-    *)
-      if [[ -n "$OPTION" ]]; then
-        guided_version_selection "$provider" "$OPTION" "$from_custom"
-      fi
-      ;;
-  esac
+  rebase_to "$target" "$skip_confirm"
 }
 
-# Function for guided version selection
-guided_version_selection() {
-  local provider="$1"
-  local image_name="$2"
-  local from_custom="$3"
-  
-  clear
-  echo "${bold}Select Version for ${green}$image_name${normal} - Provider: ${green}$provider${normal}"
-  echo
-  
-  echo "Choose version type:"
-  local version_type=$(Choose "Stable Versions" "Testing Versions" "All Versions" "Back to Image Selection")
-  
-  case "$version_type" in
-    "Back to Image Selection")
-      guided_rebase_selection "$provider" "$from_custom"
-      ;;
-    "Stable Versions")
-      show_version_menu "$provider" "$image_name" "stable" "$from_custom"
-      ;;
-    "Testing Versions")
-      show_version_menu "$provider" "$image_name" "testing" "$from_custom"
-      ;;
-    "All Versions")
-      show_version_menu "$provider" "$image_name" "all" "$from_custom"
-      ;;
-  esac
-}
-
-# Function to show version menu and handle selection
-show_version_menu() {
-  local provider="$1"
-  local image_name="$2"
-  local version_type="$3"
-  local from_custom="$4"
-  
-  clear
-  echo "${bold}${version_type^} versions for ${green}$image_name${normal}:"
-  echo
-  
-  # Get versions based on type
-  local versions=()
-  case "$version_type" in
-    "stable")
-      local regex='.Tags[] | select(test("^stable"))'
-      ;;
-    "testing")
-      local regex='.Tags[] | select(test("^testing"))'
-      ;;
-    "all")
-      local regex='.Tags[]'
-      ;;
-  esac
-  
-  # Get the versions and convert to array
-  local version_list=$(skopeo list-tags "docker://ghcr.io/$provider/$image_name" | jq -r "$regex" | sort)
-  
-  if [ -z "$version_list" ]; then
-    echo "${red}No $version_type versions found for $image_name${normal}"
-    echo
-    echo "Press Enter to continue..."
-    read -r
-    guided_version_selection "$provider" "$image_name" "$from_custom"
-    return
-  fi
-  
-  local options=()
-  while IFS= read -r line; do
-    if [[ -n "$line" ]]; then
-      options+=("$line")
-    fi
-  done <<< "$version_list"
-  
-  # Add navigation options
-  options+=("Back to Version Type Selection")
-  
-  echo "Choose a version to rebase to:"
-  local OPTION=$(Choose "${options[@]}")
-  
-  case "$OPTION" in
-    "Back to Version Type Selection")
-      guided_version_selection "$provider" "$image_name" "$from_custom"
-      ;;
-    *)
-      if [[ -n "$OPTION" ]]; then
-        # Perform the rebase
-        perform_rebase "$provider" "$image_name" "$OPTION" "$from_custom"
-      fi
-      ;;
-  esac
-}
-
-# Function to perform the actual rebase
-perform_rebase() {
-  local provider="$1"
-  local image_name="$2"
-  local version="$3"
-  local from_custom="$4"
-  
-  clear
-  echo "${bold}Confirm Rebase${normal}"
-  echo
-  
-  # Get current image prefix but replace the provider if needed
-  local current_prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
-  local signing_scheme
-  if [[ "$current_prefix" == *"ostree-image-signed"* ]]; then
-    signing_scheme="ostree-image-signed:docker://ghcr.io"
-  else
-    signing_scheme="ostree-unverified-registry:docker://ghcr.io"
-  fi
-  
-  local target_ref="$signing_scheme/$provider/$image_name:$version"
-  
-  echo "Rebasing to: ${bold}$target_ref${normal}"
-  
-  # Check for desktop environment compatibility and show warning if needed
-  local current_de=$(detect_current_de)
-  if ! show_de_warning "$current_de" "$image_name"; then
-    echo
-    echo "Press Enter to continue..."
-    read -r
-    if [[ "$from_custom" == "true" ]]; then
-      custom_provider_menu "$provider"
-    else
-      interactive_menu
-    fi
-    return
-  fi
-  
-  echo
-  echo "Are you sure? ${yellow}(y/N)${normal}"
-  read -r confirm
-  
-  if [[ "${confirm,,}" =~ ^y ]]; then
-    echo
-    echo "Performing rebase..."
-    if rpm-ostree rebase "$target_ref"; then
-      echo
-      echo "${green}Rebase successful!${normal}"
-      echo "Reboot for changes to take effect."
-    else
-      echo
-      echo "${red}Failed to rebase.${normal} The image may not exist or be accessible."
-    fi
-  else
-    echo "Rebase cancelled."
-  fi
-  
-  echo
-  echo "Press Enter to continue..."
-  read -r
-  
-  if [[ "$from_custom" == "true" ]]; then
-    custom_provider_menu "$provider"
-  else
-    interactive_menu
-  fi
-}
-show_current_status() {
-  echo "${bold}Current System Status:${normal}"
-  echo
-  local current_deployment=$(rpm-ostree status --json | jq -r '.deployments[] | select(.booted == true) | .["container-image-reference"]')
-  if [ -n "$current_deployment" ]; then
-    echo "  ${bold}Active Image:${normal} ${green}$current_deployment${normal}"
-  fi
-  
-  local pending_deployment=$(rpm-ostree status --json | jq -r '.deployments[] | select(.booted != true) | .["container-image-reference"]' | head -1)
-  if [ -n "$pending_deployment" ] && [ "$pending_deployment" != "null" ]; then
-    echo "  ${bold}Pending Image:${normal} ${yellow}$pending_deployment${normal} ${yellow}(will boot next)${normal}"
-  fi
-  echo
-}
-
-# Function to handle custom provider rebase
-custom_provider_menu() {
-  local provider="$1"
-  
-  # Clear screen for clean interface
-  clear
-  
-  echo
-  echo "${bold}Custom Provider: ${green}$provider${normal}"
-  echo
-  echo "${bold}Choose an action:${normal}"
-  local OPTION=$(Choose "List Available Images" "Select from List for Rebase" "Manual Rebase Entry" "Back to Main Menu")
-  
-  case "$OPTION" in
-    "List Available Images")
-      interactive_image_selection "$provider"
-      ;;
-    "Select from List for Rebase")
-      guided_rebase_selection "$provider" "true"
-      ;;
-    "Manual Rebase Entry")
-      clear
-      echo "${bold}Manual Rebase Entry - Provider: ${green}$provider${normal}"
-      echo
-      echo "Enter the image:tag to rebase to:"
-      echo "Examples:"
-      echo "  - ${bold}bazzite:stable${normal}"
-      echo "  - ${bold}bazzite-deck:testing${normal}"
-      echo "  - ${bold}bazzite-deck:40-stable-20240722${normal}"
-      echo
-      echo "Enter image:tag (or press Enter to cancel):"
-      read -r image_tag
-      if [ -n "$image_tag" ]; then
-        # Get current image prefix but replace the provider
-        local current_prefix=$(rpm-ostree status -b --json | jq -r '.deployments[]["container-image-reference"]')
-        local signing_scheme
-        if [[ "$current_prefix" == *"ostree-image-signed"* ]]; then
-          signing_scheme="ostree-image-signed:docker://ghcr.io"
-        else
-          signing_scheme="ostree-unverified-registry:docker://ghcr.io"
-        fi
-        
-        local custom_ref="$signing_scheme/$provider/$image_tag"
-        echo
-        echo "Rebasing to: ${bold}$custom_ref${normal}"
-        
-        # Extract image name for DE checking
-        local image_name_for_check=$(echo "$image_tag" | cut -d':' -f1)
-        local current_de=$(detect_current_de)
-        
-        if ! show_de_warning "$current_de" "$image_name_for_check"; then
-          echo
-          echo "Press Enter to continue..."
-          read -r
-          custom_provider_menu "$provider"
-          return
-        fi
-        
-        echo "Are you sure? ${yellow}(y/N)${normal}"
-        read -r confirm
-        if [[ "${confirm,,}" =~ ^y ]]; then
-          rpm-ostree rebase "$custom_ref" || echo "Failed to rebase. The image may not exist or be accessible."
-        else
-          echo "Rebase cancelled."
-        fi
-      else
-        echo "Rebase cancelled."
-      fi
-      echo
-      echo "Press Enter to continue..."
-      read -r
-      custom_provider_menu "$provider"
-      ;;
-    "Back to Main Menu")
-      interactive_menu
-      ;;
-    *)
-      echo "Invalid option selected."
-      custom_provider_menu "$provider"
-      ;;
-  esac
-}
-
-# Interactive menu function
+# Interactive menu
 interactive_menu() {
-  # Clear screen for clean interface
-  clear
-  
-  # Show help text and current status
-  echo "$helptext"
-  show_current_status
-  
-  echo "${bold}Choose an action:${normal}"
-  local OPTION=$(Choose "List Images" "Show Current Image" "Rollback" "Rebase" "Custom Image Provider" "Exit")
-  
-  case "$OPTION" in
-    "List Images")
-      interactive_image_selection "ublue-os"
-      ;;
-    "Show Current Image")
-      clear
-      echo "${bold}Current System Information:${normal}"
-      echo
-      current
-      echo
-      echo "Press Enter to continue..."
-      read -r
-      interactive_menu
-      ;;
-    "Rollback")
-      clear
-      echo "${bold}Rollback to Previous Image${normal}"
-      echo
-      echo "Are you sure you want to rollback to the previous image? ${yellow}(y/N)${normal}"
-      read -r confirm
-      if [[ "${confirm,,}" =~ ^y ]]; then
-        rollback
-      else
-        echo "Rollback cancelled."
-      fi
-      echo
-      echo "Press Enter to continue..."
-      read -r
-      interactive_menu
-      ;;
-    "Rebase")
-      clear
-      echo "${bold}Rebase to Different Image${normal}"
-      echo
-      echo "Choose rebase method:"
-      local rebase_method=$(Choose "Select from List" "Manual Entry" "Back to Main Menu")
-      
-      case "$rebase_method" in
-        "Select from List")
-          guided_rebase_selection "ublue-os" "false"
-          ;;
-        "Manual Entry")
+  while true; do
+    clear
+    echo "$helptext"
+    echo
+    print_status
+    
+    local action=$(choose "List Images" "Show Current" "Rollback" "Rebase" "Custom Provider" "Exit")
+    
+    case "$action" in
+      "List Images")
+        clear
+        local variants=$(available_variants "ublue-os")
+        local img=$(pick_image "ublue-os")
+        [[ "$img" != "Back" ]] && { 
           clear
-          echo "${bold}Manual Rebase Entry${normal}"
-          echo
-          echo "Enter the image/tag to rebase to:"
-          echo "Examples:"
-          echo "  - ${bold}stable${normal} (rebase to stable branch)"
-          echo "  - ${bold}testing${normal} (rebase to testing branch)"
-          echo "  - ${bold}bazzite-deck:stable${normal} (specific image and tag)"
-          echo "  - ${bold}40-stable-20240722${normal} (specific tag)"
-          echo
-          echo "Enter rebase target (or press Enter to cancel):"
-          read -r rebase_input
-          if [ -n "$rebase_input" ]; then
-            # Extract image name for DE checking if it's in NAME:TAG format
-            local image_name_for_check
-            if [[ "$rebase_input" == *":"* ]]; then
-              image_name_for_check=$(echo "$rebase_input" | cut -d':' -f1)
-            else
-              # For TAG-only format, use the default image
-              image_name_for_check="$DEFAULT_IMAGE"
-            fi
-            
-            # Check for desktop environment compatibility and show warning if needed
-            local current_de=$(detect_current_de)
-            if show_de_warning "$current_de" "$image_name_for_check"; then
-              rebase "$rebase_input" -y
-            else
-              echo "Rebase cancelled due to desktop environment mismatch."
-            fi
-          else
-            echo "Rebase cancelled."
+          local filter=$(choose "Stable" "Testing" "All" "Back")
+          [[ "$filter" != "Back" ]] && {
+            clear
+            skopeo_tags "ublue-os" "$img" "${filter,,}"
+            press_any_key
+          }
+        }
+        ;;
+        
+      "Show Current")
+        clear
+        current
+        press_any_key
+        ;;
+        
+      "Rollback")
+        clear
+        rollback
+        press_any_key
+        ;;
+        
+      "Rebase")
+        clear
+        local img=$(pick_image "ublue-os")
+        if [[ "$img" != "Back" ]]; then
+          local filter=$(choose "Stable" "Testing" "All" "Back")
+          if [[ "$filter" != "Back" ]]; then
+            local version=$(pick_version "ublue-os" "$img" "${filter,,}")
+            [[ "$version" != "Back" && -n "$version" ]] && {
+              clear
+              rebase_to "$(signing_scheme)/ublue-os/$img:$version"
+              press_any_key
+            }
           fi
-          echo
-          echo "Press Enter to continue..."
-          read -r
-          interactive_menu
-          ;;
-        "Back to Main Menu")
-          interactive_menu
-          ;;
-      esac
-      ;;
-    "Custom Image Provider")
-      clear
-      echo "${bold}Custom Image Provider${normal}"
-      echo
-      echo "Enter the custom provider/organization name:"
-      echo "  - Default: ${bold}ublue-os${normal}"
-      echo "  - Examples: ${bold}my-org${normal}, ${bold}custom-builder${normal}, ${bold}fork-maintainer${normal}"
-      echo
-      echo "Enter provider name (or press Enter for 'ublue-os'):"
-      read -r provider_input
-      provider_input=${provider_input:-ublue-os}
-      # Convert to lowercase for ghcr.io compatibility
-      provider_input=$(echo "$provider_input" | tr '[:upper:]' '[:lower:]')
-      
-      echo
-      echo "Using provider: ${bold}$provider_input${normal}"
-      custom_provider_menu "$provider_input"
-      ;;
-    "Exit")
-      echo "Exiting..."
-      exit 0
-      ;;
-    *)
-      echo "Invalid option selected."
-      interactive_menu
-      ;;
-  esac
+        fi
+        ;;
+        
+      "Custom Provider")
+        clear
+        echo "Enter provider name (default: ublue-os):"
+        read -r provider
+        provider="${provider:-ublue-os}"
+        provider=$(echo "$provider" | tr '[:upper:]' '[:lower:]')
+        
+        local img=$(pick_image "$provider")
+        if [[ "$img" != "Back" ]]; then
+          echo "Enter image:tag or press Enter to browse versions:"
+          read -r manual_target
+          if [[ -n "$manual_target" ]]; then
+            rebase_to "$(signing_scheme)/$provider/$manual_target"
+          else
+            local filter=$(choose "Stable" "Testing" "All" "Back")
+            if [[ "$filter" != "Back" ]]; then
+              local version=$(pick_version "$provider" "$img" "${filter,,}")
+              [[ "$version" != "Back" && -n "$version" ]] && rebase_to "$(signing_scheme)/$provider/$img:$version"
+            fi
+          fi
+        fi
+        press_any_key
+        ;;
+        
+      "Exit")
+        echo "Exiting..."
+        exit 0
+        ;;
+    esac
+  done
 }
 
-if [[ "$1" == "list" ]]; then
-  list_images "${@:2}"
-  exit
-
-elif [[ "$1" == "rollback" ]]; then
-  rollback "${@:2}"
-  exit
-
-elif [[ "$1" == "current" ]]; then
-  current "${@:2}"
-  exit
-
-elif [[ "$1" == "rebase" ]]; then
-  rebase "${@:2}"
-  exit
-
-# display the helptext and start interactive mode
-elif [[ "$1" == "-h" || "$1" == "--h" || "$1" == "-help" || "$1" == "--help" || "$1" == "help" || -z "$1" ]]; then
- interactive_menu
-else
- echo "Unsupported Option: $1"
- echo "run 'bazzite-rollback-helper help' for more details"
-fi
+# Main logic
+case "$1" in
+  "list") list_images "$2" ;;
+  "rollback") rollback ;;
+  "current") current ;;
+  "rebase") rebase "$2" "$3" ;;
+  "help"|"-h"|"--help"|"") interactive_menu ;;
+  *) echo "Unknown option: $1. Run without arguments for interactive mode." ;;
+esac

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -5,7 +5,6 @@ if [[ $UID -eq 0 ]]; then
   exit 1
 fi
 
-# Source ujust library for colors and gum functionality
 source /usr/lib/ujust/ujust.sh
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
@@ -17,7 +16,6 @@ if command -v bkt >/dev/null 2>&1; then
     skopeo() { bkt --ttl=30m --stale=5m -- command skopeo "$@"; }
 fi
 
-# Help text
 helptext="====== Bazzite Rollback Helper Util ======
 
 This tool helps with rollbacks and rebases. Warns when switching between KDE and GNOME variants.
@@ -37,7 +35,6 @@ Examples:
 
 For help: https://discord.bazzite.gg"
 
-# Available Bazzite variants
 VARIANTS=(
   "bazzite"
   "bazzite-deck"
@@ -155,13 +152,12 @@ rebase_to() {
     *) img_name="$DEFAULT_IMAGE" ;;
   esac
   
-  # Check DE compatibility
   warn_if_de_mismatch "$img_name" || return 1
   
   # Build full ostree ref if needed
   local full_ref="$target"
   case "$target" in
-    ostree-*) ;; # Already full ref
+    ostree-*) ;;
     *:*) 
       local scheme=$(signing_scheme)
       full_ref="$scheme/ublue-os/$target"
@@ -256,7 +252,6 @@ rebase() {
   local target="$1"
   local skip_confirm=false
   
-  # Handle -y flag
   if [[ "$2" == "-y" || "$2" == "--yes" ]]; then
     skip_confirm=true
   fi
@@ -270,7 +265,6 @@ rebase() {
   rebase_to "$target" "$skip_confirm"
 }
 
-# Interactive menu
 interactive_menu() {
   while true; do
     clear
@@ -356,7 +350,6 @@ interactive_menu() {
   done
 }
 
-# Main logic
 case "$1" in
   "list") list_images "$2" ;;
   "rollback") rollback ;;

--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -31,7 +31,8 @@ helptext=$(cat << EOF
 
 This tool aims to help with rollbacks and rebases
 
-NOTE: Rebasing to different desktop environments usually breaks things and is unsupported
+NOTE: Rebasing to different desktop environments usually breaks things and is unsupported.
+      The tool will warn you when switching between KDE and GNOME variants.
 
 Usage: bazzite-rollback-helper [OPTION] [ARGUMENT]
 
@@ -83,18 +84,179 @@ INPUTS:
   fi
 }
 
+# Function to detect current desktop environment
+detect_current_de() {
+  # Check for GNOME
+  if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] || [[ "$DESKTOP_SESSION" == *"gnome"* ]] || command -v gnome-shell >/dev/null 2>&1; then
+    echo "gnome"
+    return
+  fi
+  
+  # Check for KDE/Plasma
+  if [[ "$XDG_CURRENT_DESKTOP" == *"KDE"* ]] || [[ "$DESKTOP_SESSION" == *"plasma"* ]] || command -v plasmashell >/dev/null 2>&1; then
+    echo "kde"
+    return
+  fi
+  
+  # Default/unknown (assume KDE for Bazzite default)
+  echo "kde"
+}
+
+# Function to check if an image name indicates GNOME
+is_gnome_image() {
+  local image_name="$1"
+  [[ "$image_name" == *"gnome"* ]]
+}
+
+# Function to check if an image name indicates KDE (no explicit "kde" but absence of gnome)
+is_kde_image() {
+  local image_name="$1"
+  [[ "$image_name" != *"gnome"* ]]
+}
+
+# Function to show desktop environment warning
+show_de_warning() {
+  local current_de="$1"
+  local target_image="$2"
+  local target_de=""
+  
+  if is_gnome_image "$target_image"; then
+    target_de="GNOME"
+  else
+    target_de="KDE/Plasma"
+  fi
+  
+  local show_warning=false
+  local warning_msg=""
+  
+  case "$current_de" in
+    "gnome")
+      if ! is_gnome_image "$target_image"; then
+        show_warning=true
+        warning_msg="You are currently running GNOME but switching to a $target_de image ($target_image)."
+      fi
+      ;;
+    "kde")
+      if ! is_kde_image "$target_image"; then
+        show_warning=true
+        warning_msg="You are currently running KDE/Plasma but switching to a $target_de image ($target_image)."
+      fi
+      ;;
+  esac
+  
+  if [[ "$show_warning" == true ]]; then
+    echo
+    echo "${red}${bold}⚠️  DESKTOP ENVIRONMENT WARNING ⚠️${normal}"
+    echo "${yellow}$warning_msg${normal}"
+    echo "${yellow}Switching between different desktop environments may cause issues and is generally unsupported.${normal}"
+    echo "${yellow}Consider backing up your data before proceeding.${normal}"
+    echo
+    echo "Do you want to continue anyway? ${yellow}(y/N)${normal}"
+    read -r de_confirm
+    if [[ ! "${de_confirm,,}" =~ ^y ]]; then
+      echo "Rebase cancelled due to desktop environment mismatch."
+      return 1
+    fi
+  fi
+  
+  return 0
+}
+
+# Function to detect current desktop environment
+detect_current_de() {
+  # Check for GNOME
+  if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] || [[ "$DESKTOP_SESSION" == *"gnome"* ]] || command -v gnome-shell >/dev/null 2>&1; then
+    echo "gnome"
+    return
+  fi
+  
+  # Check for KDE/Plasma
+  if [[ "$XDG_CURRENT_DESKTOP" == *"KDE"* ]] || [[ "$DESKTOP_SESSION" == *"plasma"* ]] || command -v plasmashell >/dev/null 2>&1; then
+    echo "kde"
+    return
+  fi
+  
+  # Default/unknown (assume KDE for Bazzite default)
+  echo "kde"
+}
+
+# Function to check if an image name indicates GNOME
+is_gnome_image() {
+  local image_name="$1"
+  [[ "$image_name" == *"gnome"* ]]
+}
+
+# Function to check if an image name indicates KDE (no explicit "kde" but absence of gnome)
+is_kde_image() {
+  local image_name="$1"
+  [[ "$image_name" != *"gnome"* ]]
+}
+
+# Function to show desktop environment warning
+show_de_warning() {
+  local current_de="$1"
+  local target_image="$2"
+  local target_de=""
+  
+  if is_gnome_image "$target_image"; then
+    target_de="GNOME"
+  else
+    target_de="KDE/Plasma"
+  fi
+  
+  local show_warning=false
+  local warning_msg=""
+  
+  case "$current_de" in
+    "gnome")
+      if ! is_gnome_image "$target_image"; then
+        show_warning=true
+        warning_msg="You are currently running GNOME but switching to a $target_de image ($target_image)."
+      fi
+      ;;
+    "kde")
+      if ! is_kde_image "$target_image"; then
+        show_warning=true
+        warning_msg="You are currently running KDE/Plasma but switching to a $target_de image ($target_image)."
+      fi
+      ;;
+  esac
+  
+  if [[ "$show_warning" == true ]]; then
+    echo
+    echo "${red}${bold}⚠️  DESKTOP ENVIRONMENT WARNING ⚠️${normal}"
+    echo "${yellow}$warning_msg${normal}"
+    echo "${yellow}Switching between different desktop environments may cause issues and is generally unsupported.${normal}"
+    echo "${yellow}Consider backing up your data before proceeding.${normal}"
+    echo
+    echo "Do you want to continue anyway? ${yellow}(y/N)${normal}"
+    read -r de_confirm
+    if [[ ! "${de_confirm,,}" =~ ^y ]]; then
+      echo "Rebase cancelled due to desktop environment mismatch."
+      return 1
+    fi
+  fi
+  
+  return 0
+}
+
 # Function to get available Bazzite image variants
 get_bazzite_variants() {
   local provider=${1:-ublue-os}
   
-  # Official Bazzite image variants based on README.md
+  # Official Bazzite image variants based on README.md and GitHub workflows
   local variants=(
     "bazzite"
     "bazzite-deck"
     "bazzite-nvidia" 
     "bazzite-deck-nvidia"
+    "bazzite-gnome"
+    "bazzite-gnome-nvidia"
+    "bazzite-deck-gnome"
     "bazzite-dx"
-    "bazzite-gdx"
+    "bazzite-dx-gnome"
+    "bazzite-dx-nvidia"
+    "bazzite-dx-nvidia-gnome"
   )
   
   echo -e >&2 "Checking available variants from $provider..."
@@ -274,6 +436,20 @@ INPUTS:
 Rebasing to $img_ref. Continue? [Y/n]: "
   local yn
   if [[ $CONFIRM_YES -ne 1 ]]; then
+    # Extract image name from img_ref for DE checking
+    local image_name_for_check
+    if [[ "$img_ref" == *"/"* ]]; then
+      image_name_for_check=$(echo "$img_ref" | sed 's/.*\/\([^:]*\).*/\1/')
+    else
+      image_name_for_check="$DEFAULT_IMAGE"
+    fi
+    
+    # Check for desktop environment compatibility and show warning if needed
+    local current_de=$(detect_current_de)
+    if ! show_de_warning "$current_de" "$image_name_for_check"; then
+      return 1
+    fi
+    
     read -rp "$question" yn
     yn=${yn:=y} # Default to yes
   else yn=y
@@ -456,6 +632,21 @@ perform_rebase() {
   local target_ref="$signing_scheme/$provider/$image_name:$version"
   
   echo "Rebasing to: ${bold}$target_ref${normal}"
+  
+  # Check for desktop environment compatibility and show warning if needed
+  local current_de=$(detect_current_de)
+  if ! show_de_warning "$current_de" "$image_name"; then
+    echo
+    echo "Press Enter to continue..."
+    read -r
+    if [[ "$from_custom" == "true" ]]; then
+      custom_provider_menu "$provider"
+    else
+      interactive_menu
+    fi
+    return
+  fi
+  
   echo
   echo "Are you sure? ${yellow}(y/N)${normal}"
   read -r confirm
@@ -545,6 +736,19 @@ custom_provider_menu() {
         local custom_ref="$signing_scheme/$provider/$image_tag"
         echo
         echo "Rebasing to: ${bold}$custom_ref${normal}"
+        
+        # Extract image name for DE checking
+        local image_name_for_check=$(echo "$image_tag" | cut -d':' -f1)
+        local current_de=$(detect_current_de)
+        
+        if ! show_de_warning "$current_de" "$image_name_for_check"; then
+          echo
+          echo "Press Enter to continue..."
+          read -r
+          custom_provider_menu "$provider"
+          return
+        fi
+        
         echo "Are you sure? ${yellow}(y/N)${normal}"
         read -r confirm
         if [[ "${confirm,,}" =~ ^y ]]; then
@@ -637,7 +841,22 @@ interactive_menu() {
           echo "Enter rebase target (or press Enter to cancel):"
           read -r rebase_input
           if [ -n "$rebase_input" ]; then
-            rebase "$rebase_input" -y
+            # Extract image name for DE checking if it's in NAME:TAG format
+            local image_name_for_check
+            if [[ "$rebase_input" == *":"* ]]; then
+              image_name_for_check=$(echo "$rebase_input" | cut -d':' -f1)
+            else
+              # For TAG-only format, use the default image
+              image_name_for_check="$DEFAULT_IMAGE"
+            fi
+            
+            # Check for desktop environment compatibility and show warning if needed
+            local current_de=$(detect_current_de)
+            if show_de_warning "$current_de" "$image_name_for_check"; then
+              rebase "$rebase_input" -y
+            else
+              echo "Rebase cancelled due to desktop environment mismatch."
+            fi
           else
             echo "Rebase cancelled."
           fi


### PR DESCRIPTION
Refactors the `bazzite-rollback-helper` TUI to simplify the logic and adapt to some changes in the image matrix. 

Adds a warning when switching desktop environments (KDE to GNOME and vice-reversa), supports images 
with custom DEs from the template, list missing `-dx` images, and reduces overall complexity and lines of code.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
