### PR TITLE
fix: run systemctl --user daemon-reload when intel-gtk-fix.conf gets created or deleted

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-dynamic-fixes
+++ b/system_files/desktop/shared/usr/libexec/bazzite-dynamic-fixes
@@ -12,7 +12,11 @@ write_intel_gtk_fix() {
 if lsmod | awk '$3 > 0' | grep -P "^(xe|i915) " > /dev/null && [ ! -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
     # User is using an Intel GPU
     write_intel_gtk_fix
+    # This ensures that the env is set immediately when the file is generated
+    systemctl --user daemon-reload
 elif ! lsmod | awk '$3 > 0' | grep -P "^(xe|i915) " > /dev/null && [ -f "$HOME/.config/environment.d/intel-gtk-fix.conf" ]; then
     # Remove the env var file as no intel gpu is being used.
     rm "$HOME/.config/environment.d/intel-gtk-fix.conf"
+    # This ensures that the env is unset immediately when the file is deleted
+    systemctl --user daemon-reload
 fi


### PR DESCRIPTION
When the system gets started up and the file gets generated or removed by the script, GSK_RENDERER=gl doesn't get set or unset right away which can potentially rub people the wrong way.

Running the above command fixes this.