### PR TITLE
Fix(gnome): fix `ujust setup-sunshine enable` for gnome desktop

### DIFF
--- a/system_files/desktop/silverblue/etc/systemd/user/sunshine.service.d/override.conf
+++ b/system_files/desktop/silverblue/etc/systemd/user/sunshine.service.d/override.conf
@@ -1,0 +1,2 @@
+[Install]
+WantedBy=gnome-session.target


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

# Summary
I was trying bazzite-gnome and noticed the sunshine enable just script didn't seem to work. 

What I came to was that gnome doesn't trigger the systemd target that sunshine's service ships with (xdg-autostart-desktop). 

As others noted on #2044 a work-around is using Ignition, but that requires GUI access and for the user to figure out that the autostart thing is called Ignition and isn't in gnome settings etc. AND realize the just script hasn't worked.

## Solution
This PR basically creates a unit override for the sunshine user service to specify that when its installed it should also be started when gnome-session.target is reached. This is done by the WantedBy systemd directive. I'm no expert but this seemed like the least-messy solution.

## Alternatives
This is my first contribution to ublue, so I wasn't quite sure how to determine whether it was the gnome image or not (looked like maybe conditionals in containerfile?!) ~~so I just looked up that it's legal to have 1+ WantedBy directives.~~ 

## How to test ujust and the override
- use the gnome desktop image
- copy the override file to your `~/.config/systemd/user/sunshine.service.d/`
- run `ujust setup-sunshine disable` and see that it cleans up `~/.config/systemd/user/` of the systemd wants files for xdg-desktop-autostart
- run `ujust setup-sunshine enable` and see that it creates a directory structure like this:

```
.
├── gnome-session.target.wants
│   └── sunshine.service -> /usr/lib/systemd/user/sunshine.service
└── sunshine.service.d     <-- This is only here for testing
    └── override.conf      <-- This is only here for testing

```
- reboot your gnome desktop image'd machine and see that sunshine starts

Update: we moved the file to the silverblue directory for this gnome-only fix since KDE works fine.
