### PR TITLE
fix(bazzite-hardware-setup): run fixups commands after applying kargs

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -39,6 +39,7 @@ MINIMUM_FREE_ZRAM=$(awk '/MemTotal/ {printf "%.0f", $2 * 0.01}' /proc/meminfo)
 CURRENT_FREE_ZRAM=$(sysctl vm.min_free_kbytes | awk '{print $3}')
 KARGS=$(rpm-ostree kargs)
 NEEDED_KARGS=()
+NEEDED_KARGS_COMMANDS=()
 
 # Add directory for fixups
 mkdir -p /etc/bazzite/fixups
@@ -138,7 +139,7 @@ if [[ ":83E1:ROG Ally RC71L:ROG Ally X RC72LA:" =~ ":$SYS_ID:" ]]; then
     echo "Removing sd_display=0 (it is not needed anymore)"
     NEEDED_KARGS+=("--delete-if-present=amdgpu.sg_display=0")
   fi
-  touch /etc/bazzite/fixups/sg_display
+  NEEDED_KARGS_COMMANDS+=("touch /etc/bazzite/fixups/sg_display")
 fi
 
 if [[ ! -f /etc/bazzite/fixups/orientation_old ]]; then
@@ -154,7 +155,7 @@ if [[ ! -f /etc/bazzite/fixups/orientation_old ]]; then
   elif [[ ":ONEXPLAYER F1:ONEXPLAYER F1L:ONEXPLAYER F1 EVA-01:ONEXPLAYER X1Pro:Loki Max:Zeenix Pro:" =~ ":$SYS_ID:" ]]; then
     NEEDED_KARGS+=("--delete-if-present=video=eDP-1:panel_orientation=left_side_up")
   fi
-  touch /etc/bazzite/fixups/orientation_old
+  NEEDED_KARGS_COMMANDS+=("touch /etc/bazzite/fixups/orientation_old")
 fi
 
 # Slide reboots randomly, acpi=strict seems to fix it
@@ -181,7 +182,7 @@ if [[ ! -f /etc/bazzite/fixups/preempt_cleanup && $KARGS =~ "preempt" ]]; then
   echo "Removing full preemption (once)"
   NEEDED_KARGS+=("--delete-if-present=preempt=full")
 fi
-touch /etc/bazzite/fixups/preempt_cleanup
+NEEDED_KARGS_COMMANDS+=("touch /etc/bazzite/fixups/preempt_cleanup")
 
 if [[ $KARGS =~ "nomodeset" ]]; then
   echo "Removing nomodeset"
@@ -191,7 +192,13 @@ fi
 if [[ -n "$NEEDED_KARGS" ]]; then
   echo "Found needed karg changes, applying the following: ${NEEDED_KARGS[*]}"
   plymouth display-message --text="Preparing System - Please wait, this may take a while" || true
-  rpm-ostree kargs ${NEEDED_KARGS[*]} --reboot || exit 1
+
+  rpm-ostree kargs ${NEEDED_KARGS[*]} || exit 1
+  for command in "${NEEDED_KARGS_COMMANDS[@]}"; do
+    eval "$command"
+  done
+  echo "Rebooting system"
+  systemctl reboot
 else
   echo "No karg changes needed"
 fi

--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -39,7 +39,6 @@ MINIMUM_FREE_ZRAM=$(awk '/MemTotal/ {printf "%.0f", $2 * 0.01}' /proc/meminfo)
 CURRENT_FREE_ZRAM=$(sysctl vm.min_free_kbytes | awk '{print $3}')
 KARGS=$(rpm-ostree kargs)
 NEEDED_KARGS=()
-NEEDED_KARGS_COMMANDS=()
 
 # Add directory for fixups
 mkdir -p /etc/bazzite/fixups
@@ -135,14 +134,13 @@ fi
 
 # Remove sg_display
 if [[ ":83E1:ROG Ally RC71L:ROG Ally X RC72LA:" =~ ":$SYS_ID:" ]]; then
