### PR TITLE
fix(dnf) hide erroneous error messages from the user

### DIFF
--- a/system_files/overrides/usr/bin/dnf
+++ b/system_files/overrides/usr/bin/dnf
@@ -9,7 +9,7 @@ fi
 for arg in "$@"; do
     if [[ $arg == "install" || $arg == "in" || $arg == "remove" || $arg == "rm" ]]; then
         echo -e "ERROR: Fedora Atomic images utilize rpm-ostree instead (and is discouraged to use).\nPlease, \e]8;;https://docs.bazzite.gg/Installing_and_Managing_Software/\aread our documentation\e]8;;\a\n\e]8;;https://docs.bazzite.gg/Installing_and_Managing_Software/\ahttps://docs.bazzite.gg/Installing_and_Managing_Software/\e]8;;\a\n" >&2
-        ${SUDO_USER:+sudo -u $SUDO_USER dbus-launch} bash -lc 'xdg-open "https://docs.bazzite.gg/Installing_and_Managing_Software"'
+        ${SUDO_USER:+sudo -u $SUDO_USER dbus-launch} bash -lc 'xdg-open "https://docs.bazzite.gg/Installing_and_Managing_Software" 2> /dev/null'
         exit 1
     fi
 done


### PR DESCRIPTION
the custom dnf handler script opens the webpage via xdg-open, which seems to be buggy in both GNOME and KDE and will give erroneous error messages in both (while still working). We can redirect error output to /dev/null to suppress the messages and provide a better UX.
credit to BoredHusky for the code change
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
