### PR TITLE
Use Bazzite pins on a new default panel

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -384,6 +384,7 @@ RUN --mount=type=cache,dst=/var/cache \
             kde-partitionmanager \
             plasma-discover \
             konsole && \
+        sed -i '$r /usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js' /usr/share/plasma/layout-templates/org.kde.plasma.desktop.defaultPanel/contents/layout.js && \
         sed -i 's@\[Desktop Action new-window\]@\[Desktop Action new-window\]\nX-KDE-Shortcuts=Ctrl+Alt+T@g' /usr/share/applications/org.gnome.Ptyxis.desktop && \
         sed -i '/^Comment/d' /usr/share/applications/org.gnome.Ptyxis.desktop && \
         sed -i 's@Exec=ptyxis@Exec=kde-ptyxis@g' /usr/share/applications/org.gnome.Ptyxis.desktop && \

--- a/installer/system_files/kde/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
+++ b/installer/system_files/kde/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
@@ -19,7 +19,7 @@ for (let i = 0; i < allPanels.length; ++i) {
                     "preferred://browser",
                     "applications:liveinst.desktop",
                     "preferred://filemanager"
-                ].join(","));
+                ]);
                 widget.reloadConfig();
             }
         }

--- a/system_files/desktop/kinoite/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
+++ b/system_files/desktop/kinoite/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
@@ -22,7 +22,7 @@ for (let i = 0; i < allPanels.length; ++i) {
                     "applications:org.gnome.Ptyxis.desktop",
                     "applications:io.github.kolunmi.Bazaar.desktop",
                     "preferred://filemanager"
-                ].join(","));
+                ]);
                 widget.reloadConfig();
             }
         }


### PR DESCRIPTION
Fix the case of a Plasma 6.6 user picking "Add Default Panel".

Fix types Plasma was being picky about.
When the user creates a new default panel, run the upgrade script so it gets the default pins.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
