### PR TITLE
feat(liveiso): Re-enable nouveau drivers on nvidia isos

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -459,6 +459,22 @@ if [[ $imageref == *-nvidia* ]]; then
     echo "GSK_RENDERER=gl" >>/etc/skel/.config/environment.d/99-nvidia-fix.conf
 fi
 
+# Reenable noveau.
+if [[ $imageref == *-nvidia* ]]; then
+    for pkg in nvidia-gpu-firmware mesa-vulkan-drivers; do
+        dnf -yq --allowerasing --repo=fedora,updates reinstall $pkg ||
+            dnf -yq --allowerasing --repo=fedora,updates install $pkg
+    done
+    # Ensure noveau vulkan icds exist
+    (
+        shopt -u nullglob
+        ls /usr/share/vulkan/icd.d/nouveau_icd.*.json >/dev/null
+    ) || {
+        echo >&2 "::error::No nouveau vulkan icds found at /usr/share/vulkan/icd.d/nouveau_icd.*.json"
+        exit 1
+    }
+fi
+
 # Determine desktop environment. Must match one of /usr/libexec/livesys/sessions.d/livesys-{desktop_env}
 # See https://github.com/ublue-os/titanoboa/blob/6c2e8ba58c7534b502081fe24363d2a60e7edca9/Justfile#L199-L213
 desktop_env=""


### PR DESCRIPTION
This change ensures that the open-source nouveau drivers are properly reinstalled and available on the NVIDIA-specific ISO images.

It reinstalls the `nvidia-gpu-firmware` and `mesa-vulkan-drivers` packages and verifies that the nouveau Vulkan ICD files are present, preventing potential graphics issues if the proprietary NVIDIA drivers are not used.