### PR TITLE
Chore: remove GZDoom from the curation as it is no longer functional or maintained

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
@@ -74,7 +74,6 @@ rows:
           - io.mrarm.mcpelauncher
           - at.vintagestory.VintageStory
           - org.vinegarhq.Sober
-          - org.zdoom.GZDoom
           - org.zdoom.Raze
           - org.openmw.OpenMW
           - dev.goats.xivlauncher


### PR DESCRIPTION

<img width="821" height="652" alt="image2" src="https://github.com/user-attachments/assets/6d6f5641-3e8a-4a03-8944-22af4b8669d6" />
<img width="490" height="198" alt="image" src="https://github.com/user-attachments/assets/d9171fb8-6800-437d-8978-809dcee066a0" />


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
