### PR TITLE
chore: bump bluez to 5.86 for F44

### DIFF
--- a/spec_files/bluez/0019-plugins-Add-new-plugin-to-manage-wake-policy.patch
+++ b/spec_files/bluez/0019-plugins-Add-new-plugin-to-manage-wake-policy.patch
@@ -271,14 +271,14 @@ diff --git a/src/device.h b/src/device.h
 index 5722ca9ca..f8c744baf 100644
 --- a/src/device.h
 +++ b/src/device.h
-@@ -149,6 +149,7 @@ void device_set_wake_support(struct btd_device *device, bool wake_support);
+@@ -162,6 +162,7 @@ void device_set_wake_support(struct btd_device *device, bool wake_support);
  void device_set_wake_override(struct btd_device *device, bool wake_override);
  void device_set_wake_allowed(struct btd_device *device, bool wake_allowed,
  			     guint32 id);
 +bool device_get_wake_support(struct btd_device *device);
- void device_set_refresh_discovery(struct btd_device *dev, bool refresh);
  
- typedef void (*disconnect_watch) (struct btd_device *device, gboolean removal,
+ void device_set_past_support(struct btd_device *device, bool value);
+ 
 -- 
 2.34.1
 

--- a/spec_files/bluez/bluez.spec
+++ b/spec_files/bluez/bluez.spec
@@ -7,14 +7,13 @@
 %endif
 
 Name:    bluez
-Version: 5.84
+Version: 5.86
 Release: 2%{?dist}.bazzite.{{{ git_dir_version }}}
 Summary: Bluetooth utilities
 License: GPL-2.0-or-later
 URL:     http://www.bluez.org/
 
 Source0: https://www.kernel.org/pub/linux/bluetooth/%{name}-%{version}.tar.xz
-Patch0: 0001-media-fix-pac_config_cb-error-code-return.patch
 
 # Valve
 Patch10: 0001-valve-bluetooth-config.patch


### PR DESCRIPTION
Bump bluez from 5.84 to 5.86. F44 ships 5.86.

Dropped Patch0 (pac_config_cb error code fix) as it was merged upstream in 5.85. Valve patches (Patch10-16) should still apply with fuzz 2.