### PR TITLE
fix(gamescope): update to latest commit hash

### DIFF
--- a/spec_files/gamescope/gamescope.spec
+++ b/spec_files/gamescope/gamescope.spec
@@ -3,7 +3,7 @@
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
 #global gamescope_tag 3.15.11
-%global gamescope_commit 2f30679c80791844c29402d232462874fe23dd46 
+%global gamescope_commit 0353480065d2fb2b90e833fd1697676f8c8bad61
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           gamescope


### PR DESCRIPTION
I actually don't completely know how this works or if I need to rebase/reapply all of the patches listed here, but I'm hoping to gamescope HDR fixes from [this issue](https://github.com/ValveSoftware/gamescope/pull/1999) into the bazzite build.

I'm happy to do more work if necessary, just took a cursory look and thought maybe it's as simple as updating the commit hash here. It seemed like previous commits to the file only bumped the hash so I figure why not give it a shot :stuck_out_tongue: 

Leaving this in draft just to see if CI freaks out and pending help from anyone who might know what up