### PR TITLE
fix: Bazzite portal missing

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager
+++ b/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # SCRIPT VERSION
-VER=29
+VER=30
 VER_FILE="/etc/bazzite/flatpak_manager_version"
 VER_RAN=$(cat $VER_FILE)
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"


### PR DESCRIPTION
In the test images the new Bazzite Portal is missing because the VER variable needs to be incremented in  for the bazzite-flatpak-manager script for the script to run
