### PR TITLE
Fix default pins in the Live ISO for Plasma 6.6

### DIFF
--- a/installer/system_files/kde/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
+++ b/installer/system_files/kde/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
@@ -1,0 +1,28 @@
+const allPanels = panels();
+
+for (let i = 0; i < allPanels.length; ++i) {
+    const panel = allPanels[i];
+    const widgets = panel.widgets();
+
+    for (let j = 0; j < widgets.length; ++j) {
+        const widget = widgets[j];
+
+        if (widget.type === "org.kde.plasma.icontasks") {
+            widget.currentConfigGroup = ["General"];
+
+            // Read the current launchers value
+            const currentLaunchers = widget.readConfig("launchers", "");
+
+            // Only set our default if launchers is empty
+            if (!currentLaunchers || currentLaunchers.trim() === "") {
+                widget.writeConfig("launchers", [
+                    "preferred://browser",
+                    "applications:liveinst.desktop",
+                    "preferred://filemanager"
+                ].join(","));
+                widget.reloadConfig();
+            }
+        }
+    }
+}
+

--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -331,11 +331,8 @@ if [[ $desktop_env == gnome ]]; then
     sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/anaconda/gnome/org.fedoraproject.welcome-screen.desktop || :
 fi
 
-# Let only browser/installer/file manager in the task-bar/dock, set new background for GNOME
-if [[ $desktop_env == kde ]]; then
-    sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:liveinst.desktop,preferred:\/\/filemanager<\/default>/' \
-        /usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml
-elif [[ $desktop_env == gnome ]]; then
+# Set new background for GNOME
+if [[ $desktop_env == gnome ]]; then
     glib-compile-schemas /usr/share/glib-2.0/schemas
 fi
 


### PR DESCRIPTION
This fixes the default pins for the Live ISO and removes the old method of attempting to do so which no longer works and breaks the build.

This is the same change as PR#4176 except for the LiveISO and a different set of pins.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
