### PR TITLE
fix(gnome): Re-enable gnome's "experimental features"

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -390,7 +390,7 @@ fi
 
 # Fix Gnome experimental-features when we switched to fedora mutter
 # FIXME: This fix was added in 09/2025, remove it when vrr and fractional scaling are no longer experimental
-if [[ ! -f /etc/bazzite/fixups/gnome_fixup && $IMAGE_FLAVOR =~ "gnome" ]]; then
+if [[ ! -f /etc/bazzite/fixups/gnome_fixup && $IMAGE_NAME =~ "gnome" ]]; then
   echo "Enabling VRR and fractional scaling"
   gsettings set org.gnome.mutter experimental-features "['variable-refresh-rate', scale-monitor-framebuffer', 'xwayland-native-scaling']"
 fi


### PR DESCRIPTION

Add a check in bazzite-hardware-setup to re-enable VRR, fractional scaling, and xwayland native scaling in Gnome/Mutter, since this was not set when mutter was changed from bazzite-org to fedora's.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
