### PR TITLE
chore(nvidia): remove vk_hdr_layer from nvidia builds

### DIFF
--- a/build_files/install-nvidia
+++ b/build_files/install-nvidia
@@ -51,31 +51,3 @@ cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
 sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
-
-# Awful hack of an install method to restore VK_hdr_layer in a way that won't randomly break for the foreseeable future.
-PKG="VK_hdr_layer"
-TMPDIR="$(mktemp -d)"
-
-dnf download "${PKG}" --destdir "$TMPDIR"
-
-RPM_FILE=$(ls "$TMPDIR"/*.rpm)
-mkdir "$TMPDIR/$PKG"
-cd "$TMPDIR/$PKG"
-
-# Extract RPM
-rpm2cpio "$RPM_FILE" | cpio -idmv
-
-# Libraries
-mkdir -p /usr/lib64/${PKG}
-cp -v usr/lib64/${PKG}/* /usr/lib64/${PKG}/
-
-# Vulkan implicit layer
-mkdir -p /usr/share/vulkan/implicit_layer.d
-cp -v usr/share/vulkan/implicit_layer.d/VkLayer_hdr_wsi.*.json \
-    /usr/share/vulkan/implicit_layer.d/
-
-# License & Docs
-mkdir -p /usr/share/licenses/${PKG}
-cp -v usr/share/licenses/${PKG}/* /usr/share/licenses/${PKG}/
-mkdir -p /usr/share/doc/${PKG}
-cp -v usr/share/doc/${PKG}/* /usr/share/doc/${PKG}/


### PR DESCRIPTION
Uneeded on 595 driver, so can be removed
