### PR TITLE
fix(crh): Fix crh rm all

### DIFF
--- a/system_files/desktop/shared/usr/bin/custom-resolution-helper
+++ b/system_files/desktop/shared/usr/bin/custom-resolution-helper
@@ -166,8 +166,9 @@ removeAll() {
     RM_KARGS=$(for mode_options in "${OPT_ARRAY[@]}"; do
       echo -n "--delete-if-present=video=$mode_options "
       done)
+    RM_KARGS=$(echo "$RM_KARGS" | sed -e 's/[[:space:]]*$//g') #Remove trailing whitespaces
     echo "Command: ${bold}rpm-ostree kargs $RM_KARGS${normal}"
-    if rpm-ostree kargs "$RM_KARGS"; then
+    if rpm-ostree kargs $RM_KARGS; then
       echo "${green}Custom resolution removed successfully!${normal} Reboot to apply changes."
       confirm_reboot "$1"
     else
@@ -178,8 +179,9 @@ removeAll() {
       RM_KARGS=$(for mode_options in "${OPT_ARRAY[@]}"; do
         echo -n "--delete-if-present=video=$mode_options "
         done)
+      RM_KARGS=$(echo "$RM_KARGS" | sed -e 's/[[:space:]]*$//g') #Remove trailing whitespaces
       echo "Command: ${bold}rpm-ostree kargs $RM_KARGS${normal}"
-      if rpm-ostree kargs "$RM_KARGS"; then
+      if rpm-ostree kargs $RM_KARGS; then
         echo "${green}Custom resolution removed successfully!${normal} Reboot to apply changes."
         confirm_reboot "$1"
       else


### PR DESCRIPTION
Fix an issue where the whitespace causes `rpm-ostree kargs --delete-if-present=video:<res> ` to fail with no changes, by adding a `sed` to remove the trailing whitespaces in the `$RM_KARGS` variable once it is created.