### PR TITLE
Sign remote digest instead of local

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,7 +419,7 @@ jobs:
             dest_image="${{ steps.base.outputs.output_image }}:${{ steps.relabel.outputs.version }}"
             sudo skopeo copy ${{ steps.rechunk.outputs.ref }} docker://$dest_image
             log_sum "$dest_image"
-            DIGEST=$(sudo skopeo inspect --format '{{.Digest}}' ${{ steps.rechunk.outputs.ref }})
+            DIGEST=$(sudo skopeo inspect --format '{{.Digest}}' docker://$dest_image)
             cosign sign -y --key env://SIGNING_SECRET --new-bundle-format=false \
               "${{ steps.base.outputs.output_image }}@$DIGEST"
 


### PR DESCRIPTION
The signing workflow was signing the local image, but if skopeo or the registry mutates the image, this is wrong, it ends up signing the wrong digest.

This was not an issue with legacy_rechunker, but apparently is an issue with rpm-ostree rechunker.

Change the workflow to sign the remote digest so the digests match.