### PR TITLE
chore(ci): generate sha256 in dest dir for liveiso

### DIFF
--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -149,11 +149,12 @@ jobs:
         shell: bash
         run: |
           ISO_UPLOAD_DIR=${{ github.workspace }}/upload
-          DEST=${ISO_UPLOAD_DIR}/$(basename ${{ steps.build.outputs.iso-dest }})
+          ISO_NAME=$(basename ${{ steps.build.outputs.iso-dest }})
+          DEST=${ISO_UPLOAD_DIR}/$(ISO_NAME)
 
           mkdir -p ${ISO_UPLOAD_DIR}
           mv ${{ steps.build.outputs.iso-dest }} ${DEST}
-          sha256sum ${DEST} > ${DEST}-CHECKSUM
+          (cd ${ISO_UPLOAD_DIR} && sha256sum ${ISO_NAME} | tee ${ISO_NAME}-CHECKSUM)
           echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
 
       - name: Upload ISOs and Checksum to Job Artifacts

--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -150,10 +150,9 @@ jobs:
         run: |
           ISO_UPLOAD_DIR=${{ github.workspace }}/upload
           ISO_NAME=$(basename ${{ steps.build.outputs.iso-dest }})
-          DEST=${ISO_UPLOAD_DIR}/$(ISO_NAME)
 
           mkdir -p ${ISO_UPLOAD_DIR}
-          mv ${{ steps.build.outputs.iso-dest }} ${DEST}
+          mv ${ISO_NAME} ${ISO_UPLOAD_DIR}
           (cd ${ISO_UPLOAD_DIR} && sha256sum ${ISO_NAME} | tee ${ISO_NAME}-CHECKSUM)
           echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Right now checksum file includes a full path of resulting ISO which might trip out some normal users, this PR ensures that it only includes a name of ISO file as it did before Titanoboa