### PR TITLE
Feat/changelog authors

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -295,7 +295,7 @@ def get_commits(prev_manifests, manifests, workdir: str):
             parts = commit.split(" ", 3)
             if len(parts) < 4:
                 continue
-            hash, short, subject, author = parts
+            commit_hash, short, subject, author = parts
 
             if subject.lower().startswith("merge"):
                 continue
@@ -303,7 +303,7 @@ def get_commits(prev_manifests, manifests, workdir: str):
             out += (
                 COMMIT_FORMAT.replace("{short}", short)
                 .replace("{subject}", subject)
-                .replace("{hash}", hash)
+                .replace("{hash}", commit_hash)
                 .replace("{author}", author)
             )
 

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -35,8 +35,8 @@ OTHER_NAMES = {
     # "surface": "### Surface Images\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
 }
 
-COMMITS_FORMAT = "### Commits\n| Hash | Subject |\n| --- | --- |{commits}\n\n"
-COMMIT_FORMAT = "\n| **[{short}](https://github.com/ublue-os/bazzite/commit/{hash})** | {subject} |"
+COMMITS_FORMAT = "### Commits\n| Hash | Subject | Author |\n| --- | --- | --- |{commits}\n\n"
+COMMIT_FORMAT = "\n| **[{short}](https://github.com/ublue-os/bazzite/commit/{hash})** | {subject} | @{author} |"
 
 CHANGELOG_TITLE = "{tag}: {pretty}"
 CHANGELOG_FORMAT = """\
@@ -281,7 +281,7 @@ def get_commits(prev_manifests, manifests, workdir: str):
                 "-C",
                 workdir,
                 "log",
-                "--pretty=format:%H %h %s",
+                "--pretty=format:%H %h %s %an",
                 f"{start}..{finish}",
             ],
             check=True,
@@ -292,7 +292,10 @@ def get_commits(prev_manifests, manifests, workdir: str):
         for commit in commits.split("\n"):
             if not commit:
                 continue
-            hash, short, subject = commit.split(" ", 2)
+            parts = commit.split(" ", 3)
+            if len(parts) < 4:
+                continue
+            hash, short, subject, author = parts
 
             if subject.lower().startswith("merge"):
                 continue
@@ -301,6 +304,7 @@ def get_commits(prev_manifests, manifests, workdir: str):
                 COMMIT_FORMAT.replace("{short}", short)
                 .replace("{subject}", subject)
                 .replace("{hash}", hash)
+                .replace("{author}", author)
             )
 
         if out:


### PR DESCRIPTION
@KyleGospo saw you merged before I got this commit in, there was a minor codacy flag that made that job fail, if thats going to be a problem with kicking off a build this should fix, just renaming the var so its not treated like Python's hash function for the scan

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
