### PR TITLE
liveiso: fix documentation for nvidia

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -450,7 +450,7 @@ cat >>/usr/bin/on_gui_login.sh <<'EOF'
 serve_docs(){
   ADDRESS=127.0.0.1
   PORT=1290
-  { python -m http.server -b $ADDRESS $PORT -d "$(dirname "$0")"/html; } >/dev/null 2>&1 &
+  { python -m http.server -b $ADDRESS $PORT -d /usr/share/ublue-os/docs/html; } >/dev/null 2>&1 &
   if [[ $- == *i* ]]; then
       fg >/dev/null 2>&1 || true
   fi
@@ -543,7 +543,7 @@ echo "image name: ""$image_name"
 title="Bazzite Hardware Helper"
 heading_unsupported="<b>Unsupported Graphics Card</b>\n"
 detected_unsupported="We've detected you're using a now unsupported NVIDIA GPU.\nUnfortunately, we cannot provide good support for your hardware ourselves.\n\n"
-recommend_unsupported="Please read our <a href=\"http://127.0.0.1:1290/General/FAQ/#will-you-add-support-for-even-older-nvidia-graphics-cards\"><b>documentation</b></a> for more information.\n"
+recommend_unsupported="Please read our <a href=\"http://127.0.0.1:1290/General/FAQ/#will-support-for-much-older-nvidia-graphics-cards-be-added\"><b>documentation</b></a> for more information.\n"
 heading_unknown="<b>Unknown Graphics Card</b>\n"
 detected_unknown="We could not identify your NVIDIA graphics card.\n\n"
 recommend_unknown="It is not recommended to install Bazzite as we cannot guarantee your hardware will work."


### PR DESCRIPTION
fix the documentation for unsupported nvidia not opening due to incorrect path
fix the documentation link being incorrect

zeglius said i should put the PR to main
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
