### PR TITLE
Change gui_post_login.sh to not just immediately exit on EFI systems

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -440,7 +440,7 @@ chmod +x /usr/bin/on_gui_login.sh
 mkdir -p /etc/skel/.config/autostart
 cat >>/usr/bin/on_gui_login.sh <<'EOF'
 # if CSM/Legacy show blocking message and power off
-if [[! -d /sys/firmware/efi ]]; then
+if [[ ! -d /sys/firmware/efi ]]; then
     yad --undecorated --on-top --timeout=0 --button=Shutdown:0 \
         --text="Bazzite does not support CSM/Legacy Boot. Please boot into your UEFI/BIOS settings, disable CSM/Legacy Mode, and reboot." || true
     systemctl poweroff || shutdown -h now || true


### PR DESCRIPTION
On the live ISO, /usr/bin/on_gui_login.sh runs when the desktop is loaded.

This is supposed to display disclaimers and show the YAD menu for launching the installer or other utilities.  Right now on the live ISO it does nothing.

This is because the check for CSM that is added at the beginning runs first and when it detects non CSM it just exits, aborting the rest of the script.

Fix it by inverting the test.  If EFI is missing (rather than present) do the CSM stuff, else fall through to let the script continue.