### PR TITLE
fix(CEC) Fix timing issue in cec-control

### DIFF
--- a/system_files/desktop/shared/usr/bin/cec-control
+++ b/system_files/desktop/shared/usr/bin/cec-control
@@ -65,6 +65,8 @@ function perform_activate {
         done
         
         if [ "$CEC_SETSOURCE" = true ]; then
+            # Add a short delay so that the CEC device has time to acknowledge this command
+            sleep 0.1
             # Get our physical address if we are setting source
             local phys_addr=$(cec-ctl -d "$CEC_DEVICE" 2>/dev/null | grep "Physical Address" | awk '{print $4}')
             if [[ -n "$phys_addr" ]]; then

--- a/system_files/desktop/shared/usr/bin/cec-control
+++ b/system_files/desktop/shared/usr/bin/cec-control
@@ -72,6 +72,8 @@ function perform_activate {
         done
         
         if [ "$CEC_SETSOURCE" = true ]; then
+            # Add a short delay so that the CEC device has time to acknowledge this command
+            sleep 0.1
             # Get our physical address if we are setting source
             local phys_addr=$(cec-ctl -d "$CEC_DEVICE" 2>/dev/null | grep "Physical Address" | awk '{print $4}')
             if [[ -n "$phys_addr" ]]; then


### PR DESCRIPTION
This change was required for my TV to acknowledge/handle the cec --set-source command. Otherwise, the TV would never acknowledge that the set source command was ever sent.