### PR TITLE
Fix #3399 xbox360 wireless dpad mapping 

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-steam
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam
@@ -28,12 +28,16 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   else
     DECK_OPTION=""
   fi
-
-  # HHD Support
-  if ! /usr/libexec/hwsupport/valve-hardware; then
-      export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
-  fi
 fi
+
+# HHD Support
+# Fix XBOX 360 Wireless Controller for kernels >= 6.17 and SDL < 3.4.x
+export SDL_GAMECONTROLLERCONFIG=$(cat <<-END
+060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,
+0300a81c5e040000a102000000010000,X360 Wireless Controller,a:b0,b:b1,back:b6,dpdown:b12,dpleft:b13,dpright:b14,dpup:b11,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,platform:Linux,crc:1ca8,
+$SDL_GAMECONTROLLERCONFIG
+END
+)
 
 switcheroo_state="$(switcherooctl list)"
 DGPU_OPTION=""

--- a/system_files/nvidia/shared/usr/bin/bazzite-steam
+++ b/system_files/nvidia/shared/usr/bin/bazzite-steam
@@ -31,12 +31,16 @@ if [[ $IMAGE_NAME =~ "deck" || $IMAGE_NAME =~ "ally" ]]; then
   else
     DECK_OPTION=""
   fi
-
-  # HHD Support
-  if ! /usr/libexec/hwsupport/valve-hardware; then
-      export SDL_GAMECONTROLLERCONFIG="060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,"
-  fi
 fi
+
+# HHD Support
+# Fix XBOX 360 Wireless Controller for kernels >= 6.17 and SDL < 3.4.x
+export SDL_GAMECONTROLLERCONFIG=$(cat <<-END
+060000000d0f00009601000000000000,Steam Controller (HHD),a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,paddle1:b13,paddle2:b12,paddle3:b15,paddle4:b14,misc2:b11,misc3:b16,misc4:b17,crc:ea35,
+0300a81c5e040000a102000000010000,X360 Wireless Controller,a:b0,b:b1,back:b6,dpdown:b12,dpleft:b13,dpright:b14,dpup:b11,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,platform:Linux,crc:1ca8,
+$SDL_GAMECONTROLLERCONFIG
+END
+)
 
 switcheroo_state="$(switcherooctl list)"
 DGPU_OPTION=""


### PR DESCRIPTION
Recent changes to xpad kernel driver in kernel 6.17 broke controller DPad mappings for Xbox 360 wireless for all existing deployments of SDL libraries, including statically linked ones.

Changing button mappings in Steam and enabling Steam Input works as a temporary workaround, but is overwritten by steam itself every time it is restarted (`.steam/steam/config/config.vdf` contains `SDL_GamepadBind` variable with button mappings, but its value is refreshed with SDL-provided mappings if match is found every time the Steam starts).

Try to allieviate this pain by passing a now-correct DPad mapping as `SDL_GAMECONTROLLERCONFIG` environment variable.

In case of more troubles in the future similar to this one, to enable end-users to provide their own mappings as quick-fixes, `bazzite-steam` script was modified to not overwrite an existing `SDL_GAMECONTROLLERCONFIG` environment variable, but to prepend new mappings to it.

Finally a new mapping is injected, similarly to how support for HHD is added.
    
upstream kernel discussion:
https://lore.kernel.org/all/20250702034740.124817-1-vi@endrift.com/