### PR TITLE
chore: don't set cap_net_raw=ep for ksysguard

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -386,7 +386,6 @@ RUN --mount=type=cache,dst=/var/cache \
         sed -i 's@Exec=ptyxis@Exec=kde-ptyxis@g' /usr/share/applications/org.gnome.Ptyxis.desktop && \
         sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop && \
         cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop && \
-        setcap 'cap_net_raw+ep' /usr/libexec/ksysguard/ksgrd_network_helper && \
         ln -sf /usr/share/wallpapers/convergence.jxl /usr/share/backgrounds/default.jxl && \
         ln -sf /usr/share/wallpapers/convergence.jxl /usr/share/backgrounds/default-dark.jxl && \
         rm -f /usr/share/backgrounds/default.xml \


### PR DESCRIPTION
This got fixed in Fedora:
https://src.fedoraproject.org/rpms/libksysguard/c/babc3a3502afbd328969649b7dc8f52ed7ef08bc?branch=rawhide