### PR TITLE
feat(sunshine-changeover): bring back setup for sunshine

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -200,8 +200,6 @@ if [ ! -f /etc/bazzite/fixups/sunshine ]; then
   if [[ -f "$HOME/.config/sunshine/sunshine.conf" ]]; then
     # If the user is using sunshine, automatically reconfigure it to use the brew sunshine package.
     echo "Sunshine found, automatically switching over to brew package..."
-    brew update
-    brew upgrade
     brew tap LizardByte/homebrew
     brew install sunshine
     brew services start sunshine

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -36,8 +36,6 @@ setup-sunshine ACTION="":
       OPTION=$(Choose "Enable" "Enable-Beta" "Disable" "Open Portal" "Exit")
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then
-      brew update
-      brew upgrade
       brew tap LizardByte/homebrew
       if [[ "${OPTION,,}" =~ ^enable-beta ]]; then
         brew install sunshine-beta


### PR DESCRIPTION
Bring back setup for sunshine by using the brew package, and add a automatic changeover in bazzite-hardware-setup for existing sunshine users.