### PR TITLE
liveiso: add better instructions to error code 1

### DIFF
--- a/installer/system_files/shared/usr/bin/on_gui_login.sh
+++ b/installer/system_files/shared/usr/bin/on_gui_login.sh
@@ -189,12 +189,12 @@ for device in "${!mount[@]}"; do
             [[ "$base" == "fedora" || "$base" == "boot" ]] && continue
             grub=("$dir"/grub*.efi)
             (( ! ${#grub[@]} )) && continue
-            echo "The GRUB bootloader seems to be installed on $device at ${dir#$mnt}\nBazzite does not support dual boot with any other Linux installation.\nInstalls to this disk that attempt to reuse this EFI partition will fail.\nEither Bazzite must be installed to a different disk, or this partition or boot loader must be removed.\n\nSee the <a href=\"http://127.0.0.1:1290/General/Installation_Guide/troubleshoot_guide/#error-code-1\">documentation</a> for details\n"
+            echo "The GRUB bootloader seems to be installed on $device at ${dir#$mnt}\nBazzite <a href=\"http://127.0.0.1:1290/General/Installation_Guide/troubleshoot_guide/#error-code-1\">does not support dual boot with any other Linux installation.</a> \nInstalls to this disk that attempt to reuse this EFI partition will fail.\nEither Bazzite must be installed to a different disk, or this partition or boot loader must be removed.\n\nPlease see the <a href=\"http://127.0.0.1:1290/General/Installation_Guide/troubleshoot_guide/#how-to-remove-an-orphaned-copy-of-grub\">documentation</a> for instructions.\n"
         done
     ' || true)
     [ "$msg" ] || continue
     serve_docs
-    yad --image=dialog-warning --button=OK --buttons-layout=center --title="GRUB already present" --text="$msg"
+    yad --image=dialog-warning --button=OK --buttons-layout=center --title="Existing Linux bootloader detected" --text="$msg"
 done
 
 


### PR DESCRIPTION
- add the (new) documentation section about removing ubuntu from the EFI to allow for a successful Bazzite install
- Change the title slightly to be more user friendly
- Reformat the text a little.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
