### PR TITLE
fix(steamos-update): Restart graphical session on first bootstrap

### DIFF
--- a/system_files/deck/shared/usr/bin/steamos-update
+++ b/system_files/deck/shared/usr/bin/steamos-update
@@ -43,6 +43,8 @@ _fixup_file=/etc/bazzite/fixups/first_steam_gamemode_boostrap
 if [[ ! -f $_fixup_file ]]; then
     mkdir -p "$(dirname "$_fixup_file")"
     touch "$_fixup_file"
+    sync "$_fixup_file"
+    systemctl restart graphical.target
     exit 7
 fi
 


### PR DESCRIPTION
On the first boot in Game Mode, the script now triggers a restart of the graphical target. This ensures that the session is properly re-initialized after the initial setup steps are completed.

A sync command is also added to ensure the fixup file is written to disk before attempting the restart, preventing potential race conditions.