### PR TITLE
refactor(ujust): Create 'applications' folder if it doesn't exist yet in Waydroid initialization script

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
@@ -31,6 +31,7 @@ setup-waydroid ACTION="":
       echo "This might take a bit, please be patient"
       sudo waydroid init -c 'https://ota.waydro.id/system' -v 'https://ota.waydro.id/vendor'
       sudo restorecon -R /var/lib/waydroid
+      mkdir -p ~/.local/share/applications
       cp /usr/share/applications/waydroid-container-restart.desktop ~/.local/share/applications
       echo "Waydroid has been initialized, please run waydroid once before you Configure Waydroid"
     elif [[ "${OPTION,,}" =~ ^configure ]]; then


### PR DESCRIPTION
When a user initializes Waydroid immediately after installing Bazzite, the `~/.local/share/applications` directory might not be created yet. So, `/usr/share/applications/waydroid-container-restart.desktop` will be copied as a file called `~/.local/share/applications`, breaking other apps that export to `applications/` like Gear Lever (such as in #3382).

This PR adds a line to create `~/.local/share/applications` before copying `waydroid-container-restart.desktop` to prevent this error.