### PR TITLE
fix(beesd): Round up device sizes to their nearest TB

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
@@ -123,7 +123,8 @@ configure-beesd ACTION="":
                 ;;
         esac
 
-        size_tb=$((SIZE_BYTES / 1024**4))
+        # Round up to nearest TB by adding 0.5TB-->B and flooring
+        size_tb=$(((SIZE_BYTES + 500000000000) / 1000**4))
         # Clamp filesystem size between min/max for hash table calculation
         # Avoid eating too much memory when bees starts
         size_tb=$(($size_tb < $MIN_FS_TB ? $MIN_FS_TB : $size_tb))


### PR DESCRIPTION
Old
`2046703960064 / 1024^4  = 1.86 TB`
~ 1TB

New
`(2046703960064 + 5e11) / 1000^4 = 2.54 TB`
~ 2TB