### PR TITLE
Warn if the user is about to run into error 1

### DIFF
--- a/installer/system_files/shared/usr/bin/on_gui_login.sh
+++ b/installer/system_files/shared/usr/bin/on_gui_login.sh
@@ -164,6 +164,40 @@ nvidia_hardware_helper() {
         done
     fi
 }
+
+efi="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+declare -A mount
+while read -r device path; do
+    mount["$device"]="-o bind,ro $path"
+done < <(lsblk -o PATH,MOUNTPOINTS -nQ 'PARTTYPE=="'$efi'" && MOUNTPOINTS' 2> /dev/null || true)
+
+for device in $(lsblk -o PATH -nQ 'PARTTYPE=="'$efi'" && !MOUNTPOINTS' 2> /dev/null || true); do
+    mount["$device"]="-o ro -t vfat $device"
+done
+
+export mnt=$(mktemp -d)
+trap "rmdir '$mnt'" EXIT
+
+for device in "${!mount[@]}"; do
+    export device
+    msg=$(sudo -E unshare -m sh -c '
+        mount '"${mount[$device]} '$mnt'"' 2> /dev/null || exit 0
+        shopt -s nullglob nocaseglob
+        for dir in "$mnt"/EFI/*; do
+            [ -d "$dir" ] || continue
+            base=$(basename "$dir" | tr "[:upper:]" "[:lower:]")
+            [[ "$base" == "fedora" || "$base" == "boot" ]] && continue
+            grub=("$dir"/grub*.efi)
+            (( ! ${#grub[@]} )) && continue
+            echo "The GRUB bootloader seems to be installed on $device at ${dir#$mnt}\nBazzite does not support dual boot with any other Linux installation.\nInstalls to this disk that attempt to reuse this EFI partition will fail.\nEither Bazzite must be installed to a different disk, or this partition or boot loader must be removed.\n\nSee the <a href=\"http://127.0.0.1:1290/General/Installation_Guide/troubleshoot_guide/#error-code-1\">documentation</a> for details\n"
+        done
+    ' || true)
+    [ "$msg" ] || continue
+    serve_docs
+    yad --image=dialog-warning --button=OK --buttons-layout=center --title="GRUB already present" --text="$msg"
+done
+
+
 nvidia_hardware_helper
 result=$?
 if [ $result -eq 0 ] || [ $result -eq 1 ] || [ $result -eq 124 ]; then


### PR DESCRIPTION
If the user tries to install Bazzite reusing an EFI that happens to contain an old (possibly not even used) copy of Grub, anaconda fails with the infamous error 1.  The current installer will protect the user from a copy of grub installed with the subdirectory "fedora" but not any others. 

This leads to users that had previous tried say Linux Mint and are now installing Bazzite to get this rather bad failure.

So when we boot the installer, let's take a quick peek at any EFI partitions and warn the user if GRUB is lurking there.
We specifically ignore "fedora" and "boot" since the ISO has that covered.
