### PR TITLE
chore(bazaar): hooks.py: wait for input before releasing terminal

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
@@ -56,8 +56,19 @@ stage_idx = os.getenv('BAZAAR_HOOK_STAGE_IDX')
 def spawn_and_detach(args):
     subprocess.Popen(args, start_new_session=True, stdout=subprocess.DEVNULL)
 
+def make_popup_terminal_shellcmd(cmd):
+    new_cmd =  f'{cmd} ; '
+    new_cmd +=  'echo 1>&2 ; '
+    new_cmd +=  'echo "------------------" 1>&2 ; '
+    new_cmd += f'echo "Command \'{cmd}\' completed. Press ENTER to finish!" 1>&2 ; '
+    new_cmd +=  'read'
+    new_cmd = new_cmd.replace('"', '\\"')
+    return f'/bin/sh -c "{new_cmd}"'
+
 def spawn_ujust(id):
-    spawn_and_detach(make_shellcmd_argv(f'ujust {id}'))
+    cmd  = make_popup_terminal_shellcmd(f'ujust {id}')
+    args = make_shellcmd_argv(cmd)
+    spawn_and_detach(args)
 
 # ---
 


### PR DESCRIPTION
This should prevent ujust terminals from popping up only briefly and scaring users like on windows

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
