### PR TITLE
feat: sleep hang fix amd

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -299,7 +299,7 @@ toggle-i915-sleep-fix:
         ;;
     esac
 
-# Fix black screen on wake after extended S3 sleep on some AMD systems, primarily X3D chips
+# Fix black screen on wake after extended S3 sleep on some AMD chip and motherboard combinations
 [group("hardware")]
 toggle-amd-sleep-fix:
     #!/usr/bin/bash


### PR DESCRIPTION
two things:

- unhide `toggle-gigabyte-wake-fix` as this gets asked somewhat regularly and people don't see that we have a ready made fix

- add new ujust that toggles on or off karg `processor.max_cstate=1` to fix black screen on sleep for extended time. tested with my 9070xt and 5700x3d on gigabyte a520i ac board HTPC. 

gonna keep in draft till I live with the kart for a few days and ensure all my wakes are successful as they have been today after 8 hours idle


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
