### PR TITLE
feat(bazaar): add vscode and vscodium hooks

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
@@ -70,6 +70,11 @@ def spawn_ujust(id):
     args = make_shellcmd_argv(cmd)
     spawn_and_detach(args)
 
+def spawn_cmd(cmd):
+    cmd  = make_popup_terminal_shellcmd(cmd)
+    args = make_shellcmd_argv(cmd)
+    spawn_and_detach(args)
+
 # ---
 
 def handle_jetbrains():
@@ -107,12 +112,89 @@ def handle_jetbrains():
             # always prevent installation of JetBrains flatpaks
             return 'deny'
 
+def handle_vscode():
+
+    def appid_is_vscode(appid):
+        return appid.startswith('com.visualstudio.code')
+
+    match stage:
+        case 'setup':
+            if transaction_type == 'install' and appid_is_vscode(transaction_appid):
+                return 'ok'
+            else:
+                return 'pass'
+
+        case 'setup-dialog':
+            return 'ok'
+
+        case 'teardown-dialog':
+            if dialog_response_id == 'run-brew' or dialog_response_id == 'learn-dx':
+                return 'ok'
+            else:
+                return 'abort'
+
+        case 'catch':
+            return 'abort'
+
+        case 'action':
+            try:
+                if dialog_response_id == 'run-brew':
+                    spawn_cmd('/home/linuxbrew/.linuxbrew/bin/brew tap ublue-os/tap && /home/linuxbrew/.linuxbrew/bin/brew install --cask visual-studio-code-linux')
+                elif dialog_response_id == 'learn-dx':
+                    spawn_and_detach('/bin/sh -c "xdg-open https://dev.bazzite.gg/"')
+            except:
+                pass
+            return ''
+
+        case 'teardown':
+            # always prevent installation of JetBrains flatpaks
+            return 'deny'
+
+def handle_vscodium():
+
+    def appid_is_vscodium(appid):
+        return appid.startswith('com.vscodium.codium')
+
+    match stage:
+        case 'setup':
+            if transaction_type == 'install' and appid_is_vscodium(transaction_appid):
+                return 'ok'
+            else:
+                return 'pass'
+
+        case 'setup-dialog':
+            return 'ok'
+
+        case 'teardown-dialog':
+            if dialog_response_id == 'run-brew':
+                return 'ok'
+            else:
+                return 'abort'
+
+        case 'catch':
+            return 'abort'
+
+        case 'action':
+            try:
+                spawn_cmd('/home/linuxbrew/.linuxbrew/bin/brew tap ublue-os/tap && /home/linuxbrew/.linuxbrew/bin/brew install --cask vscodium-linux')
+            except:
+                pass
+            return ''
+
+        case 'teardown':
+            # always prevent installation of VSCodium
+            return 'deny'
+
 # ---
 
 response = 'pass'
 match hook_id:
     case 'jetbrains-toolbox':
         response = handle_jetbrains()
+    case 'vscode':
+        response = handle_vscode()
+    case 'vscodium':
+        response = handle_vscodium()
 
 print(response)
 sys.exit(0)

--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
@@ -1,4 +1,4 @@
-# See https://github.com/kolunmi/bazaar/blob/main/docs/overview.md#hooks
+# See https://github.com/bazaar-org/bazaar/blob/main/docs/overview.md#hooks
 
 import os, subprocess, sys
 
@@ -52,6 +52,19 @@ stage_idx = os.getenv('BAZAAR_HOOK_STAGE_IDX')
 #
 # UTIL
 #
+
+temp_file = "/tmp/bazaar-hook-choice"
+
+def pick_action(action):
+    file = open(temp_file, "w")
+    file.write(action)
+    file.close()
+
+def find_action():
+    file = open(temp_file)
+    output = file.read()
+    file.close()
+    return output
 
 def spawn_and_detach(args):
     subprocess.Popen(args, start_new_session=True, stdout=subprocess.DEVNULL)
@@ -129,6 +142,7 @@ def handle_vscode():
 
         case 'teardown-dialog':
             if dialog_response_id == 'run-brew' or dialog_response_id == 'learn-dx':
+                pick_action(dialog_response_id)
                 return 'ok'
             else:
                 return 'abort'
@@ -138,10 +152,11 @@ def handle_vscode():
 
         case 'action':
             try:
-                if dialog_response_id == 'run-brew':
+                action = find_action()
+                if action == 'run-brew':
                     spawn_cmd('/home/linuxbrew/.linuxbrew/bin/brew tap ublue-os/tap && /home/linuxbrew/.linuxbrew/bin/brew install --cask visual-studio-code-linux')
-                elif dialog_response_id == 'learn-dx':
-                    spawn_and_detach('/bin/sh -c "xdg-open https://dev.bazzite.gg/"')
+                elif action == 'learn-dx':
+                    spawn_and_detach(['xdg-open', 'https://dev.bazzite.gg/'])
             except:
                 pass
             return ''

