### PR TITLE
fix(iso): handle nvidia-gnome to gnome-nvidia naming mismatch

### DIFF
--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -91,6 +91,10 @@ jobs:
         run: |
           ref="${{ matrix.image_name }}"
           ref="${ref/-deck/}"
+          # Handle naming mismatch: deck uses nvidia-gnome, non-deck uses gnome-nvidia
+          if [[ "$ref" == "bazzite-nvidia-gnome" ]]; then
+            ref="bazzite-gnome-nvidia"
+          fi
           echo "ref=${ref}" >> $GITHUB_OUTPUT
 
       - name: Build ISOs


### PR DESCRIPTION
The change fixes a naming inconsistency where deck images use bazzite-nvidia-gnome but non-deck images use bazzite-gnome-nvidia. The added conditional corrects the reference name during ISO builds.