### PR TITLE
Fix(ujust): Correct typo in variable for coolercontrol

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -52,7 +52,7 @@ install-coolercontrol:
     if [ ${#packages[@]} -gt 0 ]; then
         repo_path="/etc/yum.repos.d/terra.repo"
 
-        if ( ! grep -q "enabled=0" "$repopath" ); then  # if not matches found
+        if ( ! grep -q "enabled=0" "$repo_path" ); then  # if not matches found
             echo 'Terra Repository is already enabled, skipping.'
         else
             echo 'Enabling Terra Repository.'


### PR DESCRIPTION
There was a typo in a variable that lead to the repo not getting enabled.