### PR TITLE
chore: replace sudo with pkexec for escalation

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -60,17 +60,17 @@ screens:
         title: "Add input group to current user"
         description: "Adds the input group to your current user. Required by certain controller drivers."
         default: true
-        script: "sudo -A ujust add-user-to-input-group"
+        script: "pkexec ujust add-user-to-input-group"
       - id: "password-asterisks"
         title: "Visible Password Asterisks"
         description: "Toggles pwfeedback on."
         default: false
-        script: "sudo -A ujust toggle-password-feedback on"
+        script: "pkexec ujust toggle-password-feedback on"
       - id: "hide-grub"
         title: "Hide GRUB Menu"
         description: "Hide the GRUB menu on boot"
         default: true
-        script: "sudo -A ujust configure-grub hide"
+        script: "pkexec ujust configure-grub hide"
       - id: "boot-to-windows"
         title: "Boot to Windows from Steam"
         description: "Adds a script in Steam to boot Windows which is useful for dual-boot setups"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -60,7 +60,7 @@ screens:
         title: "Add input group to current user"
         description: "Adds the input group to your current user. Required by certain controller drivers."
         default: true
-        script: "pkexec ujust add-user-to-input-group"
+        script: "ujust add-user-to-input-group"
       - id: "password-asterisks"
         title: "Visible Password Asterisks"
         description: "Toggles pwfeedback on."


### PR DESCRIPTION
Update scripts to use `pkexec` instead of `sudo` for escalation

That way the user will get a nice password request without the weirdness of sudo -A that as its not made for this usecase.