### PR TITLE
Remove supergfxctl-plasmoid from nvidia builds

### DIFF
--- a/build_files/install-nvidia
+++ b/build_files/install-nvidia
@@ -13,7 +13,7 @@ else
 fi
 
 if [[ "${BASE_IMAGE_NAME}" == "kinoite" ]]; then
-    VARIANT_PKGS="supergfxctl-plasmoid supergfxctl"
+    VARIANT_PKGS="supergfxctl"
 elif [[ "${BASE_IMAGE_NAME}" == "silverblue" ]]; then
     VARIANT_PKGS="supergfxctl"
 else


### PR DESCRIPTION
Remove supergfxctl-plasmoid from nvidia builds as it is downgrading plasma