### PR TITLE
fix: remove leftover initramfs

### DIFF
--- a/build_files/install-kernel
+++ b/build_files/install-kernel
@@ -15,7 +15,12 @@ printf '%s\n' '#!/bin/sh' 'exit 0' > 50-dracut.install
 chmod +x  05-rpmostree.install 50-dracut.install
 popd
 
-dnf5 -y remove --no-autoremove kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-tools kernel-tools-libs
+for pkg in kernel kernel{-core,-modules,-modules-core,-modules-extra,-tools-libs,-tools}; do
+    rpm --erase "${pkg}" --nodeps
+done
+
+# cleanup leftovers that are not covered by kernel-* packages
+rm -rf /usr/lib/modules
 
 pkgs=(
     kernel


### PR DESCRIPTION
The initramfs from the base image is not properly removed, makes the image about 200MiB smaller.

Using rpm this way is better than dnf because it doesn't remove the virtualbox-guest-additions package like dnf. I don't think this was an intentional change. It's actually faster to use rpm in a for loop here instead of doing it all at once for whatever reason. This has been used like this in Aurorafin for quite a while.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
