### PR TITLE
chore(brh): prefer signed image for official images

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
+++ b/system_files/desktop/shared/usr/bin/bazzite-rollback-helper
@@ -156,13 +156,11 @@ rebase_to() {
   local full_ref="$target"
   case "$target" in
     ostree-*) ;;
-    *:*) 
-      local scheme=$(signing_scheme)
-      full_ref="$scheme/ublue-os/$target"
+    *:*)
+      full_ref="ostree-image-signed:docker://ghcr.io/ublue-os/$target"
       ;;
     *)
-      local scheme=$(signing_scheme)
-      full_ref="$scheme/ublue-os/$DEFAULT_IMAGE:$target"
+      full_ref="ostree-image-signed:docker://ghcr.io/ublue-os/$DEFAULT_IMAGE:$target"
       ;;
   esac
   
@@ -333,7 +331,7 @@ interactive_menu() {
             local version=$(pick_version "ublue-os" "$img" "${filter,,}")
             [[ "$version" != "Back" && -n "$version" ]] && {
               clear
-              rebase_to "$(signing_scheme)/ublue-os/$img:$version"
+              rebase_to "ostree-image-signed:docker://ghcr.io/ublue-os/$img:$version"
               press_any_key
             }
           fi


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Since `ujust verify-image` now exists then brh doesn't necessary need to still keep using unverified image and it will automatically pick the signed one.

The function still exists though since it's still being used in case someone prefers a custom provider.