### PR TITLE
chore: remove btrfs-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,6 @@ jobs:
             base_image_flavor: main
             arch: x86_64
     steps:
-      - name: Mount BTRFS for podman storage
-        uses: ublue-os/container-storage-action@main
-        with:
-          target-dir: /var/lib/containers
-
       - name: Define base variables
         id: base
         run: |

--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -37,11 +37,6 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 
-      - name: Mount BTRFS for podman storage
-        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
-        with:
-          target-dir: /var/lib/containers
-
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
Github removed /mnt from their runners and /dev/root is now
145G, before it was 72G so the btrfs action was needed.
This action is broken now and always used the fallback path and has no
purpose anymore.

You might want to actually run CI on this xD


<img width="1198" height="586" alt="image" src="https://github.com/user-attachments/assets/e9643d80-97c8-4bbf-8254-a381216770b8" />
