### PR TITLE
chore(bazaar): add separate brew eval func and escaped cmd preview

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
@@ -80,13 +80,13 @@ def make_popup_terminal_shellcmd(cmd):
     new_cmd = new_cmd.replace('"', '\\"')
     return f'/bin/sh -c "{new_cmd}"'
 
-def spawn_ujust(id):
-    cmd  = make_popup_terminal_shellcmd(f'ujust {id}')
+def spawn_ujust(script):
+    cmd  = make_popup_terminal_shellcmd(f'ujust {script}')
     args = make_shellcmd_argv(cmd)
     spawn_and_detach(args)
 
-def spawn_brew_ublue(id):
-    brew = brew_eval(f'brew tap ublue-os/tap && brew install --cask {id}')
+def spawn_brew_ublue(cask):
+    brew = brew_eval(f'brew tap ublue-os/tap && brew install --cask {cask}')
     cmd  = make_popup_terminal_shellcmd(brew)
     args = make_shellcmd_argv(cmd)
     spawn_and_detach(args)

--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/hooks.py
@@ -62,14 +62,20 @@ def find_action():
     file.close()
     return output
 
+def brew_eval(args):
+    return f'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && {args}'
+
 def spawn_and_detach(args):
     subprocess.Popen(args, start_new_session=True, stdout=subprocess.DEVNULL)
 
 def make_popup_terminal_shellcmd(cmd):
+    preview = cmd.replace('$', '\\$')
+    preview = preview.replace('(', '\\(')
+    preview = preview.replace(')', '\\)')
     new_cmd =  f'{cmd} ; '
     new_cmd +=  'echo 1>&2 ; '
     new_cmd +=  'echo "------------------" 1>&2 ; '
-    new_cmd += f'echo "Command \'{cmd}\' completed. Press ENTER to finish!" 1>&2 ; '
+    new_cmd += f'echo "Command \'{preview}\' completed. Press ENTER to finish!" 1>&2 ; '
     new_cmd +=  'read'
     new_cmd = new_cmd.replace('"', '\\"')
     return f'/bin/sh -c "{new_cmd}"'
@@ -79,8 +85,9 @@ def spawn_ujust(id):
     args = make_shellcmd_argv(cmd)
     spawn_and_detach(args)
 
-def spawn_cmd(cmd):
-    cmd  = make_popup_terminal_shellcmd(cmd)
+def spawn_brew_ublue(id):
+    brew = brew_eval(f'brew tap ublue-os/tap && brew install --cask {id}')
+    cmd  = make_popup_terminal_shellcmd(brew)
     args = make_shellcmd_argv(cmd)
     spawn_and_detach(args)
 
@@ -151,7 +158,7 @@ def handle_vscode():
             try:
                 action = find_action()
                 if action == 'run-brew':
-                    spawn_cmd('/home/linuxbrew/.linuxbrew/bin/brew tap ublue-os/tap && /home/linuxbrew/.linuxbrew/bin/brew install --cask visual-studio-code-linux')
+                    spawn_brew_ublue('visual-studio-code-linux')
                 elif action == 'learn-dx':
                     spawn_and_detach(['xdg-open', 'https://dev.bazzite.gg/'])
             except:
@@ -188,7 +195,7 @@ def handle_vscodium():
 
         case 'action':
             try:
-                spawn_cmd('/home/linuxbrew/.linuxbrew/bin/brew tap ublue-os/tap && /home/linuxbrew/.linuxbrew/bin/brew install --cask vscodium-linux')
+                spawn_brew_ublue('vscodium-linux')
             except:
                 pass
             return ''


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
It's now reasonably formatted and properly displayed so eval command will not run where it doesn't supposed to

<img width="862" height="683" alt="Screenshot From 2026-04-05 11-23-04" src="https://github.com/user-attachments/assets/ab0a8b68-a3ab-4807-bbe9-5a666afbaaf6" />