### PR TITLE
fix(ujust): OpenTabletDriver: Add/remove tablet kernel modules

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -194,7 +194,7 @@ install-opentabletdriver:
     curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > $HOME/.config/systemd/user/opentabletdriver.service  && \
     systemctl --user daemon-reload && \
     systemctl enable --user --now opentabletdriver.service && \
-    rpm-ostree kargs --append=modprobe.blacklist=hid_uclogic --append=modprobe.blacklist=wacom
+    rpm-ostree kargs --append-if-missing=modprobe.blacklist=hid_uclogic --append-if-missing=modprobe.blacklist=wacom
 
 # Remove OpenTabletDriver
 [group("hardware")]
@@ -205,7 +205,7 @@ remove-opentabletdriver:
     sudo -A rm /etc/udev/rules.d/71-opentabletdriver.rules && \
     flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver && \
     systemctl disable --user --now opentabletdriver.service && \
-    rpm-ostree kargs --delete=modprobe.blacklist=hid_uclogic --delete=modprobe.blacklist=wacom
+    rpm-ostree kargs --delete-if-present=modprobe.blacklist=hid_uclogic --delete-if-present=modprobe.blacklist=wacom
 
 # Create fedora distrobox if it doesn't exist
 [private]


### PR DESCRIPTION
Fell down this rabbit hole after opening https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4066.

Per [the Flatpak guide](https://github.com/flathub/net.opentabletdriver.OpenTabletDriver/blob/master/docs/Manual-install.md#fedora-atomic), to ensure all supported tablets work properly, you should blacklist 2 kernel-level tablet modules from modprobe.

I've confirmed that running `rpm-ostree kargs --append=modprobe.blacklist=hid_uclogic --append=modprobe.blacklist=wacom` & rebooting makes my XP-Pen Artist 16 (1st gen) work with OTD when it otherwise wouldn't. I'm unsure of the side effects this could cause, as I do not own a Wacom tablet.
