### PR TITLE
chore: bump pipewire to 1.6.4 for F44

### DIFF
--- a/spec_files/pipewire/pipewire.spec
+++ b/spec_files/pipewire/pipewire.spec
@@ -1,6 +1,6 @@
 %global majorversion 1
-%global minorversion 5
-%global microversion 85
+%global minorversion 6
+%global microversion 4
 
 %global apiversion   0.3
 %global spaversion   0.2
@@ -40,17 +40,23 @@
 %bcond_with libmysofa
 %bcond_with lv2
 %bcond_with roc
+%bcond_with ffado
+%bcond_with onnx
 %else
 %bcond_without jackserver_plugin
 %bcond_without libmysofa
 %bcond_without lv2
 %bcond_without roc
-%endif
-
-%if 0%{?rhel} || ("%{_arch}" == "s390x")
+%ifarch s390x
 %bcond_with ffado
+%bcond_with onnx
+%elifarch %{ix86}
+%bcond_without ffado
+%bcond_with onnx
 %else
 %bcond_without ffado
+%bcond_without onnx
+%endif
 %endif
 
 # Disabled for RHEL < 11 and Fedora < 36
@@ -66,6 +72,8 @@ Name:           pipewire
 Summary:        Media Sharing Server
 Version:        %{majorversion}.%{minorversion}.%{microversion}
 Release:        %{baserelease}%{?snapdate:.%{snapdate}git%{shortcommit}}%{?dist}.bazzite.{{{ git_dir_version }}}
+# PipeWire is generally MIT but includes plugins using libraries under other licenses.
+# See the module specific License for details.
 License:        MIT
 URL:            https://pipewire.org/
 %if 0%{?snapdate}
