### PR TITLE
fix: restore Dualsense haptics functionality

### DIFF
--- a/system_files/overrides/usr/share/alsa/ucm2/USB-Audio/USB-Audio.conf
+++ b/system_files/overrides/usr/share/alsa/ucm2/USB-Audio/USB-Audio.conf
@@ -1,0 +1,590 @@
+Syntax 7
+
+Define.ProfileName ""
+Define.MixerRemap ""
+Define.SplitPCMPeriodTime 10000		# 10ms
+
+If.env1 {
+	Condition {
+		Type String
+		Empty "$${env:UCM_USB_PERIOD_TIME}"
+	}
+	False.Define.SplitPCMPeriodTime "${env:UCM_USB_PERIOD_TIME}"
+}
+
+If.linked {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# Aorus Master Front Headphone 0414:a000
+		Regex "USB0414:a000"
+	}
+	True.Define.ProfileName "../common/linked"
+}
+
+If.realtek-alc1220-vb {
+
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 0414:a002 Gigabyte TRX40 Aorus Pro WiFi
+		# 0414:a00d Gigabyte TRX40 Aorus Pro WiFi Rev 1.2
+		# 0b05:1917 ASUS ROG Strix
+		# 0b05:1918 ASUS PRIME TRX40 PRO-S
+		# 0db0:0d64 MSI TRX40 Creator
+		# 0db0:543d MSI TRX40
+		# 26ce:0a01 Asrock TRX40 Creator
+		Regex "USB((0414:a00[2d])|(0b05:191[78])|(0db0:(0d64|543d))|(26ce:0a01))"
+	}
+	True.Define.ProfileName "Realtek/ALC1220-VB-Desktop"
+}
+
+If.realtek-alc4080 {
+
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 0414:a00e Gigabyte Z590 Aorus Pro AX
+		# 0414:a010 Gigabyte Z590 Vision G Intel
+		# 0414:a011 Gigabyte Z690 AORUS ULTRA
+		# 0414:a012 Gigabyte Z690 AERO G DDR4
+		# 0414:a014 Gigabyte Z690I AORUS ULTRA DDR4
+		# 0b05:1984 ASUS Pro WS WRX80E-SAGE SE WIFI
+		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
+		# 0b05:1999 ASUS ROG Strix Z590-A Gaming WiFi
+		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
+		# 0b05:1a20 ASUS ROG STRIX Z690-I Gaming Wifi
+		# 0b05:1a27 ALC4082 on ASUS ROG Maximus Z690 Hero
+		# 0b05:1a52 ASUS ROG Strix X670E-F & Z790-E Gaming Wifi
+		# 0b05:1a53 ALC4082 on ASUS ROG Crosshair X670E Extreme
+		# 0b05:1a5c ASUS ROG Strix B650E-I Gaming WiFi
+		# 0b05:1a97 ASUS ROG Maximus Z790 Apex Encore
+		# 0b05:1af1 ASUS ROG Strix Z790-A Gaming Wifi II
+		# 0b05:1b7c ASUS ROG Crosshair X870E Hero
+		# 0b05:1b9b ASUS ROG STRIX X870E-E GAMING WIFI
+		# 0b05:1be1 ASUS ROG Strix B850-I Gaming WiFi
+		# 0db0:005a MSI MPG Z690 CARBON WIFI
+		# 0db0:0b58 MSI MPG X870E CARBON WIFI
+		# 0db0:124b MSI MEG Z690 ACE
+		# 0db0:151f MSI X570S EDGE MAX WIFI
+		# 0db0:1feb MSI Edge Wifi Z690
+		# 0db0:3130 MSI PRO X670-P WIFI
+		# 0db0:36e7 MSI MAG B650I Edge WiFi
+		# 0db0:419c MSI MPG X570S Carbon Max Wifi
+		# 0db0:422d MSI Mag B650 Tomahawk Wifi
+		# 0db0:4240 MSI MAG Z590 Tomahawk Wifi
+		# 0db0:488c MSI MEG Z790 Ace
+		# 0db0:543d MSI TRX40 Pro 10G
+		# 0db0:62a4 MSI MPG Z790I Edge WiFi
+		# 0db0:6c09 MSI MPG Z790 Carbon Wifi
+		# 0db0:6cc9 MSI MPG Z590 Gaming Plus
+		# 0db0:70d3 MSI MPG B650 Carbon Wifi
+		# 0db0:7696 MSI MAG B650M Mortar Wifi
+		# 0db0:82c7 MSI MEG Z690I Unify
+		# 0db0:8af7 MSI MPG Z590 Gaming Force
+		# 0db0:961e MSI MEG X670E ACE
+		# 0db0:9e6d MSI PRO B650-A WIFI
+		# 0db0:a073 MSI MAG X570S Torpedo Max
+		# 0db0:a228 MSI MPG Z590M GAMING EDGE WIFI
+		# 0db0:a47c MSI MEG X570S Ace Max
+		# 0db0:a74b MSI MPG Z790 Edge Wifi
+		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
+		# 0db0:cc78 MSI MAG B850M Mortar Wifi
+		# 0db0:cd0e MSI X870 Tomahawk
+		# 0db0:d1d7 MSI PRO Z790-A WIFI
+		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
+		# 0db0:e1f8 MSI MEG X670E Godlike
+		# 26ce:0a06 ASRock X670E/Z790 Taichi
+		# 26ce:0a08 ASRock Z790 PG-ITX/TB4, X870 Steel Legend
+		# 26ce:0a0b ASRock X870E Taichi
+		Regex "USB((0414:a0(0e|1[0124]))|(0b05:(19(84|9[69])|1a(16|2[07]|5[23c]|97|f1)|1b(7c|9b|e1)))|(0db0:(005a|0b58|124b|151f|1feb|3130|36e7|4(19c|22d|240|88c)|543d|62a4|6c[0c]9|70d3|7696|82c7|8af7|961e|9e6d|a(073|228|47c|74b)|b202|c(c78|d0e)|d1d7|d6e7|e1f8))|(26ce:0a0[68b]))"
+	}
+	True.Define.ProfileName "Realtek/ALC4080"
+}
+
+If.hp_only {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB152a:8750"
+	}
+	True.Define {
+		ProfileName "Common/HeadphonesOnly"
+	}
+}
+
+If.hyperx-solocast {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB03f0:0b8b"
+	}
+	True.Define.ProfileName "HyperX/SoloCast"
+}
+
+If.gigabyte-aorus-main {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0414:a001"
+	}
+	True.Define.ProfileName "Gigabyte/Aorus-Master-Main-Audio"
+}
+
+If.steinberg-ur22c {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0499:172f"
+	}
+	True.Define.ProfileName "Steinberg/UR22C"
+}
+
+If.steinberg-ur24c {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0499:174d"
+	}
+	True.Define.ProfileName "Steinberg/UR24C"
+}
+
+If.steinberg-ur44 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB0499:17[03]0"
+	}
+	True.Define.ProfileName "Steinberg/UR44"
+}
+
+If.sony-inzone-h9-h7 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB054c:0e53"
+	}
+	True.Define.ProfileName "Sony/Inzone-H9-H7"
+}
+
+If.boss-katana {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		# 0582:01d8 BOSS Katana HEAD MkII
+		# Might work for other models
+		# and generations from the same series
+		Needle "USB0582:01d8"
+	}
+	True.Define.ProfileName "BOSS/Katana"
+}
+
+If.roland-quadcapture {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0582:012f"
+	}
+	True.Define.ProfileName "Roland/Quad-Capture"
+}
+
+If.roland-bridgecast {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0582:02b7"
+	}
+	True.Define.ProfileName "Roland/BridgeCast"
+}
+
+If.roland-bridgecastv2 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 0582:031e Bridge Cast Firmware V2
+		# 0582:030d Bridge Cast One
+		Regex "USB0582:03((1e)|(0d))"
+	}
+	True.Define.ProfileName "Roland/BridgeCastV2"
+}
+
+If.roland-bridgecastx {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0582:0321"
+	}
+	True.Define.ProfileName "Roland/BridgeCastXV2"
+}
+
+If.tascam-m12 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0644:805f"
+	}
+	True.Define.ProfileName "TASCAM/Model12"
+}
+
+If.motu-m246 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB07fd:000[8b]"
+	}
+	True.If.M6 {
+		Condition {
+			Type String
+			Haystack "${CardLongName}"
+			Needle "MOTU M6"
+		}
+		True.Define.ProfileName "MOTU/M6"
+		False.If.M4 {
+			Condition {
+				Type String
+				Haystack "${CardLongName}"
+				Needle "MOTU M4"
+			}
+			True.Define.ProfileName "MOTU/M4"
+			False.Define.ProfileName "MOTU/M2"
+		}
+	}
+}
+
+If.motu-ultralite-mk5 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB07fd:000c"
+	}
+	True.Define.ProfileName "MOTU/UltraLite-mk5"
+}
+
+If.motu-D828 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB07fd:000e"
+	}
+	True.If.D828 {
+		Condition {
+			Type String
+			Haystack "${CardLongName}"
+			Needle "MOTU 828"
+		}
+		True.Define.ProfileName "MOTU/D828"
+	}
+}
+
+If.dell-wd15 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB0bda:40(14|2e)"
+	}
+	True.Define.ProfileName "Dell/WD15-Dock"
+}
+
+If.dell-desktop-front {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0bda:4c54"
+	}
+	True.Define.ProfileName "Dell/Desktop-Front"
+}
+
+If.dell-desktop-rear {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0bda:4c55"
+	}
+	True.Define.ProfileName "Dell/Desktop-Rear"
+}
+
+If.mbox3 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB0dba:5000"
+	}
+	True.Define.ProfileName "Digidesign/Digidesign-Mbox-3"
+}
+
+If.goxlr {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1220:8fe[04]"
+	}
+	True.Define.ProfileName "GoXLR/GoXLR"
+}
+
+If.focusrite-scarlett-2i {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 8006 2i2 1st Gen
+		# 800a 2i4 1st Gen
+		# 801c Solo 1st Gen
+		# 8200 2i4 2nd Gen
+		# 8202 2i2 2nd Gen
+		# 8205 Solo 2nd Gen
+		# 8210 2i2 3rd Gen
+		# 8211 Solo 3rd Gen
+		# 8218 Solo 4th Gen
+		# 8219 2i2 4th Gen
+		Regex "USB1235:8(0(0[6a]|1c)|2(0[025]|1[0189]))"
+	}
+	True.Define {
+		ProfileName "Focusrite/Scarlett-2i"
+	}
+}
+
+If.focusrite-scarlett-18i20 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		# 800C 1st Gen
+		# 8201 2nd Gen
+		# 8215 3rd Gen
+		# 821d 4th Gen
+		Regex "USB1235:8(00C|2(01|1(5|d)))"
+	}
+	True.Define.ProfileName "Focusrite/Scarlett-18i20"
+}
+
+If.behringer-umc202hd {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1397:0507"
+	}
+	True.Define {
+		ProfileName "Behringer/UMC202HD"
+		MixerRemap yes
+	}
+}
+
+If.behringer-umc204hd {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1397:0508"
+	}
+	True.Define {
+		ProfileName "Behringer/UMC204HD"
+		MixerRemap yes
+	}
+}
+
+If.behringer-umc404hd {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1397:0509"
+	}
+	True.Define {
+		ProfileName "Behringer/UMC404HD"
+		MixerRemap yes
+	}
+}
+
+If.behringer-Flow8-Streaming {
+	Condition {
+	Type String
+	Haystack "${CardComponents}"
+		Needle "USB1397:050d"
+	}
+	True.Define.ProfileName "Behringer/Flow8-Streaming"
+}
+
+If.behringer-Flow8-Recording {
+	Condition {
+	Type String
+	Haystack "${CardComponents}"
+		Needle "USB1397:050c"
+	}
+	True.Define.ProfileName "Behringer/Flow8-Recording"
+}
+
+If.Rane-SL-1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB13e5:0001"
+	}
+	True.Define.ProfileName "Rane/SL-1"
+}
+
+If.lenovo-p620-rear {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB17aa:1046"
+	}
+	True.Define.ProfileName "Lenovo/ThinkStation-P620-Rear"
+}
+
+If.lenovo-p620-main {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB17aa:104d"
+	}
+	True.Define.ProfileName "Lenovo/ThinkStation-P620-Main"
+}
+
+If.kontrolz1 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB17cc:1210"
+	}
+	True.Define.ProfileName "NativeInstruments/Traktor-Kontrol-Z1"
+}
+
+If.minifuse4 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB1c75:af70"
+	}
+	True.Define.ProfileName "Arturia/Minifuse-4"
+}
+
+If.minifuse12 {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB1c75:af[89]0"
+	}
+	True.Define.ProfileName "Arturia/Minifuse-12"
+}
+
+If.revelator {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB194f:0424"
+	}
+	True.Define {
+		ProfileName "Presonus/Revelator-IO-44"
+	}
+}
+
+If.zedi10 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB22f0:0016"
+	}
+	True.Define.ProfileName "AllenAndHeath/Zedi10"
+}
+
+If.id4-0003 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2708:0003"
+	}
+	True.Define.ProfileName "Audient/Audient-iD4-0003"
+}
+
+If.id4-0009 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2708:0009"
+	}
+	True.Define.ProfileName "Audient/Audient-iD4-0009"
+}
+
+If.fireface-ucx-ii {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2a39:3fd9"
+	}
+	True.Define.ProfileName "RME/Fireface-UCX-II"
+}
+
+If.ua-volt2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2b5a:0021"
+	}
+	True.Define {
+		ProfileName "UniversalAudio/Volt2"
+	}
+}
+
+If.teufel-cage-pro {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB2cc2:0033"
+	}
+	True.Define.ProfileName "Teufel/CAGE-PRO"
+}
+
+If.ssl2 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB31e9:0001"
+	}
+	True.Define {
+		ProfileName "SolidStateLabs/SSL2"
+	}
+}
+
+If.ssl2plus {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB31e9:0002"
+	}
+	True.Define {
+		ProfileName "SolidStateLabs/SSL2Plus"
+	}
+}
+If.beacn-mic {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "USB33ae:0001"
+	}
+	True.Define.ProfileName "Beacn/Beacn-Mic"
+}
+
+If.beacn-studio {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB33ae:[04]003"
+	}
+	True.Define.ProfileName "Beacn/Beacn-Studio"
+}
+
+If.mixremap {
+	Condition {
+		Type String
+		Empty "${var:MixerRemap}"
+	}
+	False {
+		Include.card-init.File "/lib/card-init.conf"
+		Include.ctl-remap.File "/lib/ctl-remap.conf"
+	}
+}
+
+If.inc {
+	Condition {
+		Type String
+		Empty "${var:ProfileName}"
+	}
+	True.Error "UCM is not supported for this USB device (${CardLongName} @ ${CardComponents})"
+	False.Include.prof.File "/USB-Audio/${var:ProfileName}.conf"
+}


### PR DESCRIPTION
override USB-Audio.conf with a known good copy from 43.20251210.1 to fix Dualsense haptics being broken, upstream regression in alsa 1.2.15

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