-  if [[ ! -f /etc/bazzite/fixups/sg_display && $KARGS =~ "amdgpu.sg_display" ]]; then
+  if [[ ! -f /etc/bazzite/fixups/sg_display2 && $KARGS =~ "amdgpu.sg_display" ]]; then
     echo "Removing sd_display=0 (it is not needed anymore)"
     NEEDED_KARGS+=("--delete-if-present=amdgpu.sg_display=0")
   fi
-  NEEDED_KARGS_COMMANDS+=("touch /etc/bazzite/fixups/sg_display")
 fi
 
-if [[ ! -f /etc/bazzite/fixups/orientation_old ]]; then
+if [[ ! -f /etc/bazzite/fixups/orientation_old2 ]]; then
   echo "Removing panel orientation for device in kernel if exists"
   if [[ ":ROG Ally RC71L:" =~ ":$SYS_ID:" ]]; then
     NEEDED_KARGS+=("--delete-if-present=video=eDP-1:panel_orientation=left_side_up")
@@ -155,7 +153,6 @@ if [[ ! -f /etc/bazzite/fixups/orientation_old ]]; then
   elif [[ ":ONEXPLAYER F1:ONEXPLAYER F1L:ONEXPLAYER F1 EVA-01:ONEXPLAYER X1Pro:Loki Max:Zeenix Pro:" =~ ":$SYS_ID:" ]]; then
     NEEDED_KARGS+=("--delete-if-present=video=eDP-1:panel_orientation=left_side_up")
   fi
-  NEEDED_KARGS_COMMANDS+=("touch /etc/bazzite/fixups/orientation_old")
 fi
 
 # Slide reboots randomly, acpi=strict seems to fix it
@@ -178,11 +175,10 @@ if [[ ! $KARGS =~ "disable_ertm" ]]; then
   NEEDED_KARGS+=("--append-if-missing=bluetooth.disable_ertm=1")
 fi
 
-if [[ ! -f /etc/bazzite/fixups/preempt_cleanup && $KARGS =~ "preempt" ]]; then
+if [[ ! -f /etc/bazzite/fixups/preempt_cleanup2 && $KARGS =~ "preempt" ]]; then
   echo "Removing full preemption (once)"
   NEEDED_KARGS+=("--delete-if-present=preempt=full")
 fi
-NEEDED_KARGS_COMMANDS+=("touch /etc/bazzite/fixups/preempt_cleanup")
 
 if [[ $KARGS =~ "nomodeset" ]]; then
   echo "Removing nomodeset"
@@ -192,16 +188,14 @@ fi
 if [[ -n "$NEEDED_KARGS" ]]; then
   echo "Found needed karg changes, applying the following: ${NEEDED_KARGS[*]}"
   plymouth display-message --text="Preparing System - Please wait, this may take a while" || true
-
   rpm-ostree kargs ${NEEDED_KARGS[*]} || exit 1
-  for command in "${NEEDED_KARGS_COMMANDS[@]}"; do
-    eval "$command"
-  done
-  echo "Rebooting system"
-  systemctl reboot
 else
   echo "No karg changes needed"
 fi
+# Applied / did not need to apply
+touch /etc/bazzite/fixups/sg_display2
+touch /etc/bazzite/fixups/preempt_cleanup2
+touch /etc/bazzite/fixups/orientation_old2
 
 if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   if /usr/libexec/hwsupport/valve-hardware; then


### PR DESCRIPTION
**Issue:**
The service `bazzite-hardware-setup` fails when updating kargs and internet access is required (updating metadata).

I'm using a vpn (mullvad) that blocks internet access on boot. In this scenario the fixup files are still written to `/etc/bazzite/fixups/**`.
Fixups files should only be written if kargs are successful.

**Fix:**
Collect commands the same way as the needed kargs and run them after applying kargs.

This won't fix the 'no internet' on boot issue but I think that's out of scope for this issue. It will work eventually when metadata gets updated.

The service could also have a trigger to run when the user session has started and if there is an active internet connection when it has failed on boot. `systemctl reboot` Would be inhibited by the user session.