### PR TITLE
fix(ujust): waydriod-helper AppImage download script

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
@@ -53,10 +53,22 @@ setup-waydroid ACTION="":
       echo "Waydroid has been reset"
     elif [[ "${OPTION,,}" =~ helper ]]; then
       echo "Installing waydroid-helper"
+      # Detect system architecture
+      ARCH=$(uname -m)
+      if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" || "$ARCH" == "armv8"* ]]; then
+          ARCH_PATTERN=".*aarch64.AppImage"
+      elif [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" || "$ARCH" == "x64" ]]; then
+          ARCH_PATTERN=".*x86_64.AppImage"
+      else
+          echo "Unsupported architecture: $ARCH"
+          echo "waydroid-helper may not be available for your system architecture"
+          return 1
+      fi
+      
       if grep -q 'it.mijorus.gearlever' <<< $(flatpak list); then
           wget \
               $(curl -s https://api.github.com/repos/waydroid-helper/waydroid-helper/releases/latest | \
-              jq -r ".assets[] | select(.name | test(\".*x86_64.AppImage\")) | .browser_download_url") \
+              jq -r ".assets[] | select(.name | test(\"$ARCH_PATTERN\")) | .browser_download_url") \
               -O $HOME/Downloads/waydroid-helper.AppImage
           chmod +x $HOME/Downloads/waydroid-helper.AppImage
           echo "Download complete, add it to your app menu via Gear Lever"
@@ -64,7 +76,7 @@ setup-waydroid ACTION="":
       else
           wget \
               $(curl -s https://api.github.com/repos/waydroid-helper/waydroid-helper/releases/latest | \
-              jq -r ".assets[] | select(.name | test(\".*AppImage\")) | .browser_download_url") \
+              jq -r ".assets[] | select(.name | test(\"$ARCH_PATTERN\")) | .browser_download_url") \
               -O $HOME/Desktop/waydroid-helper.AppImage
           chmod +x $HOME/Desktop/waydroid-helper.AppImage
           echo "Install complete, it has been added to your Desktop"


### PR DESCRIPTION
Fixing 2 issues
1. If Gear Level is installed, it downloaded the x86_64 version ignoring aarch64
2. Else, it downloaded content of all AppImages listed in release into a single file, which resulted a double sized unrunnable file

Not tested because recently I am trying solutions other than waydroid and bazzite and have no device available.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
