### PR TITLE
feat(beesd): Define I/O scheduling class

### DIFF
--- a/system_files/desktop/shared/etc/systemd/system/beesd@.service.d/bees-timeout.conf
+++ b/system_files/desktop/shared/etc/systemd/system/beesd@.service.d/bees-timeout.conf
@@ -1,7 +1,8 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/timeout 20m /usr/bin/beesd --no-timestamps %i
+ExecStart=/usr/bin/timeout 30m /usr/bin/beesd --no-timestamps %i
 Restart=no
 SuccessExitStatus=124
 OOMScoreAdjust=1000
 OOMPolicy=stop
+IOSchedulingClass=idle

--- a/system_files/desktop/shared/etc/systemd/system/beesd@.service.d/override.conf
+++ b/system_files/desktop/shared/etc/systemd/system/beesd@.service.d/override.conf
@@ -5,3 +5,4 @@ Restart=no
 SuccessExitStatus=124
 OOMScoreAdjust=1000
 OOMPolicy=stop
+IOSchedulingClass=idle


### PR DESCRIPTION
Configures the systemd unit to set the kernel I/O scheduling class to idle, as defined in [ioprio_set](https://man7.org/linux/man-pages/man2/ioprio_set.2.html):

> Processes running at this level get I/O time only when no one else needs the disk. […]

Additionally, beesd throttling should probably be kept as-is, to avoid starving the process (heat and power draw notwithstanding):

> […] Attention is required when assigning this priority class to a process, since it may become starved if higher priority processes are constantly accessing the disk.