### PR TITLE
Fix default pins on liveiso

### DIFF
--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -319,6 +319,12 @@ if [[ $imageref == *-deck* ]]; then
     fi
 fi
 
+# Change default pins for KDE
+if [[ $desktop_env == kde ]]; then
+    sed -i '/const allPanels/,$d' /usr/share/plasma/layout-templates/org.kde.plasma.desktop.defaultPanel/contents/layout.js
+    sed -i '$r /usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js' /usr/share/plasma/layout-templates/org.kde.plasma.desktop.defaultPanel/contents/layout.js
+fi
+
 # Don't start the fedora-welcome app (gnome only)
 if [[ $desktop_env == gnome ]]; then
     sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/anaconda/gnome/org.fedoraproject.welcome-screen.desktop || :


### PR DESCRIPTION
Plasma seems to have changed to use a default panel for a new user rather than a panel with unspecified launchers.
This means on the LiveISO right now it gets the wrong pins.

Fix this by reediting the pins in the LiveISO build.