### PR TITLE
feat: Enable DNF Cache for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,6 +268,16 @@ jobs:
           ARCH=${{ matrix.arch }}
           EOF
 
+      - name: Setup DNF package cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        with:
+          path: /var/tmp/buildah-cache-*
+          key: ${{ runner.os }}-buildah-${{ env.IMAGE_NAME }}
+          restore-keys: |
+            ${{ runner.os }}-buildah-${{ env.IMAGE_NAME }}
+
       # Build image using buildah and save it to raw-img
       - name: Build Image
         id: build_image
@@ -431,6 +441,12 @@ jobs:
             log_sum '```'
         env:
           SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+
+      # https://github.com/actions/cache/issues/1533
+      - name: Hack around permission issue caching
+        id: cache-perms
+        run: |
+          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
 
   generate_release:
     name: Generate Release

--- a/Containerfile
+++ b/Containerfile
@@ -75,6 +75,7 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
     mkdir -p /var/roothome && \
+    dnf5 config-manager setopt keepcache=1 && \
     dnf5 -y install dnf5-plugins && \
     for copr in \
         ublue-os/bazzite \


### PR DESCRIPTION
Taken from recent changes in Aurora, speeds up subsequent builds by sharing cache.