### PR TITLE
fix(ci): do not create cache for PR branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,6 +263,8 @@ jobs:
         id: cache-prep
         env:
           IMAGE: ${{ matrix.image }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -eoux pipefail
           if [[ "${IMAGE}" =~ gnome ]]; then
@@ -271,11 +273,15 @@ jobs:
             CACHE_NAME="kde"
           fi
 
+          ALLOW_CACHE_WRITE="false"
+
           # TODO: If we ever integrate dx images here then this may need to be adjusted
-          if [[ "${IMAGE}" =~ "-deck" ]]; then
+          # TODO: remove testing here when we have cache on main branch
+          # PR caches are useless and may wipe cache on main
+          if [[ "${IMAGE}" =~ "-deck" ]] && \
+             [[ "${EVENT_NAME}" != "pull_request" ]] && \
+             [[ "${REF_NAME}" == "main" || "${REF_NAME}" == "testing" ]]; then
             ALLOW_CACHE_WRITE="true"
-          else
-            ALLOW_CACHE_WRITE="false"
           fi
 
           echo "cache_name=${CACHE_NAME}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Due to the 10GiB cache limit we have to be careful about it's creation on PRs or any other branch other than main as they can't be reused anywhere and might kick out the important cache on main which can be reused everywhere.

We will still always retrieve cache but only runs on main and testing will upload cache again, we have enough space for one additional branch at least. This is fine for now but we should remove testing as well as soon as the cache commits from the past few weeks have made it into the main branch.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