@@ -75,15 +83,14 @@ Source0:        https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/%{ver
 %endif
 Source1:        pipewire.sysusers
 
+## valve patches
+Patch10:        bc435841c141ad38768b6cb1a7ad45e8bb13c7d2.patch
+
 ## upstream patches
 
 ## upstreamable patches
 
 ## fedora patches
-
-## valve patches
-# Holo: TODO: Bug reference
-Patch10:        bc435841c141ad38768b6cb1a7ad45e8bb13c7d2.patch
 
 BuildRequires:  gettext
 BuildRequires:  meson >= 0.59.0
@@ -119,10 +126,10 @@ BuildRequires:  libsndfile-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  pulseaudio-libs-devel
 BuildRequires:  avahi-devel
-%if 0%{?fedora} >= 40 || 0%{?rhel} >= 10
+%if (0%{?fedora} && 0%{?fedora} < 44) || (0%{?rhel} && 0%{?rhel} < 11)
 BuildRequires:  pkgconfig(webrtc-audio-processing-1)
 %else
-BuildRequires:  pkgconfig(webrtc-audio-processing) >= 0.2
+BuildRequires:  pkgconfig(webrtc-audio-processing-2)
 %endif
 BuildRequires:  libusb1-devel
 BuildRequires:  readline-devel
@@ -133,6 +140,7 @@ BuildRequires:  speexdsp-devel
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  libebur128-devel
 BuildRequires:  fftw-devel
+BuildRequires:  spandsp-devel
 
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:       systemd
@@ -150,7 +158,8 @@ systems.
 
 %package libs
 Summary:        Libraries for PipeWire clients
-License:        MIT
+# fftw is GPL-2.0-or later, ladpsa is LGPL-2.0-or-later and used in filter-graph.
+License:        MIT AND GPL-2.0-or-later AND BSD-2-Clause AND LGPL-2.0-or-later
 Recommends:     %{name}%{?_isa} = %{version}-%{release}
 Obsoletes:      %{name}-libpulse < %{version}-%{release}
 
@@ -362,7 +371,7 @@ This package contains X11 bell support for PipeWire.
 %if %{with ffado}
 %package module-ffado
 Summary:        PipeWire media server ffado support
-License:        MIT
+License:        MIT AND GPL-2.0-only OR GPL-3.0-only
 BuildRequires:  libffado-devel
 Recommends:     %{name}%{?_isa} = %{version}-%{release}
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
@@ -374,7 +383,7 @@ This package contains the FFADO support for PipeWire.
 %if %{with roc}
 %package module-roc
 Summary:        PipeWire media server ROC support
-License:        MIT
+License:        MIT AND MPL-2.0 AND LGPL-2.1-or-later AND CECILL-C
 BuildRequires:  roc-toolkit-devel
 BuildRequires:  libunwind-devel
 BuildRequires:  openfec-devel
@@ -389,7 +398,7 @@ This package contains the ROC support for PipeWire.
 %if %{with libmysofa}
 %package module-filter-chain-sofa
 Summary:        PipeWire media server sofa filter-chain support
-License:        MIT
+License:        MIT AND BSD-3-Clause
 BuildRequires:  libmysofa-devel
 Recommends:     %{name}%{?_isa} = %{version}-%{release}
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
@@ -408,6 +417,18 @@ Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description module-filter-chain-lv2
 This package contains the mysofa support for PipeWire filter-chain.
+%endif
+
+%if %{with onnx}
+%package module-filter-chain-onnx
+Summary:        PipeWire media server ONNX filter-chain support
+License:        MIT AND Apache-2.0 AND BSL-1.0 AND BSD-3-Clause
+BuildRequires:  onnxruntime-devel
+Recommends:     %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+
+%description module-filter-chain-onnx
+This package contains the ONNX support for PipeWire filter-chain.
 %endif
 
 %package config-rates
@@ -449,27 +470,30 @@ cp %{SOURCE1} subprojects/packagefiles/
 
 %build
 %meson \
-    -D docs=enabled -D man=enabled -D gstreamer=enabled -D systemd=enabled  \
-    -D sdl2=disabled                                \
-    -D audiotestsrc=disabled -D videotestsrc=disabled               \
-    -D volume=disabled -D bluez5-codec-aptx=disabled                \
-    -D bluez5-codec-lc3plus=disabled -D bluez5-codec-lc3=enabled        \
+    -D docs=enabled -D man=enabled -D gstreamer=enabled -D libsystemd=enabled	\
+    -D systemd-user-service=enabled 						\
+    -D sdl2=disabled 								\
+    -D audiotestsrc=disabled -D videotestsrc=disabled				\
+    -D volume=disabled -D bluez5-codec-aptx=disabled 		  		\
+    -D bluez5-codec-lc3plus=disabled -D bluez5-codec-lc3=enabled		\
+    -D bluez5-codec-ldac-dec=disabled 						\
 %ifarch s390x
-    -D bluez5-codec-ldac=disabled                       \
+    -D bluez5-codec-ldac=disabled						\
 %endif
-    -D session-managers=[]                          \
-    -D rtprio-server=60 -D rtprio-client=55 -D rlimits-rtprio=70        \
-    -D snap=disabled                                \
-    %{!?with_jack:-D pipewire-jack=disabled}                    \
-    %{!?with_jackserver_plugin:-D jack=disabled}                \
-    %{!?with_libcamera_plugin:-D libcamera=disabled}                \
-    %{?with_jack:-D jack-devel=true}                        \
-    %{!?with_alsa:-D pipewire-alsa=disabled}                    \
-    %{?with_vulkan:-D vulkan=enabled}                       \
-    %{!?with_libmysofa:-D libmysofa=disabled}                   \
-    %{!?with_lv2:-D lv2=disabled}                       \
-    %{!?with_roc:-D roc=disabled}                       \
-    %{!?with_ffado:-D libffado=disabled}                    \
+    -D session-managers=[] 							\
+    -D rtprio-server=60 -D rtprio-client=55 -D rlimits-rtprio=70		\
+    -D snap=disabled								\
+    %{!?with_jack:-D pipewire-jack=disabled} 					\
+    %{!?with_jackserver_plugin:-D jack=disabled} 				\
+    %{!?with_libcamera_plugin:-D libcamera=disabled} 				\
+    %{?with_jack:-D jack-devel=true} 						\
+    %{!?with_alsa:-D pipewire-alsa=disabled}					\
+    %{?with_vulkan:-D vulkan=enabled}						\
+    %{!?with_libmysofa:-D libmysofa=disabled}					\
+    %{!?with_lv2:-D lv2=disabled}						\
+    %{!?with_onnx:-D onnxruntime=disabled}					\
+    %{!?with_roc:-D roc=disabled}						\
+    %{!?with_ffado:-D libffado=disabled}					\
     %{nil}
 %meson_build
 
@@ -511,22 +535,22 @@ rm %{buildroot}%{_datadir}/pipewire/pipewire-pulse.conf
 install -d -m 0755 %{buildroot}%{_datadir}/pipewire/pipewire-pulse.conf.d/
 
 ln -s ../pipewire-pulse.conf.avail/20-upmix.conf \
-        %{buildroot}%{_datadir}/pipewire/pipewire-pulse.conf.d/20-upmix.conf
+		%{buildroot}%{_datadir}/pipewire/pipewire-pulse.conf.d/20-upmix.conf
 %endif
 
 # rates config
 ln -s ../pipewire.conf.avail/10-rates.conf \
-        %{buildroot}%{_datadir}/pipewire/pipewire.conf.d/10-rates.conf
+		%{buildroot}%{_datadir}/pipewire/pipewire.conf.d/10-rates.conf
 
 # upmix config
 ln -s ../pipewire.conf.avail/20-upmix.conf \
-        %{buildroot}%{_datadir}/pipewire/pipewire.conf.d/20-upmix.conf
+		%{buildroot}%{_datadir}/pipewire/pipewire.conf.d/20-upmix.conf
 ln -s ../client.conf.avail/20-upmix.conf \
-        %{buildroot}%{_datadir}/pipewire/client.conf.d/20-upmix.conf
+		%{buildroot}%{_datadir}/pipewire/client.conf.d/20-upmix.conf
 
 # raop config
 ln -s ../pipewire.conf.avail/50-raop.conf \
-        %{buildroot}%{_datadir}/pipewire/pipewire.conf.d/50-raop.conf
+		%{buildroot}%{_datadir}/pipewire/pipewire.conf.d/50-raop.conf
 
 %find_lang %{name}
 
@@ -730,11 +754,14 @@ systemctl --no-reload preset --global pipewire.socket >/dev/null 2>&1 || :
 %{_bindir}/pw-mididump
 %{_bindir}/pw-midiplay
 %{_bindir}/pw-midirecord
+%{_bindir}/pw-midi2play
+%{_bindir}/pw-midi2record
 %{_bindir}/pw-mon
 %{_bindir}/pw-play
 %{_bindir}/pw-profiler
 %{_bindir}/pw-record
 %{_bindir}/pw-reserve
+%{_bindir}/pw-sysex
 %{_bindir}/pw-top
 %{_mandir}/man1/pw-cat.1*
 %{_mandir}/man1/pw-cli.1*
@@ -890,6 +917,11 @@ systemctl --no-reload preset --global pipewire.socket >/dev/null 2>&1 || :
 %{_libdir}/spa-%{spaversion}/filter-graph/libspa-filter-graph-plugin-lv2.so
 %endif
 
+%if %{with onnx}
+%files module-filter-chain-onnx
+%{_libdir}/spa-%{spaversion}/filter-graph/libspa-filter-graph-plugin-onnx.so
+%endif
+
 %files config-rates
 %{_datadir}/pipewire/pipewire.conf.d/10-rates.conf
 
@@ -904,936 +936,4 @@ systemctl --no-reload preset --global pipewire.socket >/dev/null 2>&1 || :
 %{_datadir}/pipewire/pipewire.conf.d/50-raop.conf
 
 %changelog
-* Fri Jan 16 2026 Wim Taymans <wtaymans@redhat.com> - 1.4.10-1
-- Update version to 1.4.10 
-
-* Thu Oct 9 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.9-1
-- Update version to 1.4.9
-
-* Wed Sep 17 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.8-2
-- Add patch for xrun regression when stopping nodes.
-- Add patch for libcamera IPA spawn problem.
-- Add patch to fix UMP event sorting.
-
-* Thu Sep 11 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.8-1
-- Update version to 1.4.8
-
-* Wed Jul 23 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.7-1
-- Update version to 1.4.7
-
-* Fri Jun 27 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.6-1
-- Update version to 1.4.6
-
-* Wed Jun 04 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.5-1
-- Update version to 1.4.5
-
-* Thu May 29 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.4-1
-- Update version to 1.4.4
-
-* Thu May 22 2025 Christian Glombek <lorbus@fedoraproject.org> - 1.4.3-2
-- Add config-raop package with config enabling module-raop
-
-* Thu May 22 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.3-1
-- Update version to 1.4.3
-
-* Thu Apr 24 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.2-2
-- Rebuild for libcamera
-
-* Mon Apr 14 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.2-1
-- Update version to 1.4.2
-
-* Fri Mar 14 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.1-1
-- Update version to 1.4.1
-- Remove the Conflicts: with JACK, we can install both but if the
-  pipewire version is installed, all goes to pipewire.
-
-* Fri Mar 07 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.0-3
-- Always require jack-audio-connection-kit from jack-audio-connection-kit-libs
-  because the ld.so.conf is needed to build dependent packages
-  Resolves: rhbz#2345985
-
-* Fri Mar 07 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.0-2
-- Move the libjack.so ld.so.conf file to -libs.
-  Resolves: rhbz#2345985
-
-* Thu Mar 06 2025 Wim Taymans <wtaymans@redhat.com> - 1.4.0-1
-- Update version to 1.4.0
-
-* Mon Feb 24 2025 Wim Taymans <wtaymans@redhat.com> - 1.3.83-1
-- Update version to 1.3.83
-
-* Tue Feb 11 2025 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl> - 1.3.82-2
-- Drop call to %sysusers_create_compat
-
-* Thu Feb 06 2025 Wim Taymans <wtaymans@redhat.com> - 1.3.82-1
-- Update version to 1.3.82
-
-* Sat Jan 18 2025 Fedora Release Engineering <releng@fedoraproject.org> - 1.2.7-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_42_Mass_Rebuild
-
-* Fri Jan 10 2025 Wim Taymans <wtaymans@redhat.com> - 1.2.7-2
-- Rebuild for new libcamera
-
-* Tue Nov 26 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.7-1
-- Update version to 1.2.7
-
-* Wed Oct 23 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.6-1
-- Update version to 1.2.6
-
-* Fri Sep 27 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.5-1
-- Update version to 1.2.5
-- Add config packages
-
-* Thu Sep 19 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.4-1
-- Update version to 1.2.4
-- Add Recommends: pipewire-plugin-libcamera for MIPI camera support
-
-* Thu Aug 22 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.3-1
-- Update version to 1.2.3
-
-* Sun Aug 04 2024 Yaakov Selkowitz <yselkowi@redhat.com> - 1.2.1-3
-- pipewire-jack-libs Requires pipewire-jack on RHEL
-
-* Fri Jul 19 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.2.1-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_41_Mass_Rebuild
-
-* Fri Jul 12 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.1-1
-- Update version to 1.2.1
-
-* Mon Jul 1 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.0-3
-- Add patch for Ardour export regresssion.
-
-* Mon Jul 1 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.0-2
-- Add patch for KODI regresssion.
-
-* Thu Jun 27 2024 Wim Taymans <wtaymans@redhat.com> - 1.2.0-1
-- Update version to 1.2.0
-
-* Tue Jun 18 2024 Wim Taymans <wtaymans@redhat.com> - 1.1.83-1
-- Update version to 1.1.83
-
-* Fri May 24 2024 Wim Taymans <wtaymans@redhat.com> - 1.1.82-1
-- Update version to 1.1.82
-
-* Thu May 23 2024 Peter Robinson <pbrobinson@fedoraproject.org> - 1.1.81-2
-- Rebuild for libcamera 0.3
-
-* Thu May 16 2024 Wim Taymans <wtaymans@redhat.com> - 1.1.81-1
-- Update version to 1.1.81
-
-* Thu May 09 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.6-1
-- Update version to 1.0.6
-
-* Tue Apr 23 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.5-2
-- Enable ROC again
-
-* Mon Apr 15 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.5-1
-- Update version to 1.0.5
-
-* Wed Mar 13 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.4-2
-- Configure server, client and rlimit priorities to be the same as JACK.
-
-* Wed Mar 13 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.4-1
-- Update version to 1.0.4
-
-* Tue Feb 13 2024 Yaakov Selkowitz <yselkowi@redhat.com> - 1.0.3-2
-- Use webrtc-audio-processing-1 on F40 and RHEL 10
-
-* Fri Feb 02 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.3-1
-- Update version to 1.0.3
-
-* Wed Jan 31 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.2-1
-- Update version to 1.0.2
-
-* Thu Jan 25 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.0.1-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
-
-* Sun Jan 21 2024 Fedora Release Engineering <releng@fedoraproject.org> - 1.0.1-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
-
-* Thu Jan 11 2024 Wim Taymans <wtaymans@redhat.com> - 1.0.1-1
-- Update version to 1.0.1
-- Add patch to support libcamera 0.2
-
-* Thu Dec 14 2023 Wim Taymans <wtaymans@redhat.com> - 1.0.0-2
-- Add patch to avoid crash in deviceprovider.
-
-* Sun Nov 26 2023 Wim Taymans <wtaymans@redhat.com> - 1.0.0-1
-- Update version to 1.0.0
-- Disable ROC until updated in Fedora.
-
-* Thu Nov 16 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.85-1
-- Update version to 0.3.85
-
-* Wed Nov 15 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.84-5
-- Disable libcamera in RHEL 10
-
-* Tue Nov 14 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.3.84-4
-- Enable support for the lc3 bluetooth codec
-
-* Thu Nov 09 2023 Hector Martin <marcan@fedoraproject.org> - 0.3.84-3
-- Create and own /usr/share/pipewire/pipewire-pulse.conf.d
-
-* Mon Nov 06 2023 Hector Martin <marcan@fedoraproject.org> - 0.3.84-2
-- Create and own /usr/share/pipewire/pipewire.conf.d
-
-* Thu Nov 02 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.84-1
-- Update version to 0.3.84
-
-* Mon Oct 23 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.83-2
-- Apply patches to fix openal delay and echo-cancel distortion
-
-* Thu Oct 19 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.83-1
-- Update version to 0.3.83
-
-* Mon Oct 16 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.82-2
-- Add patch for device detection for asahi linux.
-- Add patch to avoid crash in ALSA.
-
-* Fri Oct 13 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.82-1
-- Update version to 0.3.82
-
-* Fri Oct 6 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.81-1
-- Update version to 0.3.81
-
-* Thu Sep 14 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.80-1
-- Update version to 0.3.80
-- Revert webrtc echo-cancel updates until fedora has newer version.
-
-* Tue Aug 29 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.79-1
-- Update version to 0.3.79
-
-* Tue Aug 22 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.78-1
-- Update version to 0.3.78
-
-* Tue Aug 08 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.77-3
-- Add patch to avoid duplicate sinks and sources.
-
-* Mon Aug 07 2023 Sandro Bonazzola <sbonazzo@redhat.com> - 0.3.77-2
-- Explicitly require pipewire-jack-audio-connection-kit-libs for pipewire-plugin-jack
-
-* Fri Aug 04 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.77-1
-- Update version to 0.3.77
-
-* Sun Jul 30 2023 Javier Martinez Canillas <javierm@redhat.com>  0.3.76-2
-- Rebuild for libcamera 0.1.0 bump
-
-* Fri Jul 28 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.76-1
-- Update version to 0.3.76
-
-* Fri Jul 21 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.75-1
-- Update version to 0.3.75
-
-* Fri Jul 21 2023 Fedora Release Engineering <releng@fedoraproject.org> - 0.3.74-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_39_Mass_Rebuild
-
-* Wed Jul 12 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.74-1
-- Update version to 0.3.74
-
-* Thu Jul 06 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.73-1
-- Update version to 0.3.73
-- Fixes rhbz#2156003 Split out lv2 and sofa filter-chain packages.
-- Split out vulkan plugin and roc module
-
-* Thu Jun 29 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.72-2
-- Move the ffado driver to module-ffado
-  Fixes rhbz#2218481
-
-* Mon Jun 26 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.72-1
-- Update version to 0.3.72
-- The jack libraries and ld.so override were split so that jack can
-  be installed together with the pipewire-jack libraries and pw-jack.
-
-* Thu Jun 15 2023 Yaakov Selkowitz <yselkowi@redhat.com> - 0.3.71-4
-- Disable libmysofa, lv2, roc in RHEL builds
-
-* Tue May 23 2023 Yaakov Selkowitz <yselkowi@redhat.com> - 0.3.71-3
-- Move JACK modules to plugin-jack subpackage
-
-* Thu May 18 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.71-2
-- Add patch to fix JACK buffersize updates
-
-* Wed May 17 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.71-1
-- Update version to 0.3.71
-
-* Thu Apr 20 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.70-1
-- Update version to 0.3.70
-
-* Tue Apr 18 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.69-2
-- Add 3 useful patches.
-
-* Thu Apr 13 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.69-1
-- Update version to 0.3.69
-
-* Tue Apr 11 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.68-2
-- Add 2 patches for some critical bugs.
-
-* Thu Apr 6 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.68-1
-- Update version to 0.3.68
-- Enable gstreamer-device-provider (rhbz#2183691)
-
-* Thu Mar 9 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.67-1
-- Update version to 0.3.67
-
-* Thu Feb 16 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.66-1
-- Update version to 0.3.66
-
-* Sat Jan 28 2023 Stefan Bluhm <stefan.bluhm@clacee.eu> - 0.3.65-3
-- Added missing build dependency
-
-* Thu Jan 26 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.65-2
-- Add NEWS file (rhbz#2032237)
-
-* Thu Jan 26 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.65-1
-- Update version to 0.3.65
-
-* Thu Jan 19 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.64-3
-- Add patch to avoid DSP mixing issues with AVX in filter-chain.
-- Add patch to revert API breakage with deprecated symbols.
-- Add patch to fix scaling overflow that could cause stuttering.
-
-* Tue Jan 17 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.64-2
-- Re-enabled roc-toolkit support.
-
-* Thu Jan 12 2023 Wim Taymans <wtaymans@redhat.com> - 0.3.64-1
-- Update version to 0.3.64
-- Disable ROC again until 0.2 support is merged in fedora.
-
-* Sun Jan 01 2023 Mamoru TASAKA <mtasaka@fedoraproject.org> - 0.3.63-2
-- Rebuild for new libcamera again
-
-* Thu Dec 15 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.63-1
-- Update version to 0.3.63
-
-* Tue Dec 13 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.62-3
-- Add patch to fix distorted sound on AVX2 in some cases.
-
-* Mon Dec 12 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.62-2
-- Package X11 bell support separately
-  Fixes rhbz#2152385
-
-* Fri Dec 09 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.62-1
-- Update version to 0.3.62
-
-* Wed Dec 07 2022 Mamoru TASAKA <mtasaka@fedoraproject.org> - 0.3.61-2
-- Rebuild for new libcamera
-
-* Thu Nov 24 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.61-1
-- Update version to 0.3.61
-
-* Thu Nov 17 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.60-5
-- Add patch to fix sound in qemu.
-
-* Tue Nov 15 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.60-4
-- Add patch to avoid crashes when switching profiles
-
-* Thu Nov 10 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.60-3
-- Add patch to make Telegram playback work again
-
-* Thu Nov 10 2022 Neal Gompa <ngompa@fedoraproject.org> - 0.3.60-2
-- Restore libusb support
-
-* Thu Nov 10 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.60-1
-- Update version to 0.3.60
-
-* Mon Oct 24 2022 Jaroslav Škarvada <jskarvad@redhat.com> - 0.3.59-3
-- Enabled roc-toolkit support
-  Resolves: rhbz#2041189
-
-* Fri Oct 21 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.59-2
-- Add a patch to fix midi processing in some cases.
-- Add a patch to fix crash when exiting some JACK apps such as
-  Ardour7.
-- Add a patch to fix a crash when switching bluetooth profiles.
-- Add a patch to fix bluetooth source switching between drivers.
-
-* Fri Sep 30 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.59-1
-- Update version to 0.3.59
-
-* Thu Sep 22 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.58-3
-- Add patch to fix ffmpeg capture and other stutterings.
-
-* Mon Sep 19 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.58-2
-- Add patch to fix stuttering in Teamspeak.
-
-* Thu Sep 15 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.58-1
-- Update version to 0.3.58
-
-* Fri Sep 2 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.57-1
-- Update version to 0.3.57
-- Add systemd BuildRequires
-- Fix lv2 include path
-
-* Fri Jul 22 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.3.56-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
-
-* Tue Jul 19 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.56-1
-- Update version to 0.3.56
-
-* Tue Jul 12 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.55-2
-- Add patch to avoid crash in JACK.
-
-* Tue Jul 12 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.55-1
-- Update version to 0.3.55
-
-* Thu Jul 07 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.54-1
-- Update version to 0.3.54
-
-* Mon Jul 4 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.53-4
-- Add channel remap patch.
-
-* Mon Jul 4 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.53-3
-- Add patch to fix speaker-test.
-- Add patch to fix noise in resampler.
-
-* Fri Jul 1 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.53-2
-- Add patch to avoid crash in audioconvert (mpv)
-
-* Thu Jun 30 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.53-1
-- Update version to 0.3.53
-
-* Thu Jun 23 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.52-4
-- Add patch to remove 44.1KHz from samplerates
-- See rhbz#2096193
-
-* Wed Jun 15 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.52-3
-- Add patch to fix stuttering in TeamSpeak.
-- Inc baserel to 3, previous build was accidentally done with 2
-  instead of 1.
-
-* Thu Jun 09 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.52-1
-- Update version to 0.3.52
-- Disable LC3plus codec.
-
-* Thu May 19 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.51-2
-- Add pulseaudio-utils as Requires for pipewire-pulseaudio
-
-* Thu Apr 28 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.51-1
-- Update version to 0.3.51
-
-* Wed Apr 13 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.50-1
-- Update version to 0.3.50
-
-* Tue Mar 29 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.49-1
-- Update version to 0.3.49
-- libusb was removed from f37
-
-* Thu Mar 3 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.48-1
-- Update version to 0.3.48
-
-* Fri Feb 18 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.47-1
-- Update version to 0.3.47
-
-* Thu Feb 17 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.46-1
-- Update version to 0.3.46
-
-* Mon Feb 7 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.45-2
-- Add patch for kernels with CONFIG_SND_VERBOSE_PROCFS=n
-- Add patch to make Musescore work again
-
-* Thu Feb 3 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.45-1
-- Update version to 0.3.45
-
-* Thu Jan 27 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.44-1
-- Update version to 0.3.44
-
-* Tue Jan 25 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.43-5
-- Add more patches to avoid segfaults in bluez5
-
-* Fri Jan 21 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.3.43-4
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
-
-* Tue Jan 18 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.43-3
-- Add patch to avoid segfault in bluez5 (rhbz#2041481)
-
-* Mon Jan 17 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.43-2
-- Add patch to avoid segfault in bluez5 (rhbz#2041481)
-
-* Wed Jan 5 2022 Wim Taymans <wtaymans@redhat.com> - 0.3.43-1
-- Update version to 0.3.43
-
-* Thu Dec 16 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.42-1
-- Update version to 0.3.42
-
-* Mon Dec 13 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.41-1
-- Update version to 0.3.41
-
-* Thu Nov 11 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.40-1
-- Update version to 0.3.40 and media-session 0.4.1
-- Enable tests for s390x again
-
-* Tue Nov 09 2021 Peter Hutterer <peter.hutterer@redhat.com> - 0.3.39-3
-- Don't build media-session on F35, it's a separate package now, see #2016247
-
-* Wed Oct 27 2021 Peter Hutterer <peter.hutterer@redhat.com> - 0.3.39-2
-- Don't build media-session on F36, it's a separate package now, see #2016247
-- Remove versioned systemd dependency, 184 was released in 2012
-
-* Thu Oct 21 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.39-1
-- Update version to 0.3.39
-
-* Wed Oct 13 2021 Neal Gompa <ngompa@fedoraproject.org> - 0.3.38-2
-- Fix libcamera bcond to work properly in RHEL10+ and F36+
-
-* Thu Sep 30 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.38-1
-- Update version to 0.3.38
-
-* Wed Sep 29 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.37-3
-- Rebuild for new libcamera
-
-* Thu Sep 23 2021 Javier Martinez Canillas <javierm@redhat.com> - 0.3.37-2
-- Enable libcamera SPA plugin
-
-* Thu Sep 23 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.37-1
-- Update version to 0.3.37
-
-* Thu Sep 16 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.36-2
-- Update version to 0.3.36
-
-* Thu Sep 16 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.36-1
-- Update to 0.3.36
-- Do systemd post install of pipewire-media-session.service
-
-* Thu Sep 09 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.35-2
-- Add patch to fix passthrough check.
-
-* Thu Sep 09 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.35-1
-- Update to 0.3.35
-
-* Mon Aug 30 2021 Neal Gompa <ngompa@fedoraproject.org> - 0.3.34-2
-- Add preference for WirePlumber for session manager (#1989959)
-
-* Thu Aug 26 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.34-1
-- Update to 0.3.34
-
-* Wed Aug 11 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.33-3
-- Add more upstream patches.
-
-* Tue Aug 10 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.33-2
-- Add patch to fix default device persistence.
-
-* Thu Aug 5 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.33-1
-- Update to 0.3.33
-
-* Thu Aug 5 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.32-4
-- Add media-session Conflicts: with older pipewire versions, they can't be
-  installed at the same time because they both contain the media-session binary.
-
-* Fri Jul 23 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.3.32-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild
-
-* Wed Jul 21 2021 Neal Gompa <ngompa@fedoraproject.org> - 0.3.32-2
-- Add conditional for media-session subpackage
-
-* Tue Jul 20 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.32-1
-- Update to 0.3.32
-
-* Thu Jul 15 2021 Peter Hutterer <peter.hutterer@redhat.com> - 0.3.31-4
-- Enable media-session.service, requires fedora-release-35-0.10 to enable the
-  service by default (#1976006).
-
-* Mon Jul 05 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.31-3
-- Add "Conflicts: pipewire-session-manager" to pipewire-media-session
-  to enforce one implementation of the session manager at a time
-
-* Mon Jun 28 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.31-2
-- Fix session manager path
-
-* Mon Jun 28 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.31-1
-- Update to 0.3.31
-
-* Fri Jun 25 2021 Peter Hutterer <peter.hutterer@redhat.com> - 0.3.30-5
-- Split media-session into a subpackage and Require it through a virtual
-  Provides from the main pipewire package
-
-* Tue Jun 15 2021 Łukasz Patron <priv.luk@gmail.com> - 0.3.30-4
-- Add patch for setting node description for module-combine-sink
-
-* Tue Jun 15 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.30-3
-- Rebuild for Gstreamer update
-
-* Thu Jun 10 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.30-2
-- Add ALSA UCM 1.2.5 compatibility fixes
-
-* Wed Jun 09 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.30-1
-- Update to 0.3.30
-
-* Fri Jun 04 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.29-2
-- Add some important patches.
-
-* Thu Jun 03 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.29-1
-- Update to 0.3.29
-
-* Mon May 17 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.28-1
-- Update to 0.3.28
-
-* Mon May 10 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.27-2
-- Add patch to fix volume issues.
-
-* Thu May 06 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.27-1
-- Update to 0.3.27
-
-* Thu Apr 29 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.26-4
-- Add some more important upstream patches.
-
-* Mon Apr 26 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.26-3
-- Add some important upstream patches.
-
-* Sat Apr 24 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.26-2
-- Disable JACK server integration on RHEL
-
-* Thu Apr 22 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.26-1
-- Update to 0.3.26
-
-* Tue Apr 20 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.25-2
-- Add jack-devel subpackage, enable JACK support on RHEL 9+ (#1945951)
-
-* Tue Apr 06 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.25-1
-- Update to 0.3.25
-
-* Thu Mar 25 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.24-4
-- Apply some critical upstream patches
-
-* Thu Mar 25 2021 Kalev Lember <klember@redhat.com> - 0.3.24-3
-- Fix RHEL build
-
-* Thu Mar 25 2021 Kalev Lember <klember@redhat.com> - 0.3.24-2
-- Move individual config files to the subpackages that make use of them
-
-* Thu Mar 18 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.24-1
-- Update to 0.3.24
-
-* Tue Mar 09 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.23-2
-- Add patch to enable UCM Microphones
-
-* Thu Mar 04 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.23-1
-- Update to 0.3.23
-
-* Wed Feb 24 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.22-7
-- Add patch to sample destroy use after free
-
-* Wed Feb 24 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.22-6
-- Add patch for jack names
-
-* Mon Feb 22 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.22-5
-- Add some critical patches
-
-* Fri Feb 19 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.22-4
-- Replace more PulseAudio modules on upgrade in F34+
-
-* Fri Feb 19 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.22-3
-- Replace ALSA plugins and PulseAudio modules on upgrade in F34+
-
-* Fri Feb 19 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.22-2
-- Replace JACK and PulseAudio on upgrade in F34+
-  Reference: https://fedoraproject.org/wiki/Changes/DefaultPipeWire
-
-* Thu Feb 18 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.22-1
-- Update to 0.3.22
-- disable sdl2 examples
-
-* Thu Feb 04 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.21-2
-- Add some upstream patches
-- Fixes rhbz#1925138
-
-* Wed Feb 03 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.21-1
-- Update to 0.3.21
-
-* Wed Jan 27 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.3.20-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
-
-* Wed Jan 20 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.20-1
-- Update to 0.3.20
-- Fix baseversion
-- Add gettext dependency
-
-* Tue Jan 12 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.19-4
-- Rework conditional build to fix ELN builds
-
-* Sat Jan  9 2021 Evan Anderson <evan@eaanderson.com> - 0.3.19-3
-- Add LDAC and AAC dependency to enhance Bluetooth support
-
-* Thu Jan  7 2021 Neal Gompa <ngompa13@gmail.com> - 0.3.19-2
-- Obsolete useless libjack subpackage with jack-audio-connection-kit subpackage
-
-* Tue Jan 5 2021 Wim Taymans <wtaymans@redhat.com> - 0.3.19-1
-- Update to 0.3.19
-- Add ncurses-devel BR
-
-* Tue Dec 15 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.18-1
-- Update to 0.3.18
-
-* Fri Nov 27 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.17-2
-- Add some more Provides: for pulseaudio
-
-* Thu Nov 26 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.17-1
-- Update to 0.3.17
-
-* Tue Nov 24 2020 Neal Gompa <ngompa13@gmail.com> - 0.3.16-4
-- Add 'pulseaudio-daemon' Provides + Conflicts to pipewire-pulseaudio
-- Remove useless ldconfig macros that expand to nothing
-
-* Fri Nov 20 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.16-3
-- Fix Requires for pipewire-pulseaudio
-- Fixes rhbz#1899945
-
-* Fri Nov 20 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.16-2
-- Add patch to fix crash in kwin, Fixes rhbz#1899826
-
-* Thu Nov 19 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.16-1
-- Update to 0.3.16
-
-* Wed Nov 4 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.15-2
-- Add patch to fix screen sharing for old clients
-
-* Wed Nov 4 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.15-1
-- Update to 0.3.15
-
-* Sun Nov 1 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.14-2
-- Add some pulse server patches
-
-* Fri Oct 30 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.14-1
-- Update to 0.3.14
-
-* Sun Oct 18 2020 Neal Gompa <ngompa13@gmail.com> - 0.3.13-6
-- Fix jack and pulseaudio subpackages to generate dependencies properly
-
-* Tue Oct 13 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.13-5
-- Disable device provider for now
-- Fixes rhbz#1884260
-
-* Thu Oct 1 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.13-4
-- Add patches for some crasher bugs
-- Fixes rhbz#1884177
-
-* Tue Sep 29 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.13-3
-- Add patch to improve pulse compatibility
-
-* Mon Sep 28 2020 Jeff Law <law@redhat.com> - 0.3.13-2
-- Re-enable LTO as upstream GCC target/96939 has been fixed
-
-* Mon Sep 28 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.13-1
-- Update to 0.3.13
-
-* Fri Sep 18 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.12-1
-- Update to 0.3.12
-
-* Fri Sep 11 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.11-2
-- Add some patches to improve pulse compatibility
-
-* Thu Sep 10 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.11-1
-- Update to 0.3.11
-
-* Mon Aug 17 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.10-1
-- Update to 0.3.10
-
-* Tue Aug 04 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.9-1
-- Update to 0.3.9
-
-* Tue Aug 04 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.8-3
-- Add patch to avoid segfault when iterating ports.
-- Fixes #1865827
-
-* Wed Jul 29 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.8-2
-- Add patch for fix chrome audio hicups
-- Add patch for infinite loop in device add/remove
-- Disable LTO on armv7
-
-* Tue Jul 28 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.8-1
-- Update to 0.3.8
-
-* Tue Jul 21 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.7-2
-- Add patch to avoid crash when clearing metadata
-
-* Tue Jul 21 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.7-1
-- Update to 0.3.7
-
-* Wed Jun 10 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.6-2
-- Use systemd presets to enable pipewire.socket
-- Remove duplicate hardened_build flags
-- Add meson build again
-- Fix -gstreamer subpackage Requires:
-
-* Wed Jun 10 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.6-1
-- Update to 0.3.6
-- Add new man pages
-- Only build vulkan/pulse/jack in Fedora.
-
-* Mon May 11 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.5-1
-- Update to 0.3.5
-
-* Fri May 01 2020 Adam Williamson <awilliam@redhat.com> - 0.3.4-2
-- Suppress library provides from pipewire-lib{pulse,jack}
-
-* Thu Apr 30 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.4-1
-- Update to 0.3.4
-- Add 2 more packages that replace libjack and libpulse
-
-* Tue Mar 31 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.2-3
-- Add patch to unsubscribe unused sequencer ports
-- Change config to only disable bluez5 handling by default.
-
-* Mon Mar 30 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.2-2
-- Add config to disable alsa and bluez5 handling by default.
-
-* Thu Mar 26 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.2-1
-- Update to 0.3.2
-
-* Fri Mar 06 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.1-1
-- Update to 0.3.1
-
-* Thu Feb 20 2020 Wim Taymans <wtaymans@redhat.com> - 0.3.0-1
-- Update to 0.3.0
-- Add libpulse-simple-pw.so
-
-* Wed Feb 19 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.97-1
-- Update to 0.2.97
-- Change download link
-
-* Tue Feb 18 2020 Kalev Lember <klember@redhat.com> - 0.2.96-2
-- Rename subpackages so that libjack-pw is in -libjack
-  and libpulse-pw is in -libpulse
-- Split libspa-jack.so out to -plugin-jack subpackage
-- Avoid hard-requiring the daemon from any of the library subpackages
-
-* Tue Feb 11 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.96-1
-- Update to 0.2.96
-- Split -gstreamer package
-- Enable aarch64 tests again
-
-* Fri Feb 07 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.95-1
-- Update to 0.2.95
-- Disable test on aarch64 for now
-
-* Wed Feb 05 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.94-1
-- Update to 0.2.94
-- Move pipewire modules to -libs
-- Add pw-profiler
-- Add libsndfile-devel as a BR
-
-* Thu Jan 30 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.2.92-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
-
-* Tue Jan 28 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.93-1
-- Update to 0.2.93
-
-* Wed Jan 15 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.92-1
-- Update to 0.2.92
-
-* Wed Jan 15 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.91-1
-- Update to 0.2.91
-- Add some more BR
-- Fix some unit tests
-
-* Mon Jan 13 2020 Wim Taymans <wtaymans@redhat.com> - 0.2.90-1
-- Update to 0.2.90
-
-* Thu Nov 28 2019 Kalev Lember <klember@redhat.com> - 0.2.7-2
-- Move spa plugins to -libs subpackage
-
-* Thu Sep 26 2019 Wim Taymans <wtaymans@redhat.com> - 0.2.7-1
-- Update to 0.2.7
-
-* Mon Sep 16 2019 Kalev Lember <klember@redhat.com> - 0.2.6-5
-- Don't require the daemon package for -devel subpackage
-- Move pipewire.conf man page to the daemon package
-
-* Fri Jul 26 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.2.6-4
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
-
-* Wed Jun 19 2019 Wim Taymans <wtaymans@redhat.com> - 0.2.6-3
-- Add patch to reuse fd in pipewiresrc
-- Add patch for device provider
-- Add patch to disable extra security checks until portal is fixed.
-
-* Tue Jun 04 2019 Kalev Lember <klember@redhat.com> - 0.2.6-2
-- Split libpipewire and the gstreamer plugin out to -libs subpackage
-
-* Wed May 22 2019 Wim Taymans <wtaymans@redhat.com> - 0.2.6-1
-- Update to 0.2.6
-- Add patch for alsa-lib 1.1.9 include path
-
-* Sat Feb 02 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.2.5-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
-
-* Fri Jan 04 2019 Wim Taymans <wtaymans@redhat.com> - 0.2.5-2
-- Add patch to avoid invalid conversion error with C++ compilers
-
-* Thu Nov 22 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.5-1
-- Update to 0.2.5
-
-* Thu Nov 22 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.4-1
-- Update to 0.2.4
-
-* Thu Oct 18 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.3-2
-- Add systemd socket activation
-
-* Thu Aug 30 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.3-1
-- Update to 0.2.3
-
-* Tue Jul 31 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.2-1
-- Update to 0.2.2
-
-* Fri Jul 20 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.1-1
-- Update to 0.2.1
-
-* Tue Jul 17 2018 Wim Taymans <wtaymans@redhat.com> - 0.2.0-1
-- Update to 0.2.0
-
-* Fri Jul 13 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.1.9-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
-
-* Tue Feb 27 2018 Wim Taymans <wtaymans@redhat.com> - 0.1.9-1
-- Update to 0.1.9
-
-* Fri Feb 09 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.1.8-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
-
-* Sat Feb 03 2018 Igor Gnatenko <ignatenkobrain@fedoraproject.org> - 0.1.8-2
-- Switch to %%ldconfig_scriptlets
-
-* Tue Jan 23 2018 Wim Taymans <wtaymans@redhat.com> - 0.1.8-1
-- Update to 0.1.8
-
-* Fri Nov 24 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.7-1
-- Update to 0.1.7
-- Add to build when memfd_create is already defined
-
-* Fri Nov 03 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.6-1
-- Update to 0.1.6
-
-* Tue Sep 19 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.5-2
-- Add patch to avoid segfault when probing
-
-* Tue Sep 19 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.5-1
-- Update to 0.1.5
-
-* Thu Sep 14 2017 Kalev Lember <klember@redhat.com> - 0.1.4-3
-- Rebuilt for GNOME 3.26.0 megaupdate
-
-* Fri Sep 08 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.4-2
-- Install SPA hooks
-
-* Wed Aug 23 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.4-1
-- Update to 0.1.4
-
-* Wed Aug 09 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.3-1
-- Update to 0.1.3
-
-* Tue Jul 04 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.2-1
-- Update to 0.1.2
-- Added more build requirements
-- Make separate doc package
-
-* Mon Jun 26 2017 Wim Taymans <wtaymans@redhat.com> - 0.1.1-1
-- Update to 0.1.1
-- Add dbus-1 to BuildRequires
-- change libs-devel to -devel
-
-* Wed Sep 9 2015 Wim Taymans <wtaymans@redhat.com> - 0.1.0-2
-- Fix BuildRequires to use pkgconfig, add all dependencies found in configure.ac
-- Add user and groups  if needed
-- Add license to %%licence
-
-* Tue Sep 1 2015 Wim Taymans <wtaymans@redhat.com> - 0.1.0-1
-- First version
+%autochangelog

--- a/spec_files/pipewire/pipewire.spec
+++ b/spec_files/pipewire/pipewire.spec
@@ -1,6 +1,6 @@
 %global majorversion 1
-%global minorversion 4
-%global microversion 10
+%global minorversion 5
+%global microversion 85
 
 %global apiversion   0.3
 %global spaversion   0.2


### PR DESCRIPTION
Bump pipewire from 1.4.10 to 1.6.3. F44 ships 1.6.3 in updates-testing. The echo-cancel monitor_mode patch still applies cleanly.