### PR TITLE
feat: rm nonfunctional steamdeck=0 global arg, replace with rdna3 fsr4 global toggle

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -591,14 +591,14 @@ toggle-global-fsr4 ACTION="":
             ;;
     esac
 
-# Toggle global SteamDeck=0 environment variable to prevent games from detecting hardware as a Steam Deck. Useful for HTPC setups to avoid hidden settings or forced lower textures.
+# Toggle global Proton FSR4 upgrade on RDNA3 GPUs; upgrades FSR 3.1+ → FSR 4, only compatible with Proton GE, Proton EM, or similar forks
 [group("gaming")]
-toggle-steamdeck-var ACTION="":
+toggle-global-fsr4-rdna3 ACTION="":
     #!/usr/bin/bash
     set -euo pipefail
     source /usr/lib/ujust/ujust.sh
 
-    FILE="$HOME/.config/environment.d/99-steamdeck-var.conf"
+    FILE="$HOME/.config/environment.d/99-proton-fsr4-rdna3.conf"
 
     CURRENT="Disabled"
     if [[ -f "$FILE" ]]; then
@@ -607,12 +607,13 @@ toggle-steamdeck-var ACTION="":
 
     OPTION="{{ ACTION }}"
     if [[ -z "$OPTION" ]]; then
-        echo -e "${bold}SteamDeck=0 Environment Variable:${normal} $CURRENT"
+        echo -e "${bold}Global FSR4 (RDNA3):${normal} $CURRENT"
         echo ""
-        echo "Sets the SteamDeck environment variable to 0 globally."
-        echo "This prevents most games from detecting your hardware as a Steam Deck,"
-        echo "which can avoid hidden settings, forced lower textures, or FPS locks."
-        echo "Useful for HTPC setups or when using gamescope session on non-Deck hardware."
+        echo "Enables Proton's FSR4 upgrade path on RDNA3 GPUs (e.g. RX 7900 XTX)."
+        echo "When enabled, Proton can upgrade games using FSR 3.1+ to FSR 4 (FP8 Emulation)"
+        echo "and automatically fetch the required FSR4 DLL."
+        echo ""
+        echo -e "${bold}Note:${normal} This is only compatible with Proton GE, Proton EM, or similar forks."
         echo ""
         OPTION="$(ugum choose "Enable" "Disable" "Exit without saving")"
     fi
@@ -620,12 +621,12 @@ toggle-steamdeck-var ACTION="":
     case "$OPTION" in
         Enable|enable)
             mkdir -p "$HOME/.config/environment.d"
-            echo "SteamDeck=0" > "$FILE"
-            echo -e "${green}${bold}Enabled${normal}: SteamDeck=0"
+            echo "PROTON_FSR4_RDNA3_UPGRADE=1" > "$FILE"
+            echo -e "${green}${bold}Enabled${normal}: PROTON_FSR4_RDNA3_UPGRADE=1"
             ;;
         Disable|disable)
             rm -f "$FILE"
-            echo -e "${red}${bold}Disabled${normal}: SteamDeck=0 removed"
+            echo -e "${red}${bold}Disabled${normal}: PROTON_FSR4_RDNA3_UPGRADE removed"
             ;;
         *)
             echo "No changes made."


### PR DESCRIPTION
as discussed in the discord:

SteamDeck=0 global toggle is definitely being overridden on the -deck images via the steam client launched in -steamdeck arg, despite our `.config/environment.d`  var set otherwise, steam overrides this unless you have pre launch args set up behind `%command%`

Proof (while game running, with global enabled, but no args in launch commands):

```shell
[bazzite@bazzite ~]$ cat /proc/13561/environ | tr '\0' '\n' | grep -i steamdeck
CLIENTCMD=steam -gamepadui -steamos3 -steampal -steamdeck
SteamDeck=1
13561 bazzite   20   0   12.9g   3.5g 193392 S  37.3  11.4   0:58.38 Sackboy-Win64-S
```
[
(thanks jasonwc in discord)](https://discord.com/channels/1072614816579063828/1237926270151688192/1456085003434721443)

instead of ripping it out wholesale, figure with the RDNA4 exclusive fsr4 toggle being so popular and appreciated, I figure we can just add the RDNA3 equivalent too. Only catch is this one needs a forked proton like GE or EM or Cachy, its been picked out of upstream Proton 10 by valve for whatever reason.

I make sure to mention this in the tui, but let me know if that is any blocker here. 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
