### PR TITLE
chore(ci): rechunk image only after applying labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,7 +393,7 @@ jobs:
           sudo buildah commit --identity-label=false --rm $container raw-img
 
           sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
-              quay.io/centos-bootc/centos-bootc:stream10 \
+              localhost/raw-img \
               rpm-ostree compose build-chunked-oci \
               --bootc --max-layers 96 --format-version 2 \
               --from localhost/raw-img --output containers-storage:localhost/chunked-img

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,6 +378,7 @@ jobs:
           )
 
           # Apply config to labels and annotations
+          container=$(sudo buildah from $img)
           for line in "${labels[@]}"; do
             [ -z "$line" ] && continue
             sudo buildah config --label "$line" --annotation "$line" "$container"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,26 +318,6 @@ jobs:
           path: /var/tmp/buildah-cache-*
           key: ${{ runner.os }}-buildah-${{ env.CACHE_NAME }}
 
-      # Reprocess raw-img using rechunker which will delete it
-      - name: Run Rechunker
-        id: rechunk
-        run: |
-          container=$(sudo buildah from raw-img)
-          mnt=$(sudo buildah mount $container)
-          sudo bash -c "rm -rf $mnt/run/.* $mnt/run/* $mnt/tmp/.* $mnt/tmp/*"
-          sudo buildah umount $container
-          sudo buildah config --label "-" $container
-          sudo buildah commit --identity-label=false --rm $container raw-img
-
-          sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
-              quay.io/centos-bootc/centos-bootc:stream10 \
-              rpm-ostree compose build-chunked-oci \
-              --bootc --max-layers 96 --format-version 2 \
-              --from localhost/raw-img --output containers-storage:localhost/chunked-img
-          sudo podman untag raw-img
-
-          echo "ref=containers-storage:localhost/chunked-img" >> "$GITHUB_OUTPUT"
-
       # Relabel the image with Bazzite labels
       - name: Apply Labels
         id: relabel
@@ -378,7 +358,7 @@ jobs:
           fi
 
           # Figure out config
-          img=${{ steps.rechunk.outputs.ref }}
+          img=raw-img
           kver=$(sudo podman run --rm "$img" rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core)
           filter='{ "packages": [inputs | split(" ") | select(length==2) | { (.[0]): .[1] }] | sort_by(keys) | add }'
           manifest=$(sudo podman run --rm "$img" rpm -qa --qf '%{NAME} %{VERSION}-%{RELEASE}\n' \
@@ -401,6 +381,25 @@ jobs:
           sudo buildah commit --identity-label=false --rm $container $img
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Reprocess raw-img using rechunker which will delete it
+      - name: Run Rechunker
+        id: rechunk
+        run: |
+          container=$(sudo buildah from raw-img)
+          mnt=$(sudo buildah mount $container)
+          sudo bash -c "rm -rf $mnt/run/.* $mnt/run/* $mnt/tmp/.* $mnt/tmp/*"
+          sudo buildah umount $container
+          sudo buildah commit --identity-label=false --rm $container $img
+
+          sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
+              quay.io/centos-bootc/centos-bootc:stream10 \
+              rpm-ostree compose build-chunked-oci \
+              --bootc --max-layers 96 --format-version 2 \
+              --from localhost/raw-img --output containers-storage:localhost/chunked-img
+          sudo podman untag raw-img
+
+          echo "ref=containers-storage:localhost/chunked-img" >> "$GITHUB_OUTPUT"
 
       # Generate tags after relabel runs and checks the primary tag is not duplicated
       # If it is, relabel will suffix it by .1, .2, etc and put it in steps.relabel.outputs.version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,6 +340,12 @@ jobs:
             version="testing-${version}"
           fi
 
+          # Clean out labels from base image
+          img=raw-img
+          container=$(sudo buildah from $img)
+          sudo buildah config --label "-" $container
+          sudo buildah commit --identity-label=false --rm $container $img
+
           declare -A tags
           while read -r t; do
               tags["$t"]=1
@@ -358,7 +364,6 @@ jobs:
           fi
 
           # Figure out config
-          img=raw-img
           kver=$(sudo podman run --rm "$img" rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core)
           filter='{ "packages": [inputs | split(" ") | select(length==2) | { (.[0]): .[1] }] | sort_by(keys) | add }'
           manifest=$(sudo podman run --rm "$img" rpm -qa --qf '%{NAME} %{VERSION}-%{RELEASE}\n' \
@@ -373,7 +378,6 @@ jobs:
           )
 
           # Apply config to labels and annotations
-          container=$(sudo buildah from $img)
           for line in "${labels[@]}"; do
             [ -z "$line" ] && continue
             sudo buildah config --label "$line" --annotation "$line" "$container"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,7 +390,7 @@ jobs:
           mnt=$(sudo buildah mount $container)
           sudo bash -c "rm -rf $mnt/run/.* $mnt/run/* $mnt/tmp/.* $mnt/tmp/*"
           sudo buildah umount $container
-          sudo buildah commit --identity-label=false --rm $container $img
+          sudo buildah commit --identity-label=false --rm $container raw-img
 
           sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
               quay.io/centos-bootc/centos-bootc:stream10 \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
I didn't liked that it added 1 custom layer on top of rechunked image so I moved this step further