### PR TITLE
fix(sunshine): add override for sunshine-kms.service

### DIFF
--- a/system_files/desktop/silverblue/etc/systemd/user/sunshine-kms.service.d/override.conf
+++ b/system_files/desktop/silverblue/etc/systemd/user/sunshine-kms.service.d/override.conf
@@ -1,0 +1,2 @@
+[Install]
+WantedBy=gnome-session.target


### PR DESCRIPTION
Add override for new kms service for sunshine on Gnome.