### PR TITLE
fix(ntfs): possible false positive

### DIFF
--- a/system_files/desktop/shared/usr/libexec/ntfs_exfat_monitor_script
+++ b/system_files/desktop/shared/usr/libexec/ntfs_exfat_monitor_script
@@ -12,7 +12,7 @@ documentation="https://docs.bazzite.gg/Gaming/Hardware_compatibility_for_gaming/
 #set other variables
 counter="0"
 query_filesystem() {
-    lsblk -o fstype,mountpoint | grep -Ec "${1}.*\S+"
+    lsblk -o fstype,mountpoint | grep -Ec "^${1}.*\S+"
 }
 ntfs="$(query_filesystem ntfs)"
 exfat="$(query_filesystem exfat)"


### PR DESCRIPTION
only detect exfat or ntfs when the line starts with that

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
