### PR TITLE
feat: rebrand bootloader entry from Fedora to Bazzite

### DIFF
--- a/build_files/image-info
+++ b/build_files/image-info
@@ -52,6 +52,9 @@ sed -i "s/^ANSI_COLOR=.*/ANSI_COLOR=\"$LOGO_COLOR\"/" /usr/lib/os-release
 sed -i "/^REDHAT_BUGZILLA_PRODUCT=/d; /^REDHAT_BUGZILLA_PRODUCT_VERSION=/d; /^REDHAT_SUPPORT_PRODUCT=/d; /^REDHAT_SUPPORT_PRODUCT_VERSION=/d" /usr/lib/os-release
 sed -i "s|^VERSION_CODENAME=.*|VERSION_CODENAME=\"${BASE_IMAGE_NAME^}\"|" /usr/lib/os-release
 
+# Rebrand system-release so that grub2-mkconfig uses "Bazzite" as the distributor
+echo "$IMAGE_PRETTY_NAME release $FEDORA_VERSION (${BASE_IMAGE_NAME^})" > /etc/system-release
+
 # Fix issues caused by ID no longer being fedora
 sed -i "s/^EFIDIR=.*/EFIDIR=\"fedora\"/" /usr/sbin/grub2-switch-to-blscfg
 


### PR DESCRIPTION
The `build_files/image-info` script already extensively rebrands `/usr/lib/os-release` (changing `PRETTY_NAME`, `NAME`, `ID`, `BOOTLOADER_NAME`, etc.), but it doesn't touch `/etc/system-release`, which still contains `Fedora release XX (...)`.

This matters because `/etc/default/grub` on Fedora derives `GRUB_DISTRIBUTOR` from `system-release`:
```
GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
```

So when users run `ujust regenerate-grub` or otherwise invoke `grub2-mkconfig`, their boot entries show "Fedora" instead of "Bazzite". This is confusing — especially in dual-boot setups where users need to distinguish Bazzite from a stock Fedora install.

The installer ISO path (`titanoboa_hook_postrootfs.sh`) already rebrands `system-release`, but users who rebase to Bazzite (without going through the installer) don't get this fix.

This one-line `sed` in `image-info` replaces `Fedora` with the `IMAGE_PRETTY_NAME` ("Bazzite") in `/etc/system-release` during the image build, ensuring the bootloader is properly branded regardless of install method.