### PR TITLE
Clean up leftover kernel-devel and kernel-common packages

### DIFF
--- a/build_files/install-kernel
+++ b/build_files/install-kernel
@@ -53,3 +53,8 @@ pushd /usr/lib/kernel/install.d
 mv -f 05-rpmostree.install.bak 05-rpmostree.install
 mv -f 50-dracut.install.bak 50-dracut.install
 popd
+
+# Remove leftover kernel-devel and clean up sources
+rpm -e kernel-devel
+rpm -e kernel-common
+rm -rf /usr/src/kernels/*


### PR DESCRIPTION
Remove leftover kernel-devel and kernel-common packages after installation to ensure a cleaner environment. Cleanup includes removing associated source files.

