### PR TITLE
Remove bind mounts from Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -56,17 +56,18 @@ ARG SHA_HEAD_SHORT="${SHA_HEAD_SHORT}"
 ARG VERSION_TAG="${VERSION_TAG}"
 ARG VERSION_PRETTY="${VERSION_PRETTY}"
 
-RUN --mount=type=bind,target=/tmp/context \
-    cp -a /tmp/context/system_files/desktop/shared/. /tmp/context/system_files/desktop/${BASE_IMAGE_NAME}/. / && \
-    find /usr/share/ublue-os/docs -type f -exec setfattr -n user.component -v "ublue-docs" {} +
+COPY system_files/desktop/shared/ system_files/desktop/${BASE_IMAGE_NAME}/ /
+RUN find /usr/share/ublue-os/docs -type f -exec setfattr -n user.component -v "ublue-docs" {} +
 
 COPY firmware /
 
 # Copy Homebrew files from the brew image
 ARG BREW_IMAGE=ghcr.io/ublue-os/brew:latest@sha256:ca91068f51ce663d495ccfc829352d6621ec95f6c7db447ade55023b222f9762
-RUN --mount=type=bind,from=${BREW_IMAGE},source=/system_files,target=/tmp/brew_source \
-    cp -a /tmp/brew_source/. / && \
-    find /tmp/brew_source -type f -printf '/%P\0' | xargs -0 setfattr -n user.component -v "homebrew"
+COPY --from=${BREW_IMAGE} /system_files/ /tmp/brew_files/
+RUN find /tmp/brew_files -type f -printf '/%P\0' > /tmp/brew_list.txt && \
+    cp -a /tmp/brew_files/. / && \
+    xargs -0 -a /tmp/brew_list.txt setfattr -h -n user.component -v "homebrew" && \
+    rm -rf /tmp/brew_files /tmp/brew_list.txt
 
 # Setup Copr repos
 RUN --mount=type=cache,dst=/var/cache \


### PR DESCRIPTION
ab6839dea6941c139b12fef01ebd941d8df5449e added user component attrs for brew and docs.  However it did it so with bind mounts.

While this works perfectly fine in github runners, bind mounts seem to confuse the Fedora podman to the point it actually core dumps.

So change these to not use bind mounts.