### PR TITLE
fix: cec race fix for DP to HDMI adaptors

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onpoweroff.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onpoweroff.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run CEC actions for poweroff
 DefaultDependencies=no
-Before=poweroff.target
+Before=systemd-poweroff.service poweroff.target
 
 [Service]
 Type=oneshot

--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onsleep.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onsleep.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run CEC actions for sleep
 DefaultDependencies=no
-Before=sleep.target
+Before=systemd-suspend.service systemd-hibernate.service systemd-hybrid-sleep.service systemd-suspend-then-hibernate.service sleep.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
messing with the Ugreen dp1.4>HDMI2.1 adaptor with CEC, its particularly susceptible to a suspend race for cec-control service to fail to send onsleep to tv when suspending. This mirrors similar approach from this forum post that addresses this, in my quick tests it is more reliable on the DP adaptor as that exposes `/dev/cec0` which is different than the pulse8 adaptor which can send from usb after HDMI is down

https://universal-blue.discourse.group/t/pulse-eight-hdmi-cec-support/7064/2

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
