### PR TITLE
feat(sunshine-brew): add announcement for active sunshine users

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/announcements/sunshine-brew.msg.json
+++ b/system_files/desktop/shared/usr/share/ublue-os/announcements/sunshine-brew.msg.json
@@ -1,0 +1,6 @@
+{
+  "title": "Changes to Sunshine on Bazzite",
+  "seeMoreUrl": "https://docs.bazzite.gg/Advanced/sunshine-brew/#what-should-i-do-if-i-am-currently-using-sunshine",
+  "body": "\n<b>Bazzite noticed you are using Sunshine actively on your system!</b>\nThis notifier is to let you know that Sunshine will soon be removed from the base Bazzite image, and you will need to reinstall it with brew.\n",
+  "if": "bash -c '[[ -f \"$HOME/.config/sunshine/sunshine.conf\" && $(journalctl --no-hostname -g sunshine -b -1 -n 1) != \"-- No entries --\" && $(ls /home/linuxbrew/.linuxbrew/Cellar/ | grep sunshine) == \"\" ]]'"
+}


### PR DESCRIPTION
Adds a conditional announcement if sunshine is being actively used, to notify users of the changes to sunshine, and point them to a page for instructions to do so. Requires https://github.com/ublue-os/docs.bazzite.gg/pull/426

Not sure if the switching instructions would be better off as an announcement on Ublue/Bazzite Discourse rather than in bazzite docs though. This can be updated if it does need to move elsewhere.