### PR TITLE
Add a service to automatically compile and install the sc0710 driver

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/sc0710.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/sc0710.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=sc0710 driver
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=sh -c "/usr/libexec/sc0710-driver &"
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/desktop/shared/usr/libexec/sc0710-driver
+++ b/system_files/desktop/shared/usr/libexec/sc0710-driver
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if modinfo sc0710 > /dev/null 2>&1; then
+    echo Module already exists, exiting.
+    exit
+fi
+
+MODULEVER=$(modinfo --field=vermagic /usr/local/lib/sc0710.ko 2> /dev/null | cut -f1 -d ' ' || true)
+KERNELVER=$(uname -r)
+echo "Module version: $MODULEVER"
+echo "Kernel verison: $KERNELVER"
+if [ "$MODULEVER" = "$KERNELVER" ]; then
+    exit
+fi
+
+nm-online -t 120
+cd /usr/local/src
+if [ -d sc0710 ]; then
+    cd sc0710
+    git pull
+else
+    git clone https://github.com/Nakildias/sc0710
+    cd sc0710
+fi
+
+make clean all
+cp sc0710.ko /usr/local/lib
+chcon -t modules_object_t /usr/local/lib/sc0710.ko
+modprobe /usr/local/lib/sc0710.ko


### PR DESCRIPTION
Add a service to automatically pull the source for the Elgago sc0710 driver and compile it.  Intended to run on boot, it will only recompile the driver if the kernel version and the driver version differ.  Basically a mini DKMS.

The service is shipped but not enabled, idea being a user could enable it if they have this hardware.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
