### PR TITLE
feat: add image verification logic for unverified images

### DIFF
--- a/system_files/overrides/etc/profile.d/verify_motd.sh
+++ b/system_files/overrides/etc/profile.d/verify_motd.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# 1. Get the current image reference
+CURRENT_REF=$(rpm-ostree status --json | jq -r '.deployments[0]["container-image-reference"] // empty')
+
+# 2. Define Identifiers
+UNVERIFIED_TAG="ostree-unverified-registry"
+OFFICIAL_TAG="ghcr.io/ublue-os/"
+
+# 3. The "Smart" Check
+if [[ "$CURRENT_REF" == *"$UNVERIFIED_TAG"* ]] && [[ "$CURRENT_REF" == *"$OFFICIAL_TAG"* ]]; then
+    
+    # 4. The Warning (Red Text)
+    echo -e "\n\033[0;31m\033[1m[!] SECURITY WARNING: Unverified System Image Detected\033[0m"
+    echo -e "\033[0;31m    Your system is running on an unsigned official image."
+    echo -e "    This prevents automatic updates and verification.\033[0m"
+    # UPDATED COMMAND HERE:
+    echo -e "\n    To fix this, run: \033[1mujust verify-image\033[0m\n"
+fi

--- a/system_files/overrides/usr/share/ublue-os/just/verify.sh
+++ b/system_files/overrides/usr/share/ublue-os/just/verify.sh
@@ -1,0 +1,31 @@
+# verify-image:
+#  Detects if you are on an unverified official image and rebases you to the signed version.
+verify-image:
+    @echo "Checking image verification status..."
+    @REF=$(rpm-ostree status --json | jq -r '.deployments[0]["container-image-reference"] // empty')
+    @BAD="ostree-unverified-registry:"
+    @GOOD="ostree-image-signed:docker://"
+    
+    @# Logic: Check for Unverified AND Official
+    @if [[ "$REF" == *"$BAD"* ]] && [[ "$REF" == *"ghcr.io/ublue-os/"* ]]; then \
+        echo "⚠️  UNVERIFIED OFFICIAL IMAGE DETECTED"; \
+        echo "Current: $REF"; \
+        CLEAN_REF=${REF#$BAD}; \
+        TARGET="$GOOD$CLEAN_REF"; \
+        echo ""; \
+        echo "Target:  $TARGET"; \
+        echo ""; \
+        echo "This will rebase your system to the signed image."; \
+        echo "This allows you to receive secure updates."; \
+        echo ""; \
+        read -p "Proceed with rebase? [y/N] " -n 1 -r; \
+        echo ""; \
+        if [[ $REPLY =~ ^[Yy]$ ]]; then \
+            echo "Requesting root permission to rebase..."; \
+            pkexec rpm-ostree rebase "$TARGET"; \
+        else \
+            echo "Cancelled."; \
+        fi \
+    else \
+        echo "✅ System is either already verified or a custom user image. No action needed."; \
+    fi


### PR DESCRIPTION
Adding in logic to tell if a user is on a unverified image, and queues a deployment for the same image, only verified. 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
