### PR TITLE
fix(bazzite-cli): prevent remove-bling from deleting unrelated lines

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -466,7 +466,7 @@ bazzite-cli:
         sed -i '/### bling.fish source start/,/### bling.fish source end/d' \
             "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish" \
             || \
-            { line=$(grep -n "source /usr/share/ublue-os/bluefin-cli/bling.fish" \
+            { line=$(grep -n "source /usr/share/bazzite-cli/bling.fish" \
             "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish" \
             | grep -Eo '^[^:]+' | head -n1) && [[ -n "${line}" ]] && sed -i "${line}"d \
             "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"; }
@@ -474,7 +474,7 @@ bazzite-cli:
         sed -i '/### bling.sh source start/,/### bling.sh source end/d' \
             "${ZDOTDIR:-$HOME}/.zshrc" \
             || \
-            { line=$(grep -n "source /usr/share/ublue-os/bluefin-cli/bling.sh" \
+            { line=$(grep -n "source /usr/share/bazzite-cli/bling.sh" \
             "${ZDOTDIR:-$HOME}/.zshrc" \
             | grep -Eo '^[^:]+' | head -n1) && [[ -n "${line}" ]] && sed -i "${line}"d \
             "${ZDOTDIR:-$HOME}/.zshrc"; }
@@ -482,7 +482,7 @@ bazzite-cli:
         sed -i '/### bling.sh source start/,/### bling.sh source end/d' \
             "${HOME}/.bashrc" \
             || \
-            { line=$(grep -n "source /usr/share/ublue-os/bluefin-cli/bling.sh" \
+            { line=$(grep -n "source /usr/share/bazzite-cli/bling.sh" \
             "${HOME}/.bashrc" \
             | grep -Eo '^[^:]+' | head -n1) && [[ -n "${line}" ]] && sed -i "${line}"d \
             "${HOME}/.bashrc"; }


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Currently the section

```bash
sed -i '/### bling.sh source start/,/### bling.sh source end/d' \
    "${HOME}/.bashrc" \
    || \
    line=$(grep -n "source /usr/share/ublue-os/bluefin-cli/bling.sh" \
    "${HOME}/.bashrc" \
    | grep -Eo '^[^:]+') && sed -i "${line}"d \
    "${HOME}/.bashrc"
```
gets parsed as `( sed -i ...  ||  line=$(grep ...) )  &&  sed -i "${line}d" ~/.bashrc` because of left association rule for lists. As `line` is global and set, this first removes the marked section and then removes the line where sourcing used to be. 

For example the following
```bash
export DOCKER_HOST="unix:///run/user/$UID/podman/podman.sock"
. "$HOME/.cargo/env"
### bling.sh source start
test -f /usr/share/bazzite-cli/bling.sh && source /usr/share/bazzite-cli/bling.sh
### bling.sh source end

function _update_ps1() {
    PS1="$(/home/linuxbrew/.linuxbrew/bin/powerline-go -error $? -jobs $(jobs -p | wc -l))"
}
```
becomes
```bash
export DOCKER_HOST="unix:///run/user/$UID/podman/podman.sock"
. "$HOME/.cargo/env"

    PS1="$(/home/linuxbrew/.linuxbrew/bin/powerline-go -error $? -jobs $(jobs -p | wc -l))"
}
```