### PR TITLE
fix(nvidia): prevent intel-gtk-fix.conf from being generated if no intel iGPU is present

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-dynamic-fixes
+++ b/system_files/desktop/shared/usr/libexec/bazzite-dynamic-fixes
@@ -9,10 +9,10 @@ write_intel_gtk_fix() {
     echo "GSK_RENDERER=gl" > "$HOME/.config/environment.d/intel-gtk-fix.conf"
 }
 
-if lsmod | grep -P "^(xe|i915)" | awk "$3 > 0" > /dev/null && [ ! -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
+if lsmod | awk '$3 > 0' | grep -P "^(xe|i915) " > /dev/null && [ ! -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
     # User is using an Intel GPU
     write_intel_gtk_fix
-elif ! lsmod | grep -P "^(xe|i915)" | awk "$3 > 0" > /dev/null && [ -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
+elif ! lsmod | awk '$3 > 0' | grep -P "^(xe|i915) " > /dev/null && [ -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
     # Remove the env var file as no intel gpu is being used.
     rm "$HOME/.config/environment.d/intel-gtk-fix.conf"
 fi


### PR DESCRIPTION
The `bazzite-dynamic-fixes` script checks for intel GPUs by checking if the `xe` or `i915 `modules are loaded.
But on NVIDIA images, the `i915` module is always loaded even if the user doesn't have an Intel iGPU.
This lead to the `intel-gtk-fix.conf` file being present on every NVIDIA system which can lead to issues like #4412 or #4413.

I modified the script to check if the user actually has an Intel iGPU by checking if the modules `used by` value is larger than 0 with `awk '$3 > 0'` where `$3` is the `used by` value.
