### PR TITLE
ci: enable iso building on testing

### DIFF
--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -4,6 +4,10 @@ name: Build Live ISOs
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches: [testing]
+    paths:
+      - installer/**
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -145,7 +149,7 @@ jobs:
           name: ${{ matrix.image_name }}-${{ steps.generate-tag.outputs.tag }}-${{ matrix.major_version}}
           path: ${{ steps.upload-directory.outputs.iso-upload-dir }}
           if-no-files-found: error
-          retention-days: 0
+          retention-days: 1
           compression-level: 0
           overwrite: true
 


### PR DESCRIPTION
ISOs will build with each push on testing, with garbage collection after 1 day.