### PR TITLE
Add users to initramfs to silence errors

### DIFF
--- a/system_files/desktop/shared/usr/lib/dracut/dracut.conf.d/99-bazzite.conf
+++ b/system_files/desktop/shared/usr/lib/dracut/dracut.conf.d/99-bazzite.conf
@@ -1,0 +1,1 @@
+install_items+=" /etc/nsswitch.conf /usr/lib/passwd /usr/lib/group "


### PR DESCRIPTION
Every boot Bazzite has a lot of alarming (to some users) errors in the journal from missing users and groups in initramfs.  This is because Bazzite reads users and groups from altfiles, and those files aren't in initramfs.

So add them.  Silences the errors from initramfs.