### PR TITLE
feat(kde): disable mouse acceleration by default on desktop variant

### DIFF
--- a/system_files/desktop/kinoite/etc/skel/.config/kcminputrc
+++ b/system_files/desktop/kinoite/etc/skel/.config/kcminputrc
@@ -1,3 +1,2 @@
 [Libinput]
-PointerAcceleration=0.0
-PointerAccelerationProfile=2
+PointerAccelerationProfile=1


### PR DESCRIPTION
This one is admittedly subjective, but I think this change is correct for an OS that prioritizes gaming.

The KDE desktop variant currently inherits KDE's default adaptive mouse acceleration profile. Most gamers expect and prefer raw 1:1 mouse input — acceleration can cause inconsistent cursor movement that makes muscle memory unreliable, which is especially problematic in FPS and other precision-heavy games.

The deck/kinoite variant already adjusts acceleration via `etc/skel/.config/kcminputrc`, but the desktop/kinoite variant has no such default.

This PR adds the same `kcminputrc` config to the desktop KDE variant (`system_files/desktop/kinoite/etc/skel/.config/kcminputrc`) with:
- `PointerAccelerationProfile=1` (no acceleration)

Users who prefer acceleration can still re-enable it in KDE System Settings > Input Devices > Mouse.