### PR TITLE
Remove unnecessary sddm.conf for non-deck images that introduces autologin bug

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -18,8 +18,8 @@ KNOWN_IMAGE_BRANCH=$(cat $KNOWN_IMAGE_BRANCH_FILE)
 KNOWN_FEDORA_VERSION_FILE="/etc/bazzite/fedora_version"
 KNOWN_FEDORA_VERSION=$(cat $KNOWN_FEDORA_VERSION_FILE)
 
-# Take care of autologin for non-deck images where this file is not needed.
-if [[ "$IMAGE_NAME" != *deck* ]]; then
+# Take care of autologin for non -deck or -dx images where this file is not needed.
+if [[ "$IMAGE_NAME" != *deck* && "$IMAGE_NAME" != *dx* ]]; then
   rm -f /etc/sddm.conf.d/steamos.conf
 fi
 


### PR DESCRIPTION
This will run before the script version check so that means every time on startup