### PR TITLE
fix(crh): fix a pipefail in print_status

### DIFF
--- a/system_files/desktop/shared/usr/bin/custom-resolution-helper
+++ b/system_files/desktop/shared/usr/bin/custom-resolution-helper
@@ -55,7 +55,7 @@ confirm_reboot() {
 print_status() {
   KARGS=$(rpm-ostree kargs)
   echo -n "Current custom resolution(s) are: "
-  MODEDB_OPTS=$(echo "$KARGS" | grep -oP 'video=\K[^ ]*')
+  MODEDB_OPTS=$(echo "$KARGS" | grep -oP 'video=\K[^ ]*' || true)
   if [ -z "$MODEDB_OPTS" ]; then
     echo -n "${bold}None${normal}"
   else


### PR DESCRIPTION
Throw away the results of grep, as that is immediately handled afterwards.

This fixes an issue where the script exits if there is no custom resolutions set, which is presumably not very useful for users.