### PR TITLE
chore: update bazzite buddy decky repo to official org

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -619,8 +619,8 @@ toggle-password-feedback ACTION="":
 get-decky-bazzite-buddy:
     #!/bin/bash
     set -euo pipefail
-    REPO_OWNER="xXJSONDeruloXx"
-    REPO_NAME="bazzite-buddy"
+    REPO_OWNER="bazzite-org"
+    REPO_NAME="decky-bazzite-buddy"
     PLUGIN_NAME="bazzite-buddy"
     PLUGIN_DIR="$HOME/homebrew/plugins"
 


### PR DESCRIPTION
Simple adj to point the ujust recipe to get decky bazzite buddy (for viewing changelogs in gamemode) to get release from bazzite-org repo, rather than my personal. First of a few remote bin relocations to centralize for governance.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
