### PR TITLE
feat(ujust): add 'configure-us-intl-dead-keys' recipe

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -362,6 +362,86 @@ configure-snapshots ACTION="":
       /usr/libexec/bazzite-snapper-config wipe
     fi
 
+# Configure Windows/Mac-like US international keyboard layout dead keys behavior
+[group("system")]
+configure-us-intl-dead-keys:
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    INPUT_MODULE_ENV_FILE="$HOME/.config/environment.d/90-fcitx.conf"
+    XCOMPOSE_FILE="$HOME/.XCompose"
+    XCOMPOSE_REMOTE_LOCATION="https://raw.githubusercontent.com/raelgc/win_us_intl/refs/heads/master/.XCompose"
+    CURRENT="Not applied"
+    CURRENT_COLOR=${red}
+    if [[ -f "${INPUT_MODULE_ENV_FILE}" && -f "${XCOMPOSE_FILE}" ]]; then
+        CURRENT="Applied"
+        CURRENT_COLOR=${green}
+    fi
+    if [[ -z "$OPTION" ]]; then
+        echo -e "US international dead keys behavior override: ${bold}${CURRENT_COLOR}${CURRENT}${normal}"
+        echo ""
+        echo "Applies a Windows/Mac-like behavior for US international keyboard layouts with dead keys."
+        echo "When enabled, dead keys will produce accented characters directly (e.g., ' + e = é)."
+        echo "This will set the input method module to 'fcitx' and download a custom .XCompose file."
+        echo ""
+        echo "This requires the \"US International with dead keys\" input method keyboard layout to be selected"
+        echo "in your system settings and will only take effect after a logout/restart."
+        echo ""
+        echo "Some flatpak applications (e.g. Discord) may not respect this setting due to sandboxing limitations."
+        echo "Use the override option in this script to apply environment variables to those applications."
+        echo ""
+        OPTION="$(ugum choose "Apply to user" "Remove from user" "Apply to flatpak environment" "Remove from flatpak environment" "Exit without saving")"
+    fi
+    case "$OPTION" in
+        "Apply to user")
+            curl -fsSL "${XCOMPOSE_REMOTE_LOCATION}" -o "${XCOMPOSE_FILE}"
+            mkdir -p "$(dirname "${INPUT_MODULE_ENV_FILE}")"
+            cat > "${INPUT_MODULE_ENV_FILE}" <<-EOF
+    export GTK_IM_MODULE=fcitx
+    export QT_IM_MODULE=fcitx
+    export SDL_IM_MODULE=fcitx
+    export XMODIFIERS=@im=fcitx
+    export XCOMPOSEFILE=$HOME/.XCompose
+    EOF
+            echo "Please logout/restart for changes to take effect."
+            ;;
+        "Remove from user")
+            rm -f "${INPUT_MODULE_ENV_FILE}" "${XCOMPOSE_FILE}"
+            echo -e "US international dead keys behavior override ${bold}${red}removed${normal}."
+            echo "Please logout/restart for changes to take effect."
+            ;;
+        "Apply to flatpak environment")
+            SELECTION=$(flatpak list --columns=name,application | fzf)
+            APP_ID=$(echo "${SELECTION}" | awk -F'\t' '{print $2}')
+            if [[ -z "${APP_ID}" ]]; then
+              echo "No app selected. Aborting."
+              exit 0
+            fi
+            flatpak override --user --env=GTK_IM_MODULE=fcitx "${APP_ID}"
+            flatpak override --user --env=QT_IM_MODULE=fcitx "${APP_ID}"
+            flatpak override --user --env=SDL_IM_MODULE=fcitx "${APP_ID}"
+            flatpak override --user --env=XMODIFIERS=@im=fcitx "${APP_ID}"
+            flatpak override --user --env=XCOMPOSEFILE=$HOME/.XCompose "${APP_ID}"
+            echo -e "Flatpak environment overrides ${bold}${green}applied${normal} to ${bold}${app}${normal}"
+            ;;
+        "Remove from flatpak environment")
+            SELECTION=$(flatpak list --columns=name,application | fzf)
+            APP_ID=$(echo "${SELECTION}" | awk -F'\t' '{print $2}')
+            if [[ -z "${APP_ID}" ]]; then
+              echo "No app selected. Aborting."
+              exit 0
+            fi
+            flatpak override --user --unset-env=GTK_IM_MODULE "${APP_ID}"
+            flatpak override --user --unset-env=QT_IM_MODULE "${APP_ID}"
+            flatpak override --user --unset-env=SDL_IM_MODULE "${APP_ID}"
+            flatpak override --user --unset-env=XMODIFIERS "${APP_ID}"
+            flatpak override --user --unset-env=XCOMPOSEFILE "${APP_ID}"
+            echo -e "Flatpak environment overrides ${bold}${red}removed${normal} from ${bold}${APP_ID}${normal}"
+            ;;
+        *)
+            echo "No changes made."
+            ;;
+    esac
+
 # Enable a Bluefin-style CLI experience
 [group("development")]
 bazzite-cli:


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
This PR aims to add an override to assist Latin-based language users of the '**US International with dead keys**' layout coming from other operating systems looking to keep the same behavior.

This change ensures that dead key composition is handled as in Windows and MacOS. (e.g. `itś -> it's`, `espaćo -> espaço`)

Adds the `configure-us-intl-dead-keys` recipe, which consists of the following:
- Downloads the `.XCompose` from https://github.com/raelgc/win_us_intl 
- Creates the `$HOME/.config/environment.d/90-fcitx.conf` which overrides the IM module with `fcitx`.
- Optionally adds the same env variables to an installed flatpak
- Allows undoing all of the above