### PR TITLE
Add plugdev group

### DIFF
--- a/system_files/desktop/shared/usr/lib/sysusers.d/plugdev.conf
+++ b/system_files/desktop/shared/usr/lib/sysusers.d/plugdev.conf
@@ -1,0 +1,1 @@
+g plugdev          46


### PR DESCRIPTION
Bazzite ships a bunch of udev rules that assume the existence of the plugdev group.
These rules fail and spam the journal on every boot, but this also means the uaccess logind tags for this hardware isn't being applied, so this is more than just cosmetic.

So add plugdev.