### PR TITLE
fix: enable aptx again by adding pipewire-codec-aptx to installation list

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -183,7 +183,8 @@ RUN --mount=type=cache,dst=/var/cache \
         libaacs \
         libbdplus \
         libbluray \
-        libbluray-utils && \
+        libbluray-utils \
+        pipewire-codec-aptx && \
     /ctx/cleanup
 
 # Remove unneeded packages


### PR DESCRIPTION
Trying to solve https://github.com/ublue-os/bazzite/issues/3419. 