--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
@@ -162,7 +162,7 @@ def handle_vscode():
             return ''
 
         case 'teardown':
-            # always prevent installation of JetBrains flatpaks
+            # always prevent installation of VSCode flatpak
             return 'deny'
 
 def handle_vscodium():
@@ -197,7 +197,7 @@ def handle_vscodium():
             return ''
 
         case 'teardown':
-            # always prevent installation of VSCodium
+            # always prevent installation of VSCodium flatpak
             return 'deny'
 
 # ---

--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/main.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/main.yaml
@@ -52,3 +52,97 @@ hooks:
             # styling
             style: suggested
     shell: exec python3 /usr/share/ublue-os/bazaar/hooks.py
+
+  - id: vscode
+    when: before-transaction
+    dialogs:
+      - id: vscode-warning
+        title: 
+          en: >-
+            Visual Studio Code is not supported in this format
+          ru: >-
+            Visual Studio Code не поддерживаются в данном формате
+
+        # If true, render inline markup commands in body; see
+        # https://docs.gtk.org/Pango/pango_markup.html
+        body-use-markup: true
+        body: 
+          en: >-
+            This is a <a href="https://www.microsoft.com/">Microsoft</a>
+            application and is not officially supported on Flatpak. Bazzite
+            recommends getting Visual Studio Code from Universal Blue's Brew
+            tap.
+
+            Alternatively, you can rebase to Bazzite DX (Developer
+            Experience) which provides Docker and Visual Studio Code out
+            of the box.
+          ru: >-
+            Это приложение <a href="https://www.microsoft.com/">Microsoft</a>
+            и оно официально не поддерживается как Flatpak. Bazzite
+            рекомендует устанавливать Visual Studio Code из Brew
+            tap репозитория Universal Blue.
+
+            Альтернативно, вы можете сменить систему на Bazzite DX
+            (Developer Experience), которая включает в себя Docker и Visual
+            Studio Code из коробки.
+        # Determines which option will be assumed if the user hits the
+        # escape key or otherwise cancels the dialog
+        default-response-id: cancel
+        options:
+          - id: cancel
+            string: 
+              en: "Cancel"
+              ru: "Отмена"
+          - id: learn-dx
+            string: 
+              en: "Learn about Bazzite DX"
+              ru: "Узнать о Bazzite DX"
+          - id: run-brew
+            string: 
+              en: "Download from Brew"
+              ru: "Скачать с Brew"
+            # can be "destructive" or "suggested" or omit for no
+            # styling
+            style: suggested
+    shell: exec python3 /usr/share/ublue-os/bazaar/hooks.py
+
+  - id: vscodium
+    when: before-transaction
+    dialogs:
+      - id: vscodium-warning
+        title:
+          en: >-
+            VSCodium is not supported in this format
+          ru: >-
+            VSCodium не поддерживаются в данном формате
+
+        # If true, render inline markup commands in body; see
+        # https://docs.gtk.org/Pango/pango_markup.html
+        body-use-markup: true
+        body:
+          en: >-
+            Although VSCodium is verified on Flathub, this is a repackaged
+            <a href="https://www.microsoft.com/">Microsoft</a> application and
+            is not officially supported on Flatpak. Bazzite recommends getting
+            VSCodium from Universal Blue's Brew tap.
+          ru: >-
+            Хотя VSCodium был подтверждён в Flathub, это перепакованное
+            приложение <a href="https://www.microsoft.com/">Microsoft</a> и оно
+            официально не поддерживается как Flatpak. Bazzite рекомендует
+            устанавливать VSCodium из Brew tap репозитория Universal Blue.
+        # Determines which option will be assumed if the user hits the
+        # escape key or otherwise cancels the dialog
+        default-response-id: cancel
+        options:
+          - id: cancel
+            string: 
+              en: "Cancel"
+              ru: "Отмена"
+          - id: run-brew
+            string: 
+              en: "Download from Brew"
+              ru: "Скачать с Brew"
+            # can be "destructive" or "suggested" or omit for no
+            # styling
+            style: suggested
+    shell: exec python3 /usr/share/ublue-os/bazaar/hooks.py


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
This PR adds new Bazaar hooks for preventing the installation of VSCode and VSCodium while providing better alternatives

<img width="398" height="457" alt="image" src="https://github.com/user-attachments/assets/213637c4-f601-4abd-8fdd-a0e4d08bc024" />
<img width="395" height="367" alt="Screenshot From 2026-03-24 22-34-01" src="https://github.com/user-attachments/assets/cb68370b-7354-4d4a-82e6-7c4a454ce7d5" />

And while coding this it made apparent that Bazaar currently doesn't provide `dialog_response_id` for `action` stage so I had to add read/write to new `/tmp` file until it's properly implemented in Bazaar.