### PR TITLE
chore(deps): Update To Mutter 49.3 & fix(gnome): Xwayland Fractional Scaling Cursor Constraint Issue

### DIFF
--- a/spec_files/mutter/mutter.spec
+++ b/spec_files/mutter/mutter.spec
@@ -15,7 +15,7 @@
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
 Name:          mutter
-Version:       49.1.1
+Version:       49.3
 Release:       %autorelease.bazzite
 Summary:       Window and compositing manager based on Clutter
 


### PR DESCRIPTION
This PR updates GNOME Mutter to 49.3 which fixes cursor constraint constraint issues on Xwayland when using fractional scaling. This issue was introduced in Mutter 47 and was present in 48, 49.0-49.2

This will resolve #1983

Draft until the Mutter 49.3 release is finalized.