### PR TITLE
Removed priority and hardware gain to default settings

### DIFF
--- a/system_files/deck/shared/usr/share/pipewire/hardware-profiles/gpd-g1618-05/pipewire.conf.d/pipewire.conf
+++ b/system_files/deck/shared/usr/share/pipewire/hardware-profiles/gpd-g1618-05/pipewire.conf.d/pipewire.conf
@@ -28,9 +28,6 @@ context.modules = [
                 audio.position   = [ MONO ]
                 audio.rate       = 48000
                 core.softvol     = true
-                node.volume      = 2.5
-                priority.driver  = 2000
-                priority.session = 2000
             }
         }
     }


### PR DESCRIPTION
1. Priority 2000 of the internal mic is causing issues and prevents auto-switching to headsets (even when the headset is the 'newer' device). Removing these lines should restore standard switching logic.

2. Discovered through testing that the 3.5mm jack and internal mic share the same physical path on the gpd win 5. A node.volume = 1.0 is a standard way to provide a predictable behavior across both inputs.