### PR TITLE
feat: Remove Toolbox

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -229,6 +229,7 @@ RUN --mount=type=cache,dst=/var/cache \
         ublue-os-update-services \
         firefox \
         firefox-langpacks \
+        toolbox \
         htop && \
     /ctx/cleanup
 


### PR DESCRIPTION
In the spirit of removing upstream tools without use, this removes toolbox. Previously we kept this despite Distrobox mogging it due to its removal not saving space, but rechunker means the 100kb this uses can be reclaimed.