### PR TITLE
fix!: temporary fix for recursive drkonqi coredump

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -612,7 +612,7 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
     dnf5 -y remove \
-        jupiter-sd-mounting-btrfs && \
+        jupiter-sd-mounting-btrfs plasma-drkonqi && \
     if grep -q "kinoite" <<< "${BASE_IMAGE_NAME}"; then \
         dnf5 -y remove \
             steamdeck-kde-presets-desktop && \


### PR DESCRIPTION
We've got some reports about 100% disk usage going on because of DrKonqi coredumping and launching when it coredumps so it coredumps again (...)

This should be a _TEMPORARY!_ fix where we just removedrkonqi from the image as a mitigation step.

