### PR TITLE
fix(gamescope): rm gamemode clipboard feature

### DIFF
--- a/system_files/nvidia/shared/usr/bin/bazzite-steam
+++ b/system_files/nvidia/shared/usr/bin/bazzite-steam
@@ -22,9 +22,6 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
     /usr/bin/bazzite-steam-brand
   fi
 
-  # Set helpful clipboard content for launch options on handheld devices
-  echo -n " %command%" | wl-copy 2>/dev/null || true
-
   # File toggle to override default Steam Deck flag behavior
   DECK_OVERRIDE_FLAG="$HOME/.config/bazzite/disable_steamdeck_flag"
 


### PR DESCRIPTION
This never worked properly, as I suppose it is initiated before the wayland session is live so `wl-copy` doesn't function. 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
