### PR TITLE
chore(flatpak-manager): improve script versioning for reliability

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager
+++ b/system_files/desktop/shared/usr/libexec/bazzite-flatpak-manager
@@ -1,7 +1,11 @@
 #!/usr/bin/bash
 
-# SCRIPT VERSION
+# Script version
 VER=32
+# Allows to version the manager based on its contents.
+# Bump VER whenever we want to trigger a run explicitly event though the script is not changed.
+SCRIPT_HASH=$(tr -d '[:space:]' <"$0" | sha256sum | cut -d ' ' -f 1)
+VER="$VER-$SCRIPT_HASH"
 VER_FILE="/etc/bazzite/flatpak_manager_version"
 VER_RAN=$(cat $VER_FILE)
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"


### PR DESCRIPTION
Update bazzite-flatpak-manager to include a script hash in its version.
This change ensures the manager runs even if the `VER` variable isn't explicitly updated, reducing human error.