### PR TITLE
liveiso: add nvidia deck warning

### DIFF
--- a/installer/system_files/shared/usr/bin/on_gui_login.sh
+++ b/installer/system_files/shared/usr/bin/on_gui_login.sh
@@ -65,7 +65,7 @@ nvidia_hardware_helper() {
     if [ -z "$image_name" ]; then
         return 124
     fi
-    #call NVIDIA detection script TODO: change path
+    #call NVIDIA detection script
     if [[ -f "/usr/libexec/bazzite_detect_nvidia_support_status" ]]; then
         output=$("/usr/libexec/bazzite_detect_nvidia_support_status")
         ret_val=$?
@@ -86,10 +86,12 @@ nvidia_hardware_helper() {
             correct_image="<b>Nvidia (RTX Series | GTX 16xx Series+)</b>"
         fi
         # parse image information
-        echo "image name: \"$image_name\""
-        if [[ $image_name == *-nvidia-open* ]] || [[ $image_name == *-deck-nvidia* ]]; then
-            echo "modern nvidia image detected!"
-            image="modern"
+        if [[ $image_name == *-nvidia-open* ]]; then
+            echo "modern nvidia desktop image detected"
+            image="nvidia-desktop"
+        elif [[ $image_name == *-deck-nvidia* ]]; then
+            echo "modern nvidia deck image detected!"
+            image="nvidia-deck"
         elif [[ $image_name == *-nvidia:* ]]; then
             echo "legacy nvidia image detected!"
             image="legacy"
@@ -99,6 +101,11 @@ nvidia_hardware_helper() {
         fi
         #user facing text
         title="Bazzite Hardware Helper"
+        image_detected="Detected Bazzite version: $(echo "$image_name" |  cut -d '/' -f3)\n\n"
+        support="\n\n\nPlease join our <a href=\"https://discord.bazzite.gg\"><b>Discord Server</b></a> for support."
+        heading_nvidia_deck="<b>STEAM GAMING MODE IN BETA ON NVIDIA HARDWARE</b>\n"
+        detected_nvidia_deck="WARNING: Nvidia GPU Support in Steam Gaming mode and on HTPCs is available as a beta with known issues that <b>cannot be fixed</b> by Bazzite.\n\n"
+        recommend_nvidia_deck="Unless you're a Linux driver developer, or looking for a known-broken toy to play with, we <b>strongly recommend</b> using one of our Desktop images without Steam Gaming Mode."
         heading_unsupported="<b>Unsupported Graphics Card</b>\n"
         detected_unsupported="We've detected you're using a now unsupported NVIDIA GPU.\nUnfortunately, we cannot provide good support for your hardware ourselves.\n"
         recommend_unsupported="Please read our <a href=\"http://127.0.0.1:1290/General/FAQ/#will-support-for-much-older-nvidia-graphics-cards-be-added\"><b>documentation</b></a> for more information.\n"
@@ -110,8 +117,8 @@ nvidia_hardware_helper() {
         recommend_wrong_image="Pick $correct_image as \"vendor of your primary GPU\" on the website to download and install the correct version instead."
         button1="I KNOW WHAT I AM DOING. Install Bazzite Anyway:0"
         button2="Power Off:1"
-        heading2="Detected Graphics Adapter"
-        button3="GPU Information:2"
+        heading2="More Information"
+        button3="More Information:2"
         if [[ "$support_status" = "unsupported" ]]; then
             serve_docs
             heading="$heading_unsupported"
@@ -124,10 +131,14 @@ nvidia_hardware_helper() {
         elif [[ "$support_status" = "legacy" ]] && [[ "$image" = "legacy" ]]; then
             echo "legacy GPU matches legacy image. Nothing to do. Exiting…"
             return 0
-        elif [[ "$support_status" = "supported" ]] && [[ "$image" = "modern" ]]; then
+        elif [[ "$support_status" = "supported" ]] && [[ "$image" = "nvidia-deck"  ]]; then
+            heading="$heading_nvidia_deck"
+            gpu_detected="$detected_nvidia_deck"
+            recommendation="$recommend_nvidia_deck"
+        elif [[ "$support_status" = "supported" ]] && [[ "$image" = "nvidia-desktop" ]]; then
             echo "supported GPU matches modern image. Nothing to do. Exiting…"
             return 0
-        elif [[ "$support_status" = "supported" ]] && [[ "$image" != "modern" ]]; then
+        elif [[ "$support_status" = "supported" ]] && [[ "$image" != "nvidia-desktop" ]] || [[ "$image" != "nvidia-deck"  ]]; then
             heading="$heading_wrong_image"
             correct_image=
             gpu_detected="$detected_wrong_image"
@@ -138,7 +149,6 @@ nvidia_hardware_helper() {
             recommendation="$recommend_wrong_image"
         fi
         while true; do
-            #YAD dialog
             yad --warning --buttons-layout=center --text-align=center --title="$title" --text="$heading""$gpu_detected""$recommendation" \
                 --button="$button1" \
                 --button="$button2" \
@@ -149,7 +159,7 @@ nvidia_hardware_helper() {
                 systemctl poweroff || shutdown -h now || true
                 break
                 ;;
-            2) yad --info --title="$heading2" --text="$gpuinfo" ;;
+            2) yad  --info --title="$heading2" --text="$image_detected""\nDetected Graphics Adapters:$gpuinfo""$support" ;;
             esac
         done
     fi


### PR DESCRIPTION
liveiso nvidia hardware helper:
- added nvidia-deck image detection warning
- added image information and Discord server link to third button
-some refactoring and general cleanup
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
