### PR TITLE
chore(motd): use rpm-ostree json output to grab timestamp

### DIFF
--- a/system_files/desktop/shared/usr/libexec/ublue-motd
+++ b/system_files/desktop/shared/usr/libexec/ublue-motd
@@ -19,10 +19,9 @@ if [[ -f "$TIP_FILE" ]]; then
 	IMAGE_BRANCH_ESCAPED=$(escape "$IMAGE_BRANCH")
 	TIP="󰋼 $(shuf -n 1 "$TIP_FILE")"
 
-	IMAGE_DATE=$(rpm-ostree status --booted | sed -n 's/.*Timestamp: \(.*\)/\1/p')
-	IMAGE_DATE_SECONDS=$(date -d "$IMAGE_DATE" +%s)
+	IMAGE_DATE=$(rpm-ostree status --booted --json | jq -r '.deployments[0]["timestamp"] // empty')
 	CURRENT_SECONDS=$(date +%s)
-	DIFFERENCE=$((CURRENT_SECONDS - IMAGE_DATE_SECONDS))
+	DIFFERENCE=$((CURRENT_SECONDS - IMAGE_DATE))
 	MONTH=$((30 * 24 * 60 * 60))
 	if [ "$DIFFERENCE" -ge "$MONTH" ]; then
 		TIP='# 󰇻 Your current image is over 1 month old, run `ujust update`'


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Should be a bit more efficient than previous command