### PR TITLE
fix(steamos-update): Prevent first boot gamemode hang

### DIFF
--- a/system_files/deck/shared/usr/bin/steamos-update
+++ b/system_files/deck/shared/usr/bin/steamos-update
@@ -7,84 +7,104 @@
 # steamos-update --enable-duplicate-detection       -- should perform an update
 # steamos-update                                    -- should perform an update
 
+# Exit Codes:
+# 0: Success (e.g., upgrade available, --supports-duplicate-detection handled, or script completed even if upgrade failed).
+# 7: Failure (e.g., uupd not installed, upgrade already installed, update checks failed, or connectivity check failed).
+# Dynamic: Value propagated from /usr/bin/hhd.steamos if it is executed and returns a non-20 code.
+
+# Fake upgrade progress bar
+_fake_progress() {
+    local value=0
+    while [ ! -f '/tmp/upgrade-check' ]; do
+        sleep 12
+        if [ ${value} -lt '100' ]; then
+            echo ${value}'%'
+            value=$((value + 1))
+        fi
+    done
+    echo 100%
+}
+
+_upgrade() {
+    # Log rotate the last session
+    if [ -f "${HOME}"/.steamos-update.log ]; then
+        cp "${HOME}"/.steamos-update.log "${HOME}"/.steamos-update.log.old
+    fi
+
+    # Pull exit code from uupd
+    systemctl start uupd.service >"${HOME}"/.steamos-update.log 2>&1
+    echo $? >/tmp/upgrade-check
+}
+
+# The first time the steam client starts in deck mode, it will attempt to fetch an update.
+# We must exit the first time, otherwise you have users stuck when booting up the first time.
+# See: https://www.reddit.com/r/Bazzite/comments/1psuar7/bazzite_xbox_ally_issue/
+_fixup_file=/etc/bazzite/fixups/first_steam_gamemode_boostrap
+if [[ ! -f $_fixup_file ]]; then
+    mkdir -p "$(dirname "$_fixup_file")"
+    touch "$_fixup_file"
+    exit 7
+fi
+
 if [ -x /usr/bin/hhd.steamos ]; then
-  /usr/bin/hhd.steamos steamos-update --fallback $@
-  ret=$?
-  # If ret is not 20, exit with the return code, otherwise continue
-  if [ $ret -ne 20 ]; then
+    /usr/bin/hhd.steamos steamos-update --fallback "$@"
+    ret=$?
+    # If ret is not 20, exit with the return code, otherwise continue
+    if [ $ret -ne 20 ]; then
+        exit $ret
+    fi
     exit $ret
-  fi
 fi
 
 while [[ $# -gt 0 ]]; do
-  case $1 in
+    case $1 in
     check)
-      CHECK=1
-      shift
-      ;;
+        _CHECK=1
+        shift
+        ;;
     --supports-duplicate-detection)
-      EXIT=1
-      shift
-      ;;
+        _EXIT=1
+        shift
+        ;;
     *)
-      shift
-      ;;
-  esac
+        shift
+        ;;
+    esac
 done
 
-if command -v uupd > /dev/null; then
-  if [ -n "${CHECK}" ]; then
+if [[ -n $_EXIT ]]; then
+    exit 0
+fi
+
+if ! command -v uupd >/dev/null; then
+    exit 7 # uupd not installed
+fi
+
+if [ -n "${_CHECK}" ]; then
     if [ -f '/tmp/upgrade-installed' ]; then
-      exit 7 # Upgrade already installed
+        exit 7 # Upgrade already installed
     else
-      # Perform connectivity check
-      wget -q --spider https://github.com
-      if [ $? -eq 0 ]; then
+        # Perform connectivity check
+        if ! wget -q --spider https://github.com; then
+            exit 7 # Connectivity check failed
+        fi
+
         # Check system state
         if uupd update-check | grep -q "true"; then
-          exit 0 # Upgrade available
+            exit 0 # Upgrade available
         else
-          exit 7 # Checks failed
+            exit 7 # Checks failed
         fi
-      else
-        exit 7 # Connectivity check failed
-      fi
     fi
-  elif [ -n "${EXIT}" ]; then
-    exit 0
-  else
-    # Fake upgrade progress bar
-    fake_progress() {
-      local value=0
-      while [ ! -f '/tmp/upgrade-check' ]; do
-        sleep 12
-        if [ ${value} -lt '100' ]; then
-          echo ${value}'%'
-          value=$(( value + 1 ))
-        fi
-      done
-      echo 100%
-    }
-    upgrade() {
-      # Log rotate the last session
-      if [ -f "${HOME}"/.steamos-update.log ]; then
-          cp "${HOME}"/.steamos-update.log "${HOME}"/.steamos-update.log.old
-      fi
-
-      # Pull exit code from uupd
-      systemctl start uupd.service > "${HOME}"/.steamos-update.log 2>&1
-      echo $? > /tmp/upgrade-check
-    }
-    upgrade | fake_progress
+else
+    # We are triggering update
+    _upgrade | _fake_progress
     # Check if upgrade failed
     UPGRADE_CHECK=$(cat /tmp/upgrade-check)
     rm /tmp/upgrade-check
     if [ "${UPGRADE_CHECK}" -eq 0 ]; then
-      touch /tmp/upgrade-installed
+        touch /tmp/upgrade-installed
     else
-      exit 0 # Upgrade failed
+        exit 0 # Upgrade failed
     fi
-  fi
-else
-  exit 7 # uupd not installed
 fi


### PR DESCRIPTION
Introduce exit codes for clarity and refactor `fake_progress` and `upgrade` into private functions within `steamos-update`.

Cleaning up nested if-else conditions.

Implement a fixup mechanism to allow the Steam client's first boot in Deck Mode to proceed without getting stuck in a 'STEAMOS' screen, by exiting `steamos-update` early. This addresses a known issue (see: https://www.reddit.com/r/Bazzite/comments/1psuar7/bazzite_xbox_ally_issue/).