### PR TITLE
feat(liveiso): Enhance live session welcome dialog

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -437,17 +437,34 @@ rm -vf /etc/skel/.config/autostart/steam*.desktop
 # Remove packages that shouldnt be used in a live session
 dnf -yq remove steam lutris || :
 
-# Warn about limited capabilities of live sessions
+# Warn about limited capabilities of live sessions, and also show buttons to:
+#   - Install Bazzite
+#   - Launch Bootloader Restoring tool
+#   - Close dialog
 cat >>/usr/bin/on_gui_login.sh <<'EOF'
-yad --timeout=30 \
+_RETVAL=0
+yad \
     --no-escape \
-    --no-buttons \
     --on-top \
     --timeout-indicator=bottom \
     --text-align=center \
+    --buttons-layout=center \
     --title="Welcome" \
     --text="\nWelcome to the Live ISO for Bazzite\!\n\nThe Live ISO is designed for installation and troubleshooting.\nBecause of this, it is <b>not capable of playing games.</b>\n\nPlease do not use it for benchmarks as it\ndoes not represent the installed experience.\n" \
-    || :
+    --button="Install Bazzite:10" \
+    --button="Launch Bootloader Restoring tool:20"
+    --button="Close dialog:0"
+_RETVAL=$?
+
+case $_RETVAL in
+    10)
+        liveinst & disown $!
+        ;;
+    20)
+        /usr/bin/bootloader_restore.sh & disown $!
+        ;;
+    0) : ;;
+esac
 EOF
 
 (


### PR DESCRIPTION
Add interactive buttons to the yad welcome dialog in the live ISO. Provide options to "Install Bazzite" and "Launch Bootloader Restoring tool" directly from the dialog. This improves user experience by making the initial live session dialog more functional.