### PR TITLE
fix: grub disappearing in dual boot scenarios after Windows is removed

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -146,7 +146,7 @@ configure-grub ACTION="":
       local options=(
         "Hide After Successful Boot (menu_auto_hide=2)"
         "Same except when Dual Booting (menu_auto_hide=1)"
-        "Always Show Grub (menu_auto_hide=0)"
+        "Always Show Grub (unset menu_auto_hide)"
         "Exit without changes"
       )
       local choice
@@ -167,8 +167,8 @@ configure-grub ACTION="":
           sudo grub2-editenv - set menu_auto_hide=1
           echo "GRUB menu is now set to ${bold}${yellow}Hide After Successful Boot except when Dual Booting${normal}."
           ;;
-        *"(menu_auto_hide=0)"*|show)
-          sudo grub2-editenv - set menu_auto_hide=0
+        *"(unset menu_auto_hide)"*|show)
+          sudo grub2-editenv - unset menu_auto_hide
           echo "GRUB menu is now set to ${bold}${green}Always Show${normal}."
           ;;
         *"exit without changes"*|exit)


### PR DESCRIPTION
fixes the following issue: 
https://github.com/ublue-os/bazzite/issues/2809

unset behaves the same as 0 (in dualboot) so as far as i'm concerned, it can replace 0

The hiding behaviour may have to be tweaked further for single-boot scenarios, since auto_hide only seems to work properly in dualboot scenarios
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
