### PR TITLE
chore: redirect dnf to dnf5 if usroverlay is enabled

### DIFF
--- a/system_files/overrides/usr/bin/dnf
+++ b/system_files/overrides/usr/bin/dnf
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
-# Redirect to dnf5 if we are running inside a container
-if systemd-detect-virt -cq || { [[ -e /run/.containerenv || -e /.dockerenv ]]; }; then
+# Redirect to dnf5 if we are running inside a container or usroverlay is enabled
+if systemd-detect-virt -cq || { [[ -e /run/.containerenv || -e /.dockerenv ]]; } || { [[ $(rpm-ostree status --json --booted | jq -r '.deployments[0]["unlocked"]') == 'development' ]] }; then
     exec /usr/bin/dnf5 "$@"
 fi
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
I've noticed that while running either `rpm-ostree usroverlay` or `sudo bootc usroverlay` rpm-ostree unlocks `development` feature as indicated in both `rpm-ostree status` and `rpm-ostree status --json`, this is should be enough to just run dnf instead of dnf5 with usroverlay enabled. If of course it doesn't break anything in container builds...