### PR TITLE
fix: KDE menu entries created via distrobox-export do not work (#3163)

### DIFF
--- a/system_files/desktop/kinoite/usr/bin/kde-ptyxis
+++ b/system_files/desktop/kinoite/usr/bin/kde-ptyxis
@@ -1,8 +1,16 @@
 #!/usr/bin/bash
 # Shim to handle KDE only supporting -e
 # https://bugs.kde.org/show_bug.cgi?id=459616
-args=("${@//-e/--}")
- 
+# We replace all standalone occurrences, but ignore others, e.g. in 'distrobox-enter'
+args=()
+for arg in ${@}; do
+        if [[ "$arg" == -e ]]; then
+                args+=("--")
+        else
+                args+=("$arg")
+        fi
+done
+
 # Dolphin integration requires --new-window to function properly
 if [[ ! "${args[@]}" =~ "--" && ! "${args[@]}" =~ "-h" && ! "${args[@]}" =~ "-x" ]]; then
         /usr/bin/ptyxis --new-window "${args[@]}"


### PR DESCRIPTION
The original code in `system_files/desktop/kinoite/usr/bin/kde-ptyxis` replaced all occurrences of `-e` by `--`, which mangled legit paths, e.g. `/usr/bin/distrobox-enter` became `/usr/bin/distrobox--nter`.
After the fix, only standalone occurrences are replaced and all others are ignored.
