### PR TITLE
docs(motd): remove archived Flatpak donation page

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/motd/tips/10-ublue.md
+++ b/system_files/desktop/shared/usr/share/ublue-os/motd/tips/10-ublue.md
@@ -2,7 +2,6 @@ It is **always** better to install packages with Distrobox rather than layer the
 Packages installed in Distrobox can be exported to appear like any other application~[View documentation](https://distrobox.it/usage/distrobox-export/)
 *Update break something?* You can roll back and pin the previous release or rebase by build date~[View our guide](https://docs.bazzite.gg/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rolling_back_system_updates/)
 *This isn't a distro*, this is a custom image built on  Fedora Atomic Desktop technology~[View our mission](https://ublue.it/mission/)
-**Support the app store!**~[Donate to  Flatpak](https://opencollective.com/flatpak)
 **Support indie game preservation and OSS developers!**~[Join Hit Save!'s Patreon](https://patreon.com/hitsave)
 **Protect your video games!**~[Visit Stop Killing Games](https://www.stopkillinggames.com/)
 **H.264 hardware acceleration is supported out of the box.** No tweaks necessary!


### PR DESCRIPTION
<img width="1924" height="1284" alt="image" src="https://github.com/user-attachments/assets/a805f44e-7450-44f0-9d5c-d01c138138e8" />

Flatpak is no longer accepting donations on https://opencollective.com/flatpak. Ideally we would replace this with something else to support Flathub/Flatpak.
