### PR TITLE
fix(intel): set GSK_RENDERER to gl for Intel Xe/Arc gpus

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -578,6 +578,7 @@ RUN --mount=type=cache,dst=/var/cache \
     systemctl --global disable sunshine.service && \
     systemctl disable waydroid-container.service && \
     systemctl disable force-wol.service && \
+    systemctl --global enable bazzite-dynamic-fixes.service && \
     /ctx/ghcurl "https://raw.githubusercontent.com/doitsujin/dxvk/master/dxvk.conf" -Lo /etc/dxvk-example.conf && \
     /ctx/ghcurl "https://raw.githubusercontent.com/bazzite-org/waydroid-scripts/main/waydroid-choose-gpu.sh" -Lo /usr/bin/waydroid-choose-gpu && \
     chmod +x /usr/bin/waydroid-choose-gpu && \

--- a/system_files/desktop/shared/usr/lib/systemd/user/bazzite-dynamic-fixes.service
+++ b/system_files/desktop/shared/usr/lib/systemd/user/bazzite-dynamic-fixes.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Configure Bazzite for current user
+ConditionUser=!@system
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/bazzite-dynamic-fixes
+
+[Install]
+WantedBy=default.target

--- a/system_files/desktop/shared/usr/libexec/bazzite-dynamic-fixes
+++ b/system_files/desktop/shared/usr/libexec/bazzite-dynamic-fixes
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# Intel Xe/Arc gpus need the GSK_RENDERER set to gl to avoid graphical glitches with GTK4/libadwaita applications
+# This script dynamically detects if such a gpu is present by checking if the xe module is loaded and apply the workaround
+# and then remove the workaround, if it is applied but the xe module is not loaded (thereby no affected gpu is in use)
+if lsmod | grep -P "^xe " > /dev/null && [ ! -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
+    # Set GSK_RENDERER to gl for the user
+    mkdir -p "$HOME/.config/environment.d"
+    echo "GSK_RENDERER=gl" > "$HOME/.config/environment.d/intel-gtk-fix.conf"
+elif ! lsmod | grep -P "^xe " > /dev/null && [ -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
+    # Remove the env var file as no intel xe/arc gpu is being used.
+    rm "$HOME/.config/environment.d/intel-gtk-fix.conf"
+fi


### PR DESCRIPTION
workaround for hardware accelerated gtk4/libadwaita applications on intel xe/arc gpus the fix disables itself when it detects the xe module is not loaded.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
