### PR TITLE
fix: re-add hidden ujust to fix GPP0 wake on Gigabyte mobos

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/disable-gpp0-wakeup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/disable-gpp0-wakeup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Workaround for Gigabyte BIOS sleep/wakeup bug
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'if grep 'GPP0' /proc/acpi/wakeup | grep -q 'enabled'; then echo 'GPP0' > /proc/acpi/wakeup; fi'
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -295,6 +295,31 @@ toggle-i915-sleep-fix:
         ;;
     esac
 
+# Toggle GPP0 wakeup fix to prevent unwanted system wake-ups, primarily affects Gigabyte motherboards.
+[group("hardware")]
+_toggle-gpp0-wakeup-fix:
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    if systemctl is-enabled disable-gpp0-wakeup.service &>/dev/null; then
+      echo "Current status: ${green}${bold}enabled${normal}"
+      CHOICE=$(ugum choose "Disable GPP0 wakeup fix" "Exit without changes")
+      if [[ "$CHOICE" == "Disable GPP0 wakeup fix" ]]; then
+        sudo systemctl disable --now disable-gpp0-wakeup.service
+        echo "GPP0 wakeup fix ${red}${bold}disabled${normal}."
+      else
+        echo "No changes made."
+      fi
+    else
+      echo "Current status: ${red}${bold}disabled${normal}"
+      CHOICE=$(ugum choose "Enable GPP0 wakeup fix" "Exit without changes")
+      if [[ "$CHOICE" == "Enable GPP0 wakeup fix" ]]; then
+        sudo systemctl enable --now disable-gpp0-wakeup.service
+        echo "GPP0 wakeup fix ${green}${bold}enabled${normal}."
+      else
+        echo "No changes made."
+      fi
+    fi
+
 # Manage Steam game shortcuts on the Desktop. Usage: just steam-icons [command] (list, remove, enable, disable)
 steam-icons ACTION="":
     #!/usr/bin/bash


### PR DESCRIPTION
Initially implemented first as a ujust, then as a udev rule here: https://github.com/ublue-os/bazzite/pull/3025

then reverted as it had adverse effects on select gigabyte motherboards here: https://github.com/ublue-os/bazzite/pull/3200

to split the difference, heres a hidden ujust so its available for those who need it, but not a footgun for those who it won't apply to. This way its something we can easily point to (or I can apply to my HTPC when I next break my install!), instead of digging up the og reddit discussion and solution this is sourced from:

https://github.com/DAK404/OpenSUSE-Setup-Scripts/blob/main/Scriptlets/Fixes-and-Tweaks/Fix-GigabyteDesktopSleepFix.sh

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
