### PR TITLE
Keep /run/systemd out of image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,8 +285,12 @@ jobs:
         id: rechunk
         run: |
           container=$(sudo buildah from raw-img)
+          mnt=$(sudo buildah mount $container)
+          sudo bash -c "rm -rf $mnt/run/.* $mnt/run/* $mnt/tmp/.* $mnt/tmp/*"
+          sudo buildah umount $container
           sudo buildah config --label "-" $container
           sudo buildah commit --identity-label=false --rm $container raw-img
+
           sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
               quay.io/centos-bootc/centos-bootc:stream10 \
               rpm-ostree compose build-chunked-oci \

--- a/Containerfile
+++ b/Containerfile
@@ -597,7 +597,7 @@ RUN --mount=type=cache,dst=/var/cache \
     /ctx/build-initramfs && \
     /ctx/finalize
 
-RUN bootc container lint
+RUN --mount=type=tmpfs,target=/run --network=none bootc container lint
 
 ################
 # DECK BUILDS
@@ -777,7 +777,7 @@ RUN --mount=type=cache,dst=/var/cache \
     /ctx/build-initramfs && \
     /ctx/finalize
 
-RUN bootc container lint
+RUN --mount=type=tmpfs,target=/run --network=none bootc container lint
 
 ################
 # NVIDIA BUILDS
@@ -844,4 +844,4 @@ RUN --mount=type=cache,dst=/var/cache \
     /ctx/build-initramfs && \
     /ctx/finalize
 
-RUN bootc container lint
+RUN --mount=type=tmpfs,target=/run --network=none bootc container lint


### PR DESCRIPTION
Podman "helpfully" injects /run/systemd files into every run and /run is not a tmpfs so it just stays there.
legacy_rechunker used to clean /run and /tmp, so add this back in.

On a related note, bootc 1.13 now complains about the existence of these automatic files, so also shut bootc up.