### PR TITLE
chore: Remove leftovers of ublue-os-automount udev rules

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -199,24 +199,20 @@ add-user-to-input-group:
 
 # Enables automounting of labeled BTRFS/EXT4 partitions under /run/media/system
 enable-automounting:
-    #!/usr/bin/bash
+    #!/usr/bin/pkexec /usr/bin/bash
     set -eo pipefail
-    rule=/etc/udev/rules.d/99-media-automount.rules
-    if [[ "$(readlink $rule || :)" == /dev/null ]]; then
-        sudo -A rm -f $rule
-    fi
+    rm -f /etc/udev/rules.d/99-media-automount.rules # DELETEME
     if systemctl status --no-pager ublue-os-media-automount.service >/dev/null 2>&1; then
-        sudo -A systemctl enable --now ublue-os-media-automount.service
+        systemctl enable --now ublue-os-media-automount.service
     fi
 
 # Disables automounting of labeled BTRFS/EXT4 partitions under /run/media/system
 disable-automounting:
-    #!/usr/bin/bash
+    #!/usr/bin/pkexec /usr/bin/bash
     set -eo pipefail
-    rule=/etc/udev/rules.d/99-media-automount.rules
-    sudo ln -sf /dev/null $rule
+    rm -f /etc/udev/rules.d/99-media-automount.rules # DELETEME
     if systemctl status --no-pager ublue-os-media-automount.service >/dev/null 2>&1; then
-        sudo -A systemctl disable ublue-os-media-automount.service
+        systemctl disable ublue-os-media-automount.service
     fi
 
 # Enable support for Tailscale


### PR DESCRIPTION
Remove old devnull placeholders at /etc/udev/rules.d that disabled old udev rules