### PR TITLE
feat(Portal): Add GUI autologin fix for KDE users after rebase from gamemode to a Desktop image

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -76,6 +76,11 @@ screens:
         description: "Adds a script in Steam to boot Windows which is useful for dual-boot setups"
         default: false
         script: "ujust setup-boot-windows-steam"
+      - id: "fix-autologin"
+        title: "Fixes autologin after rebase KDE ONLY (Needs reboot)"
+        description: "Fixes autologin for users that have rebased from Gamemode to a Desktop version of Bazzite"
+        default: false
+        script: "sudo -A rm /etc/sddm.conf.d/steamos.conf"
       - id: "automounting"
         title: "Automounting"
         description: "Enables automounting of labeled BTRFS/EXT4 partitions under /run/media/system"


### PR DESCRIPTION
Implement a GUI fix for user so they can start using the autologin option again. This is a new button in the portal. 