### PR TITLE
fix(just): fix enable_iwd typo

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -181,7 +181,7 @@ toggle-iwd:
     remove_saved_networks() {
       nmcli -t -f NAME connection show | while read -r line; do sudo nmcli connection delete "$line"; done
     }
-    enablw_iwd() {
+    enable_iwd() {
       sudo rm -f "/etc/NetworkManager/conf.d/supplicant.conf"
       sudo systemctl mask wpa_supplicant.service
       sudo systemctl unmask iwd.service


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Fix below failure when `ujust toggle-iwd` and select `Enable iwd` that is caused by function name typo

```
/run/user/1000/just/just-lhTDOB/toggle-iwd: line 207: enable_iwd: command not found
error: Recipe `toggle-iwd` failed with exit code 127
```
