### PR TITLE
Feat(just): Added two new interactive just fixes to 81-bazzite-fixes.just

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -580,14 +580,14 @@ toggle-cec-sleep ACTION="":
         ;;
     esac
 
-# Manage Intel Ethernet fix (Disables EEE & ASPM). Options: status | enable | disable
+# Manage Intel Ethernet fix (Disables ASPM and sets PCIe policy to Performance). Options: status | enable | disable
 [group("network")]
 manage-intel-ethernet ACTION="":
     #!/usr/bin/env bash
     # 1. Capture current state
     CURRENT_KARGS=$(rpm-ostree kargs)
     get_status_token() {
-        if echo "$CURRENT_KARGS" | grep -q "igc.EEE=0" && echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
+        if echo "$CURRENT_KARGS" | grep -q "pcie_aspm.policy=performance" && echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
             echo "enable"
         else
             echo "disable"
@@ -595,7 +595,7 @@ manage-intel-ethernet ACTION="":
     }
     get_current_status() {
         if [[ "$(get_status_token)" == "enable" ]]; then
-            echo "Disable EEE & ASPM"
+            echo "Disable ASPM & Set Performance Policy"
         else
             echo "Defaults"
         fi
@@ -613,35 +613,35 @@ manage-intel-ethernet ACTION="":
         exit 0
     fi
     echo -e "This script manages a stability fix for Intel I225-V and I226-V Ethernet controllers."
-    echo -e "It disables Energy Efficient Ethernet (EEE) and PCIe Active State Power Management (ASPM) to prevent hardware hangs, failed register reads, and total connection drops during high-speed transfers or gaming."
+    echo -e "It disables PCIe Active State Power Management (ASPM) and sets the PCIe policy to performance to prevent hardware hangs, failed register reads, and total connection drops."
     echo -e "\nCurrent setting: $(get_current_status)\n"
     if [ -z "$OPTION" ]; then
-        OPTION=$(gum choose "Disable EEE & ASPM" "Restore Defaults" "Exit without changes")
+        OPTION=$(gum choose "Disable ASPM & Performance Policy" "Restore Defaults" "Exit without changes")
     fi
 
     case "$OPTION" in
-      "Disable EEE & ASPM"|enable)
+      "Disable ASPM & Performance Policy"|enable)
         if ! lspci | grep -Ei "I225|I226|I221|I222" > /dev/null; then
              gum style --foreground 196 "Error: No compatible Intel NIC detected."
              exit 0
         fi
 
         # 2. Only run rpm-ostree if the fix is actually missing
-        if echo "$CURRENT_KARGS" | grep -q "igc.EEE=0" && echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
+        if echo "$CURRENT_KARGS" | grep -q "pcie_aspm.policy=performance" && echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
             gum style --foreground 212 "Notice: Fixes are already applied in kargs."
         else
             echo "Applying Intel Ethernet stability fixes..."
-            # We use --append-if-missing alone to ensure it actually adds the keys
-            rpm-ostree kargs --append-if-missing='igc.EEE=0' --append-if-missing='pcie_aspm=off'
+            # Added deletion of the old ignored EEE arg and appended the new policy
+            rpm-ostree kargs --delete='igc.EEE=0' --append-if-missing='pcie_aspm=off' --append-if-missing='pcie_aspm.policy=performance' 2>/dev/null || true
             echo "Done! Please reboot to apply changes."
         fi
         ;;
       "Restore Defaults"|disable)
-        if ! echo "$CURRENT_KARGS" | grep -q "igc.EEE=0"; then
+        if ! echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
             gum style --foreground 117 "Notice: System is already at defaults."
         else
             echo "Restoring Intel Ethernet defaults..."
-            rpm-ostree kargs --delete='igc.EEE=0' --delete='pcie_aspm=off' 2>/dev/null || true
+            rpm-ostree kargs --delete='igc.EEE=0' --delete='pcie_aspm=off' --delete='pcie_aspm.policy=performance' 2>/dev/null || true
             echo "Defaults restored. Please reboot."
         fi
         ;;

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -579,3 +579,136 @@ toggle-cec-sleep ACTION="":
         echo "No changes made."
         ;;
     esac
