### PR TITLE
fix(sddm): Start after plymouth-quit-wait

### DIFF
--- a/system_files/desktop/kinoite/usr/lib/systemd/system/sddm.service.d/override.conf
+++ b/system_files/desktop/kinoite/usr/lib/systemd/system/sddm.service.d/override.conf
@@ -1,3 +1,3 @@
 [Unit]
-Wants=systemd-udev-settle.service
-After=systemd-udev-settle.service
+Wants=plymouth-quit-wait.service
+After=plymouth-quit-wait.service


### PR DESCRIPTION
Instead of using systemd-udev-settle.service as After=, will make bootup faster.
Fixes #4149