### PR TITLE
Disable iscsi NetworkManager displatch to shut up SELinux

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -337,6 +337,7 @@ RUN --mount=type=cache,dst=/var/cache \
         wlr-randr \
         bazzite-portal \
         ls-iommu && \
+    ln -s /dev/null /etc/NetworkManager/dispatcher.d/04-iscsi && \
     systemctl mask iscsi && \
     systemctl mask wpa_supplicant.service && \
     systemctl mask systemd-remount-fs.service && \


### PR DESCRIPTION
Network Manager is configured to "do stuff" with iSCSI but every time it tries, SELinux stops it and complains in the logs.  Bazzite already masks the iSCSI service so might as well finish the job and mask the iSCSI dispatcher as well.

This removes the SELinux AVC log spam.