+
+# Manage Intel Ethernet fix (Disables EEE & ASPM). Options: status | enable | disable
+[group("network")]
+manage-intel-ethernet ACTION="":
+    #!/usr/bin/env bash
+    # 1. Capture current state
+    CURRENT_KARGS=$(rpm-ostree kargs)
+    get_status_token() {
+        if echo "$CURRENT_KARGS" | grep -q "igc.EEE=0" && echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
+            echo "enable"
+        else
+            echo "disable"
+        fi
+    }
+    get_current_status() {
+        if [[ "$(get_status_token)" == "enable" ]]; then
+            echo "Disable EEE & ASPM"
+        else
+            echo "Defaults"
+        fi
+    }
+    OPTION="{{ ACTION }}"
+    if [ "$OPTION" == "help" ]; then
+        echo "Usage: ujust manage-intel-ethernet <option>"
+        echo "  <option>: Specify the option to skip the interactive prompt"
+        echo "  Use 'enable' to apply the Intel Ethernet stability fix"
+        echo "  Use 'disable' to restore Intel Ethernet defaults"
+        echo "  Use 'status' to print the current fix state"
+        exit 0
+    elif [ "$OPTION" == "status" ]; then
+        get_status_token
+        exit 0
+    fi
+    echo -e "This script manages a stability fix for Intel I225-V and I226-V Ethernet controllers."
+    echo -e "It disables Energy Efficient Ethernet (EEE) and PCIe Active State Power Management (ASPM) to prevent hardware hangs, failed register reads, and total connection drops during high-speed transfers or gaming."
+    echo -e "\nCurrent setting: $(get_current_status)\n"
+    if [ -z "$OPTION" ]; then
+        OPTION=$(gum choose "Disable EEE & ASPM" "Restore Defaults" "Exit without changes")
+    fi
+
+    case "$OPTION" in
+      "Disable EEE & ASPM"|enable)
+        if ! lspci | grep -Ei "I225|I226|I221|I222" > /dev/null; then
+             gum style --foreground 196 "Error: No compatible Intel NIC detected."
+             exit 0
+        fi
+
+        # 2. Only run rpm-ostree if the fix is actually missing
+        if echo "$CURRENT_KARGS" | grep -q "igc.EEE=0" && echo "$CURRENT_KARGS" | grep -q "pcie_aspm=off"; then
+            gum style --foreground 212 "Notice: Fixes are already applied in kargs."
+        else
+            echo "Applying Intel Ethernet stability fixes..."
+            # We use --append-if-missing alone to ensure it actually adds the keys
+            rpm-ostree kargs --append-if-missing='igc.EEE=0' --append-if-missing='pcie_aspm=off'
+            echo "Done! Please reboot to apply changes."
+        fi
+        ;;
+      "Restore Defaults"|disable)
+        if ! echo "$CURRENT_KARGS" | grep -q "igc.EEE=0"; then
+            gum style --foreground 117 "Notice: System is already at defaults."
+        else
+            echo "Restoring Intel Ethernet defaults..."
+            rpm-ostree kargs --delete='igc.EEE=0' --delete='pcie_aspm=off' 2>/dev/null || true
+            echo "Defaults restored. Please reboot."
+        fi
+        ;;
+      "Exit without changes"|*)
+        echo "No changes made."
+        ;;
+    esac
+
+# Manage PCIe Power Management fix. Options: status | enable | disable
+[group("hardware")]
+manage-pcie-power ACTION="":
+    #!/usr/bin/env bash
+    CURRENT_KARGS=$(rpm-ostree kargs)
+    get_status_token() {
+        if echo "$CURRENT_KARGS" | grep -q "pcie_port_pm=off"; then
+            echo "enable"
+        else
+            echo "disable"
+        fi
+    }
+    get_current_status() {
+        if [[ "$(get_status_token)" == "enable" ]]; then
+            echo "Disable PCIe Port PM"
+        else
+            echo "Defaults"
+        fi
+    }
+    OPTION="{{ ACTION }}"
+    if [ "$OPTION" == "help" ]; then
+        echo "Usage: ujust manage-pcie-power <option>"
+        echo "  <option>: Specify the option to skip the interactive prompt"
+        echo "  Use 'enable' to disable PCIe Port Power Management"
+        echo "  Use 'disable' to restore PCIe Port Power Management defaults"
+        echo "  Use 'status' to print the current fix state"
+        exit 0
+    elif [ "$OPTION" == "status" ]; then
+        get_status_token
+        exit 0
+    fi
+    echo -e "This script manages PCIe Port Power Management for maximum hardware stability."
+    echo -e "Disabling PCIe Port Power Management prevents the PCIe bus from entering low-power states that can cause micro-stuttering in games, latency spikes for NVMe drives, or wake-from-sleep issues on modern AMD Ryzen systems."
+    echo -e "Recommended for users seeking the lowest possible system latency."
+    echo -e "\nCurrent setting: $(get_current_status)\n"
+    if [ -z "$OPTION" ]; then
+        OPTION=$(gum choose "Disable PCIe Port PM" "Restore Defaults" "Exit without changes")
+    fi
+
+    case "$OPTION" in
+      "Disable PCIe Port PM"|enable)
+        if echo "$CURRENT_KARGS" | grep -q "pcie_port_pm=off"; then
+            gum style --foreground 212 "Notice: PCIe Port PM fix is already applied."
+        else
+            echo "Disabling PCIe Port Power Management..."
+            rpm-ostree kargs --append-if-missing='pcie_port_pm=off'
+            echo "Done! Please reboot to apply changes."
+        fi
+        ;;
+      "Restore Defaults"|disable)
+        if ! echo "$CURRENT_KARGS" | grep -q "pcie_port_pm=off"; then
+            gum style --foreground 117 "Notice: System is already at defaults."
+        else
+            echo "Restoring PCIe Port Power Management defaults..."
+            rpm-ostree kargs --delete='pcie_port_pm=off' 2>/dev/null || true
+            echo "Defaults restored. Please reboot."
+        fi
+        ;;
+      "Exit without changes"|*)
+        echo "No changes made."
+        ;;
+    esac


### PR DESCRIPTION
Added interactive just recipes:
fix(desktop): Intel I225-V and I226-V Ethernet controllers stability fix (manage-pcie-power)
fix(desktop): AM5 PCIe Port Power Management anti "nap" fix (manage-intel-ethernet)

Verified on AMD 9800X3D + B850 hardware.

### Description
**Intel Ethernet Fix**
Group: Hardware
Addresses frequent "Hardware Hang" or "Failed to read reg" errors on Intel I225-V and I226-V Ethernet controllers (common on AM5/B650/B850 motherboards). This fix disables Energy Efficient Ethernet (EEE) and PCIe Active State Power Management (ASPM) for the NIC, which prevents the controller from entering low-power states that lead to total connection drops during high-speed transfers, gaming or even when idle.

**PCIe Power Management Fix**
Group: Network
Disables PCIe Port Power Management (pcie_port_pm=off) to ensure maximum stability for high-performance hardware. This prevents the PCIe bus from "napping" during periods of low activity, which can cause micro-stuttering in games, latency spikes for NVMe drives, or wake-from-sleep issues on modern AMD Ryzen systems (Zen 4/Zen 5). Recommended for users seeking the lowest possible system latency.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
