### PR TITLE
fix(ntfs): "Learn more" was not working

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/user/ntfs-nag.service
+++ b/system_files/desktop/shared/usr/lib/systemd/user/ntfs-nag.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=NTFS/exFAT Monitor notification service
+PartOf=xdg-desktop-autostart.target
+After=xdg-desktop-autostart.target
 
 [Service]
 Type=simple
 ExecStart=/usr/libexec/ntfs_exfat_monitor_script
 
 [Install]
-WantedBy=default.target
+WantedBy=xdg-desktop-autostart.target


### PR DESCRIPTION
service started before the graphical session so opening the documentation was not functional

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
