### PR TITLE
fix(beesd): Get the beesd under control

### DIFF
--- a/system_files/desktop/shared/etc/systemd/system/beesd@.service.d/bees-timeout.conf
+++ b/system_files/desktop/shared/etc/systemd/system/beesd@.service.d/bees-timeout.conf
@@ -1,6 +1,6 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/timeout 10m /usr/bin/beesd --no-timestamps %i
+ExecStart=/usr/bin/timeout 20m /usr/bin/beesd --no-timestamps %i
 Restart=no
 SuccessExitStatus=124
 OOMScoreAdjust=1000

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
@@ -141,7 +141,7 @@ configure-beesd ACTION="":
         # https://github.com/Zygo/bees/blob/master/docs/options.md#load-management-options
         sudo sed -i "s/^UUID=.*/UUID=${UUID}/" "/etc/bees/${UUID}.conf"
         sudo sed -i "s/# DB_SIZE=.*/DB_SIZE=${db_size}/" "/etc/bees/${UUID}.conf"
-        sudo sed -i "s/# OPTIONS=.*/OPTIONS=\"--strip-paths --no-timestamps --thread-factor 0.5 --throttle-factor 10\"/" "/etc/bees/${UUID}.conf"
+        sudo sed -i "s/# OPTIONS=.*/OPTIONS=\"--strip-paths --no-timestamps --thread-factor 0.125 --thread-min 1 --throttle-factor 50\"/" "/etc/bees/${UUID}.conf"
         echo "Created /etc/bees/${UUID}.conf with DB_SIZE=${db_size} bytes"
 
         # Only start the service if enough memory is free


### PR DESCRIPTION
beesd was using upwards of ~40% of a Ryzen 3700X, attempt to calm them down with more aggressive parameters (and smoke). Also adjust the daemon time limit upwards due to the throttling.