### PR TITLE
fix(ujust): enable Ryzenadj max performance

### DIFF
--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -75,10 +75,10 @@ enable-ryzenadj-max-performance:
     #/bin/bash
     # credit to adolforegosa on discord for the original fix and Katman for the script corrections
     echo 'this fix sets ryzenadj --max-performance whenever AC status changes to battery from plugged-in'
-    echo 'ACTION=="change", SUBSYSTEM=="power_supply", ATTR{online}=="0", RUN+="/bin/sh -c '/usr/bin/ryzenadj --max-performance'"' | sudo tee "/etc/udev/rules.d/99-ryzenadj-power-source-change.rules" > /dev/null
+    echo 'ACTION=="change", SUBSYSTEM=="power_supply", ATTR{online}=="0", RUN+="/usr/bin/ryzenadj --max-performance"' | sudo tee "/etc/udev/rules.d/99-ryzenadj-power-source-change.rules" > /dev/null
 
     sudo udevadm control --reload-rules
-    sudo cat > /etc/systemd/system/max-perf-boot.service<< EOF
+    cat <<EOF | sudo tee /etc/systemd/system/max-perf-boot.service > /dev/null
 [Unit]
 Description=Apply RyzenAdj max performance at boot
 


### PR DESCRIPTION
Fix: Corrected the ujust script for enabling and disabling the max-performance mode in ryzenadj.

Previously the script would not run after every plug or unplug due to syntax issues with the "add|change" part of the script, and the fact that the run portion had an invalid bin/sh which would lose single quotes when written, but I corrected it and it now successfully runs and writes all files properly.

It also left an edge case where if you booted the device while unplugged, it would never run the script and you would experience the performance issue until plugging and unplugging again. I added a oneshot boot service to fix that.