### PR TITLE
fix(ujust): fix kvmfr udev permissions

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -205,13 +205,13 @@ setup-virtualization ACTION="":
     # Find the current value by running "rpm-ostree kargs"
     KVMFR_MODPROBE'
       rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128" --append-if-missing="split_lock_detect=off"
-      if [ -f "/etc/udev/rules.d/99-kvmfr.rules" ]; then
+      if [ -f "/etc/udev/rules.d/70-kvmfr.rules" ]; then
         echo "Re-creating kvmfr udev rules"
-        sudo rm /etc/udev/rules.d/99-kvmfr.rules
+        sudo rm /etc/udev/rules.d/70-kvmfr.rules
       fi
       echo "Adding udev rule for /dev/kvmfr0"
-      sudo bash -c 'cat << KVMFR_UDEV > /etc/udev/rules.d/99-kvmfr.rules
-    SUBSYSTEM=="kvmfr", OWNER="'$USER'", GROUP="qemu", MODE="0660"
+      sudo bash -c 'cat << KVMFR_UDEV > /etc/udev/rules.d/70-kvmfr.rules
+    SUBSYSTEM=="kvmfr", TAG+="uaccess", GROUP="qemu", MODE="0660"
     KVMFR_UDEV'
       echo "Adding /dev/kvmfr0 to qemu cgroup_device_acl"
       sudo perl -0777 -pi -e 's/


### PR DESCRIPTION
Since Bazzite 43,  `ujust setup-virtualization`'s `udev` rule handling permissions on `/dev/kvmfr0` no longer works due to a breaking change in SystemD 258.

If a udev rule has `OWNER` set to a user who is not a "system" user, `systemd-udevd` will not only ignore just the `OWNER` part - *it will refuse to process the entire rule:*

```
User 'myuser' is not a system user, ignoring.
```

Some discussion about it (not linking directly because SystemD discussions can get a bit heated):

```
https://github.com/systemd/systemd/issues/39056
```

I don't agree with this change, but "playing the game" seems to be the path of least resistance for Bazzite.

This PR changes two things:

- Renames the rule to have a prefix of `70-` (it needs to run before `73-seat-late.rules` or `uaccess` will be ignored; the prefix of `99-` did not work in my tests).
- Drops `OWNER` and adds a `uaccess` tag. This adds an ACL for our currently logged in seat (I beleive this is `seat0` in `loginctl list-sessions`).

The result of this change:

- `/dev/kvmfr0` is now owned by `root:qemu` with mode `0660`; the `qemu` group can now read/write it.
- `uaccess` ACL grants the currently logged in user access; now the user's Looking Glass client can read it.

I tested this and now I can cleanly run Looking Glass, the VM will start, etc.

I probably also could have just added the current user to the `qemu` group, but I think `uaccess` is cleaner in this case with less side effects.

(Apologies for the force pushes, the semantic PR check was unhappy and I didn't want to add work for you guys to handle multiple commit messages)