### PR TITLE
Add section for Copr packages we maintain

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ We deploy, patch, and maintain these Copr repos and RPMs. Packages are grouped b
   - [pipewire](https://copr.fedorainfracloud.org/coprs/ublue-os/bazzite-multilib/package/pipewire/)
   - [NetworkManager](https://copr.fedorainfracloud.org/coprs/ublue-os/bazzite-multilib/package/NetworkManager/)
   - [fw-ectool](https://copr.fedorainfracloud.org/coprs/ublue-os/staging/package/fw-ectool/)
-  - [libdex](https://copr.fedorainfracloud.org/coprs/ublue-os/staging/package/libdex/)
   - [bazaar](https://copr.fedorainfracloud.org/coprs/ublue-os/packages/package/bazaar/)
   - [iwd](https://copr.fedorainfracloud.org/coprs/ublue-os/bazzite/package/iwd/)
   - [fw-fanctrl](https://copr.fedorainfracloud.org/coprs/ublue-os/staging/package/fw-fanctrl/)


### PR DESCRIPTION
Introduce a new section detailing the Copr packages maintained by the project, organized by source for clarity. 
This will help devs and maintainers know what package changes need to be notified to Kyle so he can initiate a rebuild so the changes will appear on next Bazzite build 
