### PR TITLE
chore: update ujust picker repo to bazzite-org

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/90-bazzite-picker.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/90-bazzite-picker.just
@@ -6,7 +6,7 @@ pick:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    REPO="xXJSONDeruloXx/bazzite-ujust-picker"
+    REPO="bazzite-org/bazzite-ujust-picker"
     DEST="$HOME/.local/bin/ujust-picker"
 
     # Ensure local bin directory exists


### PR DESCRIPTION
Moved ujust picker over to bazzite-org from my personal repo, updating ujust to new destination. better accountability and governance going forward

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
