### PR TITLE
Add shadow sync service

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -565,6 +565,7 @@ RUN --mount=type=cache,dst=/var/cache \
     systemctl enable greenboot-healthcheck.service && \
     systemctl enable greenboot-set-rollback-trigger.service && \
     systemctl disable force-wol.service && \
+    systemctl enable shadow-sync.service && \
     systemctl --global enable bazzite-dynamic-fixes.service && \
     systemctl --global enable ntfs-nag.service && \
     /ctx/ghcurl "https://raw.githubusercontent.com/doitsujin/dxvk/master/dxvk.conf" -Lo /etc/dxvk-example.conf && \

--- a/system_files/desktop/shared/usr/lib/systemd/system/shadow-sync.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/shadow-sync.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Early Shadow Sync
+DefaultDependencies=no
+Before=systemd-sysusers.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/shadow-sync
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/system_files/desktop/shared/usr/libexec/shadow-sync
+++ b/system_files/desktop/shared/usr/libexec/shadow-sync
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Read users
+mapfile -t users < <(cut -d: -f1 /etc/passwd /lib/passwd 2>/dev/null | sort -u || true)
+declare -A usermap
+for user in "${users[@]}"; do
+    [[ -n $user ]] && usermap["$user"]=1
+done
+
+# read shadow users
+mapfile -t shadow < <(cut -d: -f1 /etc/shadow | sort -u)
+declare -A shadowmap
+for user in "${shadow[@]}"; do
+    [[ -n $user ]] && shadowmap["$user"]=1
+done
+
+# Add missing shadow users
+[[ -n $(tail -c1 /etc/shadow) ]] && echo "" >> /etc/shadow
+for user in "${users[@]}"; do
+    [[ -v shadowmap[$user] ]] && continue
+    echo "Adding $user to /etc/shadow"
+    echo "$user:!*:::::::" >> /etc/shadow
+done
+
+# Delete extra shadow users
+for user in "${shadow[@]}"; do
+    [[ -v usermap[$user] ]] && continue
+    echo "Removing $user from /etc/shadow"
+    sed -i "/^${user}:/d" /etc/shadow
+done
+
+# Read groups
+mapfile -t groups < <(cut -d: -f1 /etc/group /lib/group 2>/dev/null | sort -u || true)
+declare -A groupmap
+for group in "${groups[@]}"; do
+    [[ -n $group ]] && groupmap["$group"]=1
+done
+
+# read shadow groups
+mapfile -t gshadow < <(cut -d: -f1 /etc/gshadow | sort -u)
+declare -A gshadowmap
+for group in "${gshadow[@]}"; do
+    [[ -n $group ]] && gshadowmap["$group"]=1
+done
+
+# Add missing shadow groups
+[[ -n $(tail -c1 /etc/gshadow) ]] && echo "" >> /etc/gshadow
+for group in "${groups[@]}"; do
+    [[ -v gshadowmap[$group] ]] && continue
+    echo "Adding $group to /etc/gshadow"
+    echo "$group:!*::" >> /etc/gshadow
+done
+
+# Delete extra shadow groups
+for group in "${gshadow[@]}"; do
+    [[ -v groupmap[$group] ]] && continue
+    echo "Removing $group from /etc/gshadow"
+    sed -i "/^${group}:/d" /etc/gshadow
+done


### PR DESCRIPTION
Add a service that on boot will fix missing/extra entries in /etc/shadow and /etc/gshadow.

This solves the issue of a new user (for instance "plasmalogin") showing up in lib/group from a rebase and there not being a corresponding entry in /etc/shadow.  It also solves the issue of swapping to an image that doesn't have that user, as it will cleanup the dangling entry.

It will only do this for users that come and go with image swaps, anything in /etc/passwd and /etc/group is safe from having their shadow entries touched (unless the entries are missing of course), so non system users will never be modified.

This service could also be used to migrate off NSS altfiles.  If you boot an image without /lib/group or /lib/passwd, the service will fix up /etc/shadow and /etc/gshadow and systemd-sysusers would immediately create the missing users.  Without this service systemd-sysusers will bomb from the inconsistent files.
