### PR TITLE
fix(service): Correct the execStart command in steam-icons-cleanup.service

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/user/steam-icons-cleanup.service
+++ b/system_files/desktop/shared/usr/lib/systemd/user/steam-icons-cleanup.service
@@ -5,7 +5,7 @@ PartOf=graphical-session.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/just steam-icons remove
+ExecStart=/usr/bin/ujust steam-icons remove
 RemainAfterExit=no
 
 [Install]


### PR DESCRIPTION
the service was returning just file does not exist for a long time now so I just fixed the typo so the icon cleanup service will work from now on. Tried it on a live system by running the actual command on the terminal and it returned the same error. With the fixed type it returned the proper feedback, cleared the .desktop files and then successfully exited.

Users show have clean desktop again from now on.
