### PR TITLE
fix(nvidia): install egl-wayland alongside egl-wayland2

### DIFF
--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -40,7 +40,7 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2
         with:
           name: ${{ steps.generate-release.outputs.title }}
           tag_name: ${{ steps.generate-release.outputs.tag }}

--- a/Containerfile
+++ b/Containerfile
@@ -940,6 +940,7 @@ RUN --mount=type=cache,dst=/var/cache \
         mesa-vdpau-drivers.x86_64 \
         mesa-vdpau-drivers.i686 && \
     dnf5 -y install \
+        egl-wayland \
         egl-wayland2.x86_64 \
         egl-wayland2.i686 && \
     /ctx/ghcurl "https://raw.githubusercontent.com/ublue-os/main/refs/heads/main/build_files/nvidia-install.sh" --retry 3 -Lo /tmp/nvidia-install.sh && \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
It seems like there is no reason not to have both installed according to the [egl-wayland2](https://github.com/NVIDIA/egl-wayland2) project:
> This library can be installed alongside the previous egl-wayland implementation (https://github.com/NVIDIA/egl-wayland). The new library has a higher selection priority by default, so if both are present, then a 560 or later driver will select the new library, and an older driver will fall back to the old library.

I have tested this on my system both using `rpm-ostree install egl-wayland` and my custom image.
This resolves #3145 and possibly #3159.

So far I have not experienced any adverse effects from having both installed, but if anybody has a specific example of a reproducible egl-wayland2 improvement that I can use to test for regressions please let me know.