### PR TITLE
fix: prevent NM from starting before iwd inits

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/NetworkManager.service.d/iwd.conf
+++ b/system_files/desktop/shared/usr/lib/systemd/system/NetworkManager.service.d/iwd.conf
@@ -1,0 +1,4 @@
+[Unit]
+# Ensure iwd is started before NetworkManager when using iwd as WiFi backend
+Wants=iwd.service
+After=iwd.service


### PR DESCRIPTION
when rebasing from stable to testing, the iwd defaulting swap recently is causing wifi to be unusable, with some logs like

`iwd: station: Network configuration is disabled.`

`iwd: station: Quick network configuration is disabled.`

`device (wlp4s0): state change: unavailable -> unmanaged (reason 'unmanaged-link-not-init')`

fix was to rebase back to stable, run `ujust toggle-iwd enable` then rebase back to testing (which removes this recipe entirely)

to make transition smoother for users especially when this goes to main, I think (but could be very wrong, new to the networking services side here) that the fix is to ensure that NetworkingManager does not start before iwd has initiated the wifi device, hence the `unmanaged-link-not-init`.

Soooo I think best way to solve here is add a conf for NM service to force it after init of iwd? If we are all in on only iwd going forward (implied by the removal of the ujust) then this shouldn't be an issue right? Do let me know if theres anything here I have wrong!


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
