### PR TITLE
feat(gaming): add global Steam Deck override toggle

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -722,6 +722,46 @@ toggle-global-dlss ACTION="":
             ;;
     esac
 
+# Toggle global SteamDeck environment override
+[group("gaming")]
+toggle-global-steamdeck ACTION="":
+    #!/usr/bin/bash
+    set -euo pipefail
+    source /usr/lib/ujust/ujust.sh
+
+    FILE="$HOME/.config/environment.d/99-steamdeck-override.conf"
+
+    CURRENT="Disabled"
+    if [[ -f "$FILE" ]]; then
+        CURRENT="Enabled"
+    fi
+
+    OPTION="{{ ACTION }}"
+    if [[ -z "$OPTION" ]]; then
+        echo -e "${bold}Global Steam Deck Override:${normal} $CURRENT"
+        echo ""
+        echo "Forces SteamDeck=0 globally so games stop detecting the system as a Steam Deck."
+        echo "Useful for preventing games from loading Steam Deck assets or presets."
+        echo ""
+        OPTION="$(ugum choose "Enable" "Disable" "Exit without saving")"
+    fi
+
+    case "$OPTION" in
+        Enable|enable)
+            mkdir -p "$HOME/.config/environment.d"
+            echo "SteamDeck=0" > "$FILE"
+            echo -e "${green}${bold}Enabled${normal}: SteamDeck=0"
+            echo "You may need to restart Steam or log out for changes to take effect."
+            ;;
+        Disable|disable)
+            rm -f "$FILE"
+            echo -e "${red}${bold}Disabled${normal}: SteamDeck override removed"
+            ;;
+        *)
+            echo "No changes made."
+            ;;
+    esac
+
 # Toggle whether Steam launches with the -steamdeck flag, which causes Big Picture / Game Mode to emulate Steam Deck behavior. Disabling this can prevent games from forcing Steam Deck-specific assets, such as lower-resolution textures.
 [group("gaming")]
 _toggle-steamdeck-alias:

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -135,7 +135,12 @@ screens:
         title: "Global DLSS Upgrade"
         description: "Toggle global Proton DLSS upgrade; updates DLSS DLLs. Only compatible with Proton GE, Proton EM, or similar forks."
         default: false
-        script: "ujust toggle-global-dlss enable"        
+        script: "ujust toggle-global-dlss enable"   
+      - id: "global-steamdeck"
+        title: "Disable Steam Deck Mode"
+        description: "Forces SteamDeck=0 globally so games stop detecting the system as a Steam Deck."
+        default: false
+        script: "ujust toggle-global-steamdeck enable"
   - title: "Media Applications"
     description: "Entertainment and streaming services"
     actions:


### PR DESCRIPTION
- Added `ujust toggle-global-steamdeck` command to enable/disable Steam Deck mode globally
- When enabled, `SteamDeck=0` is set to force games to run in PC mode
- Integrated Steam Deck toggle into Yafti portal under "Customizations and Tweaks"

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
