### PR TITLE
fix: Repo owners with upper-case names can build images on their forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  REPO_OWNER: ${{ github.repository_owner }}
+
 jobs:
   push-ghcr:
     name: Make
@@ -91,6 +94,13 @@ jobs:
         with:
           target-dir: /var/lib/containers
 
+      # The image registry name must be lower-case, but GitHub usernames can be capitalized.
+      - name: Get lower-case equivalent of the repository owner's username
+        id: repo_owner_case
+        uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
+        with:
+          string: ${{ env.REPO_OWNER }}
+
       - name: Define base variables
         id: base
         run: |
@@ -133,7 +143,7 @@ jobs:
           # Define push and pull registries
           #
           PULL_REGISTRY=ghcr.io/ublue-os
-          PUSH_REGISTRY=ghcr.io/${{ github.repository_owner }}
+          PUSH_REGISTRY=ghcr.io/${{ steps.repo_owner_case.outputs.lowercase }}
           echo "push_registry=${PUSH_REGISTRY}" >> $GITHUB_OUTPUT
           echo "pull_registry=${PULL_REGISTRY}" >> $GITHUB_OUTPUT
           echo "output_image=${PUSH_REGISTRY}/${{ matrix.image }}" >> $GITHUB_OUTPUT
@@ -248,7 +258,7 @@ jobs:
           FEDORA_VERSION=${{ matrix.fedora_version }}
           BASE_IMAGE=${{ steps.base.outputs.base_image }}
           IMAGE_NAME=${{ matrix.image }}
-          IMAGE_VENDOR=${{ github.repository_owner }}
+          IMAGE_VENDOR=${{ steps.repo_owner_case.outputs.lowercase }}
           IMAGE_BRANCH=${{ github.ref_name }}
           KERNEL_REF=${{ steps.base.outputs.kernel_ref }}
           NVIDIA_REF=${{ steps.labels.outputs.nvidia_ref }}

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 env:
-  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  REPO_OWNER: ${{ github.repository_owner }}
 
 permissions: {}
 
@@ -86,19 +86,19 @@ jobs:
 
           echo "flatpak-dir-shortname=${FLATPAK_DIR_SHORTNAME}" >> $GITHUB_OUTPUT
 
-      # Docker requires lowercase registry references
-      - name: Lowercase Registry
-        id: registry_case
+      # The image registry name must be lower-case, but GitHub usernames can be capitalized.
+      - name: Get lower-case equivalent of the repository owner's username
+        id: repo_owner_case
         uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
         with:
-          string: ${{ env.IMAGE_REGISTRY }}
+          string: ${{ env.REPO_OWNER }}
 
       - name: Determine Flatpak Dependencies
         id: flatpak_dependencies
         shell: bash
         run: |
           set -ex
-          image="${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}:${{ steps.generate-tag.outputs.tag }}"
+          image="ghcr.io/${{ steps.repo_owner_case.outputs.lowercase }}/${{ matrix.image_name }}:${{ steps.generate-tag.outputs.tag }}"
           # Make temp space
           TEMP_FLATPAK_INSTALL_DIR=$(mktemp -d -p ${{ github.workspace }} flatpak.XXX)
           # Get list of refs from directory
@@ -136,7 +136,7 @@ jobs:
         with:
           arch: x86_64
           image_name: ${{ matrix.image_name }}
-          image_repo: ${{ steps.registry_case.outputs.lowercase }}
+          image_repo: ghcr.io/${{ steps.repo_owner_case.outputs.lowercase }}
           variant: 'Kinoite'
           version: ${{ matrix.major_version }}
           image_tag: ${{ steps.generate-tag.outputs.tag }}

--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -10,7 +10,7 @@ on:
       - installer/**
 
 env:
-  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  REPO_OWNER: ${{ github.repository_owner }}
 
 permissions: {}
 
@@ -94,12 +94,12 @@ jobs:
 
           echo "flatpak-dir-shortname=${FLATPAK_DIR_SHORTNAME}" >> $GITHUB_OUTPUT
 
-      # Docker requires lowercase registry references
-      - name: Lowercase Registry
-        id: registry_case
+      # The image registry name must be lower-case, but GitHub usernames can be capitalized.
+      - name: Get lower-case equivalent of the repository owner's username
+        id: repo_owner_case
         uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
         with:
-          string: ${{ env.IMAGE_REGISTRY }}
+          string: ${{ env.REPO_OWNER }}
 
       # - name: Setup Bazzite Repo
       #   id: setup-bazzite-repo
@@ -124,8 +124,8 @@ jobs:
 
       - name: Build Container Image
         run: |
-          BASE_IMAGE="${{ steps.registry_case.outputs.lowercase }}/${{ steps.get-nondeck-ref.outputs.ref }}:${{ steps.generate-tag.outputs.tag }}"
-          INSTALL_IMAGE_PAYLOAD="${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}:${{ steps.generate-tag.outputs.tag }}"
+          BASE_IMAGE="ghcr.io/${{ steps.repo_owner_case.outputs.lowercase }}/${{ steps.get-nondeck-ref.outputs.ref }}:${{ steps.generate-tag.outputs.tag }}"
+          INSTALL_IMAGE_PAYLOAD="ghcr.io/${{ steps.repo_owner_case.outputs.lowercase }}/${{ matrix.image_name }}:${{ steps.generate-tag.outputs.tag }}"
           FLATPAK_DIR_SHORTNAME="${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}"
 
           sudo podman build \

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -4,6 +4,9 @@
 # Under NO CIRCUMSTANCES should this workflow be automatically triggered.
 name: Retag image
 
+env:
+  REPO_OWNER: ${{ github.repository_owner }}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -38,12 +41,19 @@ jobs:
     permissions:
       packages: write
     steps:
+      # The image registry name must be lower-case, but GitHub usernames can be capitalized.
+      - name: Get lower-case equivalent of the repository owner's username
+        id: repo_owner_case
+        uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
+        with:
+          string: ${{ env.REPO_OWNER }}
+
       - uses: Zeglius/ghcr-oci-retagger@1e08f1dac27d25efe1377d9a35f133731bf3d986
         env:
           ver: "43"
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          PREFIX: ghcr.io/${{ github.repository_owner }}/
+          PREFIX: ghcr.io/${{ steps.repo_owner_case.outputs.lowercase }}
           TAG_MAPPINGS: |-
             bazzite:${{ inputs.old_tag }}                           => bazzite:latest,stable,${{ env.ver }}
             bazzite-deck:${{ inputs.old_tag }}                      => bazzite-deck:latest,stable,${{ env.ver }}


### PR DESCRIPTION
Prevents a gotcha with people with capital letters in their usernames not actually being able to fork and build the project.

It's possible to (ab)use Bash to do this, but marking strings with little crab stalks (`;;`) to do it is weird Bash magic. This project already to-lowers the usernames this way in two places, so it makes sense to just do that. Happy to do the crab stalks trick instead though where suitable.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
