### PR TITLE
feat(beesd): Implement daily timer with resource limits

### DIFF
--- a/system_files/desktop/shared/etc/systemd/beesd@.service.d/override.conf
+++ b/system_files/desktop/shared/etc/systemd/beesd@.service.d/override.conf
@@ -1,0 +1,7 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/timeout 10m /usr/bin/beesd --no-timestamps %i
+Restart=no
+SuccessExitStatus=124
+OOMScoreAdjust=1000
+OOMPolicy=stop

--- a/system_files/desktop/shared/usr/lib/systemd/system/beesd@.timer
+++ b/system_files/desktop/shared/usr/lib/systemd/system/beesd@.timer
@@ -1,0 +1,7 @@
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
@@ -4,11 +4,27 @@ configure-beesd ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
 
-    while true; do
-        # Get btrfs filesystem uuids
-        mapfile -t btrfs_devices < <(lsblk --fs --list --noheadings --output "NAME,UUID,SIZE" --filter 'FSTYPE == "btrfs"')
+    # Constants for bees hash table sizing
+    readonly MIN_FS_TB=1
+    readonly MAX_FS_TB=4
+    readonly HASH_SIZE_MB_PER_TB=512
 
-        if [ ${#btrfs_devices[@]} -eq 0 ]; then
+    remove_beesd_config() {
+        local uuid="$1"
+        echo "Removing configuration..."
+        sudo systemctl disable --now "beesd@${uuid}.timer"
+        sudo systemctl stop "beesd@${uuid}.service" 2>/dev/null || true
+        sudo rm "/etc/bees/${uuid}.conf"
+        sudo rm -f "/etc/systemd/system/beesd@${uuid}.service.d/override.conf"
+        sudo rmdir "/etc/systemd/system/beesd@${uuid}.service.d" 2>/dev/null || true
+        echo "Configuration removed and timer disabled."
+    }
+
+    while true; do
+        # Get btrfs filesystem info
+        mapfile -t raw_btrfs_output < <(lsblk --fs --list --noheadings --output "NAME,UUID,SIZE" --filter 'FSTYPE == "btrfs"' --bytes)
+
+        if [[ ${#raw_btrfs_output[@]} -eq 0 ]]; then
           echo "No BTRFS filesystems found."
           exit 0
         fi
@@ -16,23 +32,29 @@ configure-beesd ACTION="":
         # Check for existing configurations
         unset configured_uuids
         declare -A configured_uuids
-        if [ -d "/etc/bees" ]; then
+        if [[ -d "/etc/bees" ]]; then
             for config in /etc/bees/*.conf; do
-                if [ -f "$config" ]; then
+                if [[ -f "$config" ]]; then
                     filename=$(basename "$config" .conf)
                     configured_uuids["$filename"]=1
                 fi
             done
         fi
 
-        # Create menu options
+        # Create menu options and size map
         menu_options=()
-        for device in "${btrfs_devices[@]}"; do
-            uuid=$(echo "$device" | awk '{print $2}')
+        unset filesystem_size_map
+        declare -A filesystem_size_map
+        for line in "${raw_btrfs_output[@]}"; do
+            read -r name uuid size_bytes <<< "$line"
+            # Convert bytes to human readable for display
+            size_human=$(numfmt --to=iec-i --suffix=B "$size_bytes")
+            filesystem_size_map["$uuid"]="$size_bytes"
+
             if [[ -n "${configured_uuids[$uuid]}" ]]; then
-                menu_options+=("$device (Configured)")
+                menu_options+=("$name $uuid $size_human (Configured)")
             else
-                menu_options+=("$device")
+                menu_options+=("$name $uuid $size_human")
             fi
         done
         menu_options+=("Exit")
@@ -40,41 +62,61 @@ configure-beesd ACTION="":
         echo "Select a BTRFS filesystem:"
         CHOICE=$(ugum choose "${menu_options[@]}")
 
-        if [ "$CHOICE" == "Exit" ] || [ -z "$CHOICE" ]; then
+        if [[ "$CHOICE" == "Exit" ]] || [[ -z "$CHOICE" ]]; then
             exit 0
         fi
 
         UUID=$(echo "$CHOICE" | awk '{print $2}')
+        SIZE_BYTES="${filesystem_size_map[$UUID]}"
 
         if [[ -f "/etc/bees/${UUID}.conf" ]]; then
             echo "Configuration already exists for UUID: ${UUID}"
             ACTION=$(ugum choose "Remove configuration" "Reinstall/Overwrite" "Back")
-            if [ "$ACTION" == "Remove configuration" ]; then
-                echo "Removing configuration..."
-                sudo systemctl disable --now "beesd@${UUID}.service"
-                sudo rm "/etc/bees/${UUID}.conf"
-                echo "Removed /etc/bees/${UUID}.conf and disabled service."
-                continue
-            elif [ "$ACTION" == "Back" ]; then
-                continue
-            elif [ -z "$ACTION" ]; then
-                exit 0
-            fi
         else
             ACTION=$(ugum choose "Create configuration" "Back")
-            if [ "$ACTION" == "Back" ]; then
-                continue
-            elif [ -z "$ACTION" ]; then
-                exit 0
-            fi
         fi
+
+        case "$ACTION" in
+            "Remove configuration")
+                remove_beesd_config "$UUID"
+                continue
+                ;;
+            "Back")
+                continue
+                ;;
+            "")
+                exit 0
+                ;;
+        esac
+
+        size_tb=$((SIZE_BYTES / 1024**4))
+        # Clamp filesystem size between min/max for hash table calculation
+        # Avoid eating too much memory when bees starts
+        size_tb=$(($size_tb < $MIN_FS_TB ? $MIN_FS_TB : $size_tb))
+        size_tb=$(($size_tb > $MAX_FS_TB ? $MAX_FS_TB : $size_tb))
+        # Bees Hash Table Sizing
+        # Size MUST be multiple of 128KB
+        # DB_SIZE=$((1024*1024*1024)) # 1G in bytes
+        db_size=$((size_tb * $HASH_SIZE_MB_PER_TB * 1024**2))
+        # Convert db_size from bytes to MB for memory threshold
+        mem_thresh_mb=$((db_size / 1024**2))
 
         sudo mkdir -p /etc/bees
         sudo cp /usr/etc/bees/beesd.conf.sample "/etc/bees/${UUID}.conf"
         # https://github.com/Zygo/bees/blob/master/docs/options.md#load-management-options
         sudo sed -i "s/^UUID=.*/UUID=${UUID}/" "/etc/bees/${UUID}.conf"
-        sudo sed -i "s/# DB_SIZE=.*/DB_SIZE=\$((128*1024*1024))/" "/etc/bees/${UUID}.conf"
+        sudo sed -i "s/# DB_SIZE=.*/DB_SIZE=${db_size}/" "/etc/bees/${UUID}.conf"
         sudo sed -i "s/# OPTIONS=.*/OPTIONS=\"--strip-paths --no-timestamps --throttle-factor 10\"/" "/etc/bees/${UUID}.conf"
-        echo "Created /etc/bees/${UUID}.conf"
-        sudo systemctl enable --now "beesd@${UUID}.service"
+        echo "Created /etc/bees/${UUID}.conf with DB_SIZE=${db_size} bytes"
+
+        # Only start the service if enough memory is free
+        # Per service as hash table size may differ in each configuration
+        sudo mkdir -p "/etc/systemd/system/beesd@${UUID}.service.d"
+        {
+            echo "[Service]"
+            echo "ExecCondition=/bin/sh -c \"test \$(free -m | awk '/^Mem:/ {print \$7}') -gt ${mem_thresh_mb}\""
+        } | sudo tee "/etc/systemd/system/beesd@${UUID}.service.d/override.conf" > /dev/null
+
+        sudo systemctl daemon-reload
+        sudo systemctl enable --now "beesd@${UUID}.timer"
     done


### PR DESCRIPTION
Hash table is now matched against filesystem size.
To limit resources, the service now exits after 10 minutes and will only start if enough memory is free for bees' hash table.

Would be nice if it only ran when the user is idle but I could not think of a way to implement that.
Hopefully haven't made any mistakes this time around.