### PR TITLE
fix: don't append /var/ublue-update/branch but overwrite it completey

### DIFF
--- a/system_files/deck/shared/usr/libexec/ublue-update-rebase
+++ b/system_files/deck/shared/usr/libexec/ublue-update-rebase
@@ -2,4 +2,4 @@
 set -e
 
 sudo mkdir -p /var/ublue-update/
-echo "$1" | sudo tee -a /var/ublue-update/branch > /dev/null
+echo "$1" | sudo tee /var/ublue-update/branch > /dev/null


### PR DESCRIPTION
This file should only have one line containing the selected branch. When it appends and has multiple ones, the script reading from it has problems detecting the branch because it uses 'cat' but gets a lot of lines instead of just one string without newline.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Fixes #1543
