### PR TITLE
feat(portal): add portal to prepinned apps

### DIFF
--- a/system_files/desktop/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kicker-extra-favoritesrc
+++ b/system_files/desktop/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kicker-extra-favoritesrc
@@ -1,3 +1,3 @@
 [General]
-Prepend=preferred://browser;steam.desktop;net.lutris.Lutris.desktop;systemsettings.desktop;io.github.kolunmi.Bazaar.desktop;org.kde.konsole.desktop;org.kde.dolphin.desktop;
+Prepend=preferred://browser;steam.desktop;net.lutris.Lutris.desktop;systemsettings.desktop;io.github.kolunmi.Bazaar.desktop;io.github.ublue_os.yafti_gtk.desktop;org.kde.konsole.desktop;org.kde.dolphin.desktop;
 IgnoreDefaults=true

--- a/system_files/desktop/kinoite/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
+++ b/system_files/desktop/kinoite/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js
@@ -21,6 +21,7 @@ for (let i = 0; i < allPanels.length; ++i) {
                     "applications:net.lutris.Lutris.desktop",
                     "applications:org.kde.konsole.desktop",
                     "applications:io.github.kolunmi.Bazaar.desktop",
+                    "applications:io.github.ublue_os.yafti_gtk.desktop",
                     "preferred://filemanager"
                 ]);
                 widget.reloadConfig();
@@ -28,4 +29,3 @@ for (let i = 0; i < allPanels.length; ++i) {
         }
     }
 }
-

--- a/system_files/desktop/silverblue/usr/share/glib-2.0/schemas/zz0-01-bazzite-desktop-silverblue-dash.gschema.override
+++ b/system_files/desktop/silverblue/usr/share/glib-2.0/schemas/zz0-01-bazzite-desktop-silverblue-dash.gschema.override
@@ -1,2 +1,2 @@
 [org.gnome.shell] 
-favorite-apps=['org.mozilla.firefox.desktop', 'steam.desktop', 'net.lutris.Lutris.desktop', 'io.github.kolunmi.Bazaar.desktop', 'org.gnome.Ptyxis.desktop', 'org.gnome.Nautilus.desktop']
+favorite-apps=['org.mozilla.firefox.desktop', 'steam.desktop', 'net.lutris.Lutris.desktop', 'io.github.kolunmi.Bazaar.desktop', 'io.github.ublue_os.yafti_gtk.desktop', 'org.gnome.Ptyxis.desktop', 'org.gnome.Nautilus.desktop']


### PR DESCRIPTION
This PR adds the Bazzite Portal kickstart too to the prepinned apps so users can have it ready to go out of the box instead of searching for it. 