### PR TITLE
chore: add an icon to ntfs nag script

### DIFF
--- a/system_files/desktop/shared/usr/libexec/ntfs_exfat_monitor_script
+++ b/system_files/desktop/shared/usr/libexec/ntfs_exfat_monitor_script
@@ -133,7 +133,7 @@ findmnt -n --poll -t exfat,ntfs,fuseblk | while read -r _; do
             firstbutton="$firstbutton_ignore"
         fi
         # send notification
-        choice="$(notify-send  -t 500000 --action="opt1=$firstbutton" --action="opt2=$secondbutton"  -a "$sender" "$header" "$warning")"
+        choice="$(notify-send  -t 500000 --action="opt1=$firstbutton" --action="opt2=$secondbutton"  -a "$sender" "$header" "$warning" -i drive-harddisk)"
         case "$choice" in
             "opt1")
                 if [ "$counter" -gt 4 ]; then


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Adds a simple icon to NTFS/exFAT nag script which is universally acceptable in both GNOME and KDE Plasma:

<img width="347" height="196" alt="Screenshot_baz_2026-03-24_21:32:02" src="https://github.com/user-attachments/assets/7ff82f60-a3ba-477d-af65-23504fc4abdf" />

<img width="542" height="229" alt="Screenshot From 2026-03-24 21-35-13" src="https://github.com/user-attachments/assets/1ec512a1-f52b-4e19-85d5-aefaaf197dc3" />
