### PR TITLE
fix(mcelog): add override to prevent running in virtualized environments instead of failing.

### DIFF
--- a/system_files/desktop/shared/usr/lib/systemd/system/mcelog.service.d/override.conf
+++ b/system_files/desktop/shared/usr/lib/systemd/system/mcelog.service.d/override.conf
@@ -1,0 +1,3 @@
+# Override configuration for mcelog.service so that it does not run in virtualized environments.
+[Unit]
+ConditionVirtualization=no


### PR DESCRIPTION
Add an override configuration to the mcelog service to ensure it does not run in virtualized environments. Service now wont fail and instead exit gracefully

