### PR TITLE
Stop SDDM from starting too early

### DIFF
--- a/system_files/desktop/kinoite/usr/lib/systemd/system/sddm.service.d/override.conf
+++ b/system_files/desktop/kinoite/usr/lib/systemd/system/sddm.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service


### PR DESCRIPTION
Users are seeing repeated issues with sddm just starting as a black screen.  Switching to a VC and running `sudo systemctl restart sddm` fixes the issue and then the system works normally.

Not quite sure of the cause, but possibly nvidia related, not sure if AMD users have seen it.

Making sddm wait for udev to settle down seems to solve the issue, so let's do that.  This has solved the issue for multiple users and seems harmless for those that don't have the issue.