### PR TITLE
feat(bazzite-hardware-setup): Add workaround for nvidia flatpak mismatch

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -6,7 +6,7 @@ IMAGE_BRANCH=$(jq -r '."image-branch"' < $IMAGE_INFO)
 FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 
 # SCRIPT VERSION
-HWS_VER=64
+HWS_VER=65
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VER_FILE)
 
@@ -18,10 +18,17 @@ KNOWN_IMAGE_BRANCH=$(cat $KNOWN_IMAGE_BRANCH_FILE)
 KNOWN_FEDORA_VERSION_FILE="/etc/bazzite/fedora_version"
 KNOWN_FEDORA_VERSION=$(cat $KNOWN_FEDORA_VERSION_FILE)
 
+# NVIDIA DRIVER VERSION IDENTIFIERS
+if [[ $IMAGE_NAME =~ "nvidia" ]]; then
+    FLATPAK_NVIDIA_VERSION=$(flatpak list --runtime | grep nvidia | grep -Eo "[0-9]+-[0-9]+-[0-9]+" | tail -1)
+    SYSTEM_NVIDIA_VERSION=$(cat /proc/driver/nvidia/version | grep NVIDIA | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" | tr '.' '-')
+fi
+
 if [[ "$KNOWN_IMAGE_NAME" == "$IMAGE_NAME" && \
     "$KNOWN_IMAGE_BRANCH" == "$IMAGE_BRANCH" && \
     "$KNOWN_FEDORA_VERSION" == "$FEDORA_VERSION" && \
-    "$HWS_VER_RAN" == "$HWS_VER" ]]; then
+    "$HWS_VER_RAN" == "$HWS_VER" && \
+    "$SYSTEM_NVIDIA_VERSION" == "$FLATPAK_NVIDIA_VERSION" ]]; then
   echo "Hardware setup already ran for version $HWS_VER_RAN, skipping"
   exit 0
 fi
@@ -361,6 +368,16 @@ if [ ! -f /etc/bazzite/fixups/hhd_service_cleanup ]; then
     systemctl disable --now "$service" || true
   done
   touch /etc/bazzite/fixups/hhd_service_cleanup
+fi
+
+# Fix Flatpak and System Nvidia driver mismatch
+# FIXME: This fix was added in 12/2025, remove it when there is a proper fix for this issue
+if [[ "$SYSTEM_NVIDIA_VERSION" != "$FLATPAK_NVIDIA_VERSION" && \
+    $IMAGE_NAME =~ "nvidia" ]]; then
+  echo "Installing Nvidia Flatpak runtime"
+  flatpak install -y org.freedesktop.Platform.GL.nvidia-$SYSTEM_NVIDIA_VERSION org.freedesktop.Platform.GL32.nvidia-$SYSTEM_NVIDIA_VERSION
+else
+  echo "No Flatpak runtime changes needed"
 fi
 
 if [[ -n "$NEEDED_KARGS" ]]; then


### PR DESCRIPTION
This adds two new variables, `$SYSTEM_NVIDIA_VERSION` and `$FLATPAK_NVIDIA_VERSION`. 
The variables will be empty if the system is not nvidia. 
If they have a mismatch, install the matching version on flatpak.

This should fix the nvidia system and flatpak driver mismatch issue, however as yukidream mentioned in #bazzite-dev, there appears to be a better way to fix it.