### PR TITLE
fix(cec): flaky shutdown and sleep

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onpoweroff.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onpoweroff.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run CEC actions for poweroff
 DefaultDependencies=no
-Before=final.target
+Before=poweroff.target
 
 [Service]
 Type=oneshot

--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onsleep.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onsleep.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run CEC actions for sleep
 DefaultDependencies=no
-Before=final.target
+Before=sleep.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This PR fixes #3296 by running `cec-control` earlier in the shutdown/sleep process. As explained in the [doc](https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html) of `final.target` makes it clear it should not be the default target for this kind of behavior I believe:
> final.target:
> A special target unit that is used during the shutdown logic and may be used to pull in late services after all normal services are already terminated and all mounts unmounted.

This includes `/dev` where the serial port is which may or may not be available at that time. 