### PR TITLE
feat(kcminputrc): add global default that sets mouse acceleration to off [kde specific]

### DIFF
--- a/system_files/desktop/kinoite/etc/skel/.config/kcminputrc
+++ b/system_files/desktop/kinoite/etc/skel/.config/kcminputrc
@@ -1,0 +1,3 @@
+[Libinput]
+PointerAcceleration=0.0
+PointerAccelerationProfile=2


### PR DESCRIPTION
Mouse acceleration is the first setting every gamer and almost every normal user changes to off when they setup their system. 
So having the acceleration set to off for for all new users is a sane change that will also not affect our current user base at all as it lives in the skeleton dir that only gets used when a new user is setup.

Also the mouse of the users will feel the same between OSes as under KDE at least so its another very small change that removes friction.

I will research and see what I need to do to seed a new db file for the skel directory of the Gnome image too at a later pr. 