### PR TITLE
nvidia hardware helper: add Discord Server link as QR code

### DIFF
--- a/installer/system_files/shared/usr/bin/on_gui_login.sh
+++ b/installer/system_files/shared/usr/bin/on_gui_login.sh
@@ -102,7 +102,8 @@ nvidia_hardware_helper() {
         #user facing text
         title="Bazzite Hardware Helper"
         image_detected="Detected Bazzite version: $(echo "$image_name" |  cut -d '/' -f3)\n\n"
-        support="\n\n\nPlease join our <a href=\"https://discord.bazzite.gg\"><b>Discord Server</b></a> for support."
+        qrencode -o "\$SUPPORT_QR" "https://discord.bazzite.gg"
+        support="\n\n\nPlease join our <a href=\"https://discord.bazzite.gg\"><b>Discord Server</b></a> (scan the QR code) for support."
         heading_nvidia_deck="<b>STEAM GAMING MODE IN BETA ON NVIDIA HARDWARE</b>\n"
         detected_nvidia_deck="WARNING: Nvidia GPU Support in Steam Gaming mode and on HTPCs is available as a beta with known issues that <b>cannot be fixed</b> by Bazzite.\n\n"
         recommend_nvidia_deck="Unless you're a Linux driver developer, or looking for a known-broken toy to play with, we <b>strongly recommend</b> using one of our Desktop images without Steam Gaming Mode."
@@ -136,7 +137,7 @@ nvidia_hardware_helper() {
             gpu_detected="$detected_nvidia_deck"
             recommendation="$recommend_nvidia_deck"
         elif [[ "$support_status" = "supported" ]] && [[ "$image" = "nvidia-desktop" ]]; then
-            echo "supported GPU matches modern image. Nothing to do. Exiting…"
+            echo "supported GPU matches modern desktop image. Nothing to do. Exiting…"
             return 0
         elif [[ "$support_status" = "supported" ]] && [[ "$image" != "nvidia-desktop" ]] || [[ "$image" != "nvidia-deck"  ]]; then
             heading="$heading_wrong_image"
@@ -158,7 +159,7 @@ nvidia_hardware_helper() {
                 systemctl poweroff || shutdown -h now || true
                 break
                 ;;
-            2) yad  --info --title="$heading2" --text="$image_detected""\nDetected Graphics Adapters:$gpuinfo""$support" ;;
+            2) yad  --info --title="$heading2" --text="$image_detected""\nDetected Graphics Adapters:$gpuinfo""$support" --image=\$SUPPORT_QR ;;
             esac
         done
     fi


### PR DESCRIPTION
i do not know how to change the positioning of the QR or if it's even possible
<img width="877" height="256" alt="Screenshot_20260315_133344" src="https://github.com/user-attachments/assets/1557f88c-52f6-4531-979e-d35cf657e407" />


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
