### PR TITLE
fix(nvidia): install VK_hdr_layer for nvidia build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -799,6 +799,7 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf5 -y install \
         egl-wayland.x86_64 \
         egl-wayland.i686 && \
+        VK_hdr_layer && \
     /ctx/install-nvidia && \
     rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json && \
     ln -s libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so && \


### PR DESCRIPTION
`VK_hdr_layer` is still needed for the nvidia driver since it doesn't support `VK_EXT_swapchain_colorspace` extension.
Add it back for the nvidia build.

Fixes #3852 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
