### PR TITLE
feat: recommend ONLYOFFICE in the Office & Productivity section of Bazaar

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -161,6 +161,7 @@ sections:
     appids:
       - org.mozilla.Thunderbird
       - org.libreoffice.LibreOffice
+      - org.onlyoffice.desktopeditors
       - org.gimp.GIMP
       - org.kde.krita
       - org.inkscape.Inkscape


### PR DESCRIPTION
Only office does a better job than libre office at MS Word compatibility in my experience and it seems to be fairly commonly recommended + not so easy to discover for a new user. Seems like a good candidate to recommend as curated.