### PR TITLE
feat: add rpm-ostree status in ujust get-logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -25,8 +25,8 @@ body:
   - type: textarea
     id: version
     attributes:
-      label: Output of `rpm-ostree status`
-      description: Please run `rpm-ostree status` and paste the output here.
+      label: Output of `ujust get-logs`
+      description: Please run `ujust get-logs` and paste the output here.
       render: shell
     validations:
       required: true

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -805,6 +805,11 @@ get-logs:
     #!/bin/bash
     set -euo pipefail
     source /usr/lib/ujust/ujust.sh
+    # Get system status information
+    echo -e "${bold}System Information:${normal}"
+    echo " "
+    rpm-ostree status
+    echo " "
     # Get logs for this boot
     this_boot_logs=$(journalctl -b | fpaste 2>/dev/null)
     echo -e "${bold}Logs This Boot:${normal} $this_boot_logs"
@@ -813,3 +818,13 @@ get-logs:
     last_boot_logs=$(journalctl -b -1 | fpaste 2>/dev/null)
     echo -e "${bold}Logs Last Boot:${normal} $last_boot_logs"
     echo " "
+    # Concatenate all outputs and copy to clipboard
+    {
+      echo "System Information:"
+      rpm-ostree status
+      echo
+      echo "Logs This Boot: $this_boot_logs"
+      echo
+      echo "Logs Last Boot: $last_boot_logs"
+    } | wl-copy
+    echo -e "${green}All output has been copied to your clipboard.${normal}"


### PR DESCRIPTION
from discord convo when troubleshooting: https://discord.com/channels/1072614816579063828/1087140957096517672/1415843918980841545

simple addition to `ujust get-logs` to also get rpm-ostree status output. 

Also copies it to clipboard for easy pasting into discord/github for troubleshooting



<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
