### PR TITLE
chore(liveiso): don't start fedora-welcome and fix up bg change

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -659,6 +659,10 @@ dnf -yq remove steam lutris bazaar || :
     wget -nv -O "$wallpaper_file" "$wallpaper_url"
     cp 2>/dev/null "$wallpaper_file" /usr/share/backgrounds/convergence.jxl || :
     cp 2>/dev/null "$wallpaper_file" /usr/share/backgrounds/convergence/convergence_morn.jxl || :
+    cp 2>/dev/null "$wallpaper_file" /usr/share/backgrounds/convergence/convergence_midmorn.jxl || :
+    cp 2>/dev/null "$wallpaper_file" /usr/share/backgrounds/convergence/convergence_day.jxl || :
+    cp 2>/dev/null "$wallpaper_file" /usr/share/backgrounds/convergence/convergence_sunset.jxl || :
+    cp 2>/dev/null "$wallpaper_file" /usr/share/backgrounds/convergence/convergence_night.jxl || :
     rm -f /usr/share/backgrounds/default.xml
 )
 

--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -686,7 +686,7 @@ fi
 
 # Let only browser/installer in the task-bar/dock
 if [[ $desktop_env == kde ]]; then
-    sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:anaconda.desktop,preferred:\/\/filemanager<\/default>/' \
+    sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:liveinst.desktop,preferred:\/\/filemanager<\/default>/' \
         /usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml
 elif [[ $desktop_env == gnome ]]; then
     cat >/usr/share/glib-2.0/schemas/zz2-org.gnome.shell.gschema.override <<EOF

--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -683,13 +683,13 @@ fi
 
 # Let only browser/installer in the task-bar/dock
 if [[ $desktop_env == kde ]]; then
-    sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:liveinst.desktop,preferred:\/\/filemanager<\/default>/' \
+    sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:anaconda.desktop,preferred:\/\/filemanager<\/default>/' \
         /usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml
 elif [[ $desktop_env == gnome ]]; then
     cat >/usr/share/glib-2.0/schemas/zz2-org.gnome.shell.gschema.override <<EOF
 [org.gnome.shell]
 welcome-dialog-last-shown-version='4294967295'
-favorite-apps = ['liveinst.desktop', 'org.mozilla.firefox.desktop', 'org.gnome.Nautilus.desktop']
+favorite-apps = ['anaconda.desktop', 'org.mozilla.firefox.desktop', 'org.gnome.Nautilus.desktop']
 EOF
     glib-compile-schemas /usr/share/glib-2.0/schemas
 fi

--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -691,7 +691,6 @@ if [[ $desktop_env == kde ]]; then
 elif [[ $desktop_env == gnome ]]; then
     cat >/usr/share/glib-2.0/schemas/zz2-org.gnome.shell.gschema.override <<EOF
 [org.gnome.shell]
-welcome-dialog-last-shown-version='4294967295'
 favorite-apps = ['anaconda.desktop', 'org.mozilla.firefox.desktop', 'org.gnome.Nautilus.desktop']
 EOF
     glib-compile-schemas /usr/share/glib-2.0/schemas

--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -675,10 +675,9 @@ if [[ $imageref == *-deck* ]]; then
     fi
 fi
 
-# Tweak the fedora-welcome app (gnome only) with our own text/icons
+# Don't start the fedora-welcome app (gnome only)
 if [[ $desktop_env == gnome ]]; then
-    sed -i 's| Fedora| Bazzite|' /usr/share/anaconda/gnome/fedora-welcome || :
-    cp -f /usr/share/pixmaps/{fedora-logo-sprite,fedora-logo-icon}.png || :
+    sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/anaconda/gnome/org.fedoraproject.welcome-screen.desktop || :
 fi
 
 # Let only browser/installer in the task-bar/dock


### PR DESCRIPTION
Some quick changes mostly related to GNOME env in Live ISO. This PR swaps liveinst.desktop to anaconda.desktop as seen in Bluefin's ISO config to ensure it's properly added to the dock, disables fedora-welcome app from showing up since there's already one made for Bazzite and properly swaps background to ensure it uses DX variant.