### PR TITLE
fix(install-nvidia): Disable copy of modeset on 595

### DIFF
--- a/build_files/install-nvidia
+++ b/build_files/install-nvidia
@@ -46,7 +46,10 @@ systemctl enable ublue-nvctk-cdi.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 
 # Universal Blue specific Initramfs fixes
-cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+if [[ ! $IMAGE_NAME =~ "deck" && ! $IMAGE_NAME =~ "open" && ! $IMAGE_NAME =~ "dx" ]]; then
+    cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+fi
+
 # we must force driver load to fix black screen on boot for nvidia desktops
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration


### PR DESCRIPTION
595 automatically sets modeset, so this file is on only copied on legacy images