### PR TITLE
feat: add -y to brh rollback to skip confirmation dialog

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -257,7 +257,13 @@ current() {
 }
 
 rollback() {
-  if confirm "Rollback to previous image?"; then
+  local skip_confirm=false
+
+  if [[ "$1" == "-y" || "$1" == "--yes" ]]; then
+    skip_confirm=true
+  fi
+
+  if $skip_confirm || confirm "Rollback to previous image?"; then
     rpm-ostree rollback && echo >&2 "Reboot for changes to take effect"
   else
     echo "Cancelled."
@@ -368,7 +374,7 @@ interactive_menu() {
 
 case "$1" in
   "list") list_images "$2" ;;
-  "rollback") rollback ;;
+  "rollback") rollback "$2" ;;
   "current") current ;;
   "rebase") rebase "$2" "$3" ;;
   "help"|"-h"|"--help"|"") interactive_menu ;;


### PR DESCRIPTION
This simplifies the implementation of `brh rollback` for GUI applications.