### PR TITLE
fix(ujust): update ujust setup-sunshine to use new service name

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -5,7 +5,7 @@
 setup-sunshine ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    SERVICE_STATE="$(systemctl is-enabled --user sunshine.service)"
+    SERVICE_STATE="$(systemctl is-enabled --user app-dev.lizardbyte.app.Sunshine.service)"
     OPTION={{ ACTION }}
     if [ "$SERVICE_STATE" == "enabled" ]; then
         SERVICE_STATE="${green}${b}Enabled${n}"
@@ -25,9 +25,9 @@ setup-sunshine ACTION="":
       OPTION=$(Choose "Enable" "Disable" "Open Portal" "Exit")
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then
-      systemctl enable --user --now sunshine.service
+      systemctl enable --user --now app-dev.lizardbyte.app.Sunshine.service
     elif [[ "${OPTION,,}" =~ ^(remove|uninstall|disable) ]]; then
-      systemctl disable --user --now sunshine.service 
+      systemctl disable --user --now app-dev.lizardbyte.app.Sunshine.service 
     elif [[ "${OPTION,,}" =~ ^(portal|open) ]]; then
       echo "Opening Sunshine management portal..."
       xdg-open https://localhost:47990


### PR DESCRIPTION
ujust setup-sunshine is broken at the moment because LizardByte changed the name of the sunshine service from `sunshine.service` to `app-dev.lizardbyte.app.Sunshine.service`, but the ujust recipe did not update to reflect this change. This changes the service name.