### PR TITLE
feat: dankpods proofing

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -492,6 +492,7 @@ unset -v _EXITLOCK
 unset -v _RETVAL
 }
 
+
 detect_nvidia () {
 timeout_seconds=30
 gpuinfo="$(timeout $timeout_seconds lspci -nn | grep '\[03')"


### PR DESCRIPTION
- liveiso: show a warning dialog if the user has nvidia and is trying to install an incorrect image, such as Nvidia card and AMD image, or old Nvidia card/ new Nvidia image
- show a different warning if the user has an unsupported (Kepler or earlier) GPU with a link to the documentation (locally served)
- show another warning about unrecognized Nvidia GPU, recommending not to install Bazzite
- three buttons: 
-- install anyway
-- power off
-- show gpu information (mostly for support requests)
- reduce the number of popups by 1 by removing the separate Nvidia driver warning and making the warning in the welcome prompt more clear

Nvidia GPU detection based on information from lspci and architecture codenames. image detection based on podman (which only works in the live iso)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
