### PR TITLE
feat: add common language support for Spectacle OCR

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -378,6 +378,21 @@ RUN --mount=type=cache,dst=/var/cache \
             kio-extras \
             krunner-bazaar \
             krdc \
+            tesseract-langpack-spa \
+            tesseract-langpack-deu \
+            tesseract-langpack-jpn \
+            tesseract-langpack-jpn_vert \
+            tesseract-langpack-fra \
+            tesseract-langpack-por \
+            tesseract-langpack-rus \
+            tesseract-langpack-ita \
+            tesseract-langpack-nld \
+            tesseract-langpack-pol \
+            tesseract-langpack-tur \
+            tesseract-langpack-chi_sim \
+            tesseract-langpack-chi_sim_vert \
+            tesseract-langpack-ces \
+            tesseract-langpack-ell \
             ptyxis && \
         dnf5 -y remove \
             plasma-welcome \


### PR DESCRIPTION
This adds Spanish, German, Japanese, French, Portuguese, Russian, Italian, Dutch, Polish, Turkish, Chinese (Simplified), Czech, and Greek support for OCR in Spectacle. 
I used this https://en.wikipedia.org/wiki/Languages_used_on_the_Internet as reference and added everything that seemed relevant to me. The packs are about 1MB per so really not huge.


more languages can be added by the user by installing tesseract-lang from brew and adding an environment variable, though this makes the language selection in OCR incredibly ugly looking. I think it makes sense to have some common languages baked in.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
