### PR TITLE
chore: bump mutter to 50.1 for F44

### DIFF
--- a/spec_files/mutter/4296.patch
+++ b/spec_files/mutter/4296.patch
@@ -1,56 +1,16 @@
-From cb11ba42ce297ed97d229429fcfece9f5c0c5cc3 Mon Sep 17 00:00:00 2001
+From ef3e2f3f8042295c82bd44c3d927e8f7f49e6cc0 Mon Sep 17 00:00:00 2001
 From: Dallas Strouse <dallas.strouse2007@gmail.com>
-Date: Tue, 30 Sep 2025 18:49:43 -0500
-Subject: [PATCH 1/3] input-settings: Custom acceleration profiles
+Date: Fri, 20 Feb 2026 14:07:47 -0600
+Subject: [PATCH] input-settings, input-settings/native: Custom acceleration
+ profiles
 
 ---
- src/backends/meta-input-settings-dummy.c   | 12 ++--
- src/backends/meta-input-settings-private.h | 19 +++--
- src/backends/meta-input-settings.c         | 83 +++++++++++++++++++---
- 3 files changed, 96 insertions(+), 18 deletions(-)
+ src/backends/meta-input-settings-dummy.c      | 12 ++-
+ src/backends/meta-input-settings-private.h    | 19 ++++-
+ src/backends/meta-input-settings.c            | 83 ++++++++++++++++---
+ .../native/meta-input-settings-native.c       | 68 +++++++++++++--
+ 4 files changed, 155 insertions(+), 27 deletions(-)
 
-diff --git a/src/backends/meta-input-settings-dummy.c b/src/backends/meta-input-settings-dummy.c
-index 2abac056984..7259c144e47 100644
---- a/src/backends/meta-input-settings-dummy.c
-+++ b/src/backends/meta-input-settings-dummy.c
-@@ -165,21 +165,24 @@ meta_input_settings_dummy_set_tablet_area (MetaInputSettings  *settings,
- static void
- meta_input_settings_dummy_set_mouse_accel_profile (MetaInputSettings           *settings,
-                                                    ClutterInputDevice          *device,
--                                                   GDesktopPointerAccelProfile  profile)
-+                                                   GDesktopPointerAccelProfile  profile,
-+                                                   MetaCustomAccelConfig       *accel_config)
- {
- }
- 
- static void
- meta_input_settings_dummy_set_touchpad_accel_profile (MetaInputSettings           *settings,
-                                                       ClutterInputDevice          *device,
--                                                      GDesktopPointerAccelProfile  profile)
-+                                                      GDesktopPointerAccelProfile  profile,
-+                                                      MetaCustomAccelConfig       *accel_config)
- {
- }
- 
- static void
- meta_input_settings_dummy_set_trackball_accel_profile (MetaInputSettings           *settings,
-                                                        ClutterInputDevice          *device,
--                                                       GDesktopPointerAccelProfile  profile)
-+                                                       GDesktopPointerAccelProfile  profile,
-+                                                       MetaCustomAccelConfig       *accel_config)
- {
- }
- 
-@@ -235,7 +238,8 @@ meta_input_settings_dummy_set_pointing_stick_scroll_method (MetaInputSettings
- static void
- meta_input_settings_dummy_set_pointing_stick_accel_profile (MetaInputSettings           *settings,
-                                                             ClutterInputDevice          *device,
--                                                            GDesktopPointerAccelProfile  profile)
-+                                                            GDesktopPointerAccelProfile  profile,
-+                                                            MetaCustomAccelConfig       *accel_config)
- {
- }
- 
 diff --git a/src/backends/meta-input-settings-private.h b/src/backends/meta-input-settings-private.h
 index bb1e4bbb4d1..32b7c091d2e 100644
 --- a/src/backends/meta-input-settings-private.h
@@ -95,10 +55,10 @@ index bb1e4bbb4d1..32b7c091d2e 100644
                                               ClutterInputDevice                *device,
                                               GDesktopPointingStickScrollMethod  profile);
 diff --git a/src/backends/meta-input-settings.c b/src/backends/meta-input-settings.c
-index d41b5def2c8..35ebed70be8 100644
+index bdb24064d23..f88ce7827db 100644
 --- a/src/backends/meta-input-settings.c
 +++ b/src/backends/meta-input-settings.c
-@@ -380,7 +380,8 @@ static void
+@@ -377,7 +377,8 @@ static void
  do_update_pointer_accel_profile (MetaInputSettings          *input_settings,
                                   GSettings                  *settings,
                                   ClutterInputDevice         *device,
@@ -108,7 +68,7 @@ index d41b5def2c8..35ebed70be8 100644
  {
    MetaInputSettingsPrivate *priv =
      meta_input_settings_get_instance_private (input_settings);
-@@ -390,34 +391,87 @@ do_update_pointer_accel_profile (MetaInputSettings          *input_settings,
+@@ -387,34 +388,87 @@ do_update_pointer_accel_profile (MetaInputSettings          *input_settings,
    if (settings == priv->mouse_settings)
      input_settings_class->set_mouse_accel_profile (input_settings,
                                                     device,
@@ -204,8 +164,8 @@ index d41b5def2c8..35ebed70be8 100644
      }
    else
      {
-@@ -434,7 +488,7 @@ update_pointer_accel_profile (MetaInputSettings  *input_settings,
-             continue;
+@@ -427,7 +481,7 @@ update_pointer_accel_profile (MetaInputSettings  *input_settings,
+           device = l->data;
  
            do_update_pointer_accel_profile (input_settings, settings,
 -                                           device, profile);
@@ -213,7 +173,7 @@ index d41b5def2c8..35ebed70be8 100644
          }
      }
  }
-@@ -1199,6 +1253,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
+@@ -1192,6 +1246,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
          update_device_natural_scroll (input_settings, NULL);
        else if (strcmp (key, "accel-profile") == 0)
          update_pointer_accel_profile (input_settings, settings, NULL);
@@ -222,7 +182,7 @@ index d41b5def2c8..35ebed70be8 100644
        else if (strcmp (key, "middle-click-emulation") == 0)
          update_middle_click_emulation (input_settings, settings, NULL);
      }
-@@ -1212,6 +1268,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
+@@ -1205,6 +1261,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
          update_device_natural_scroll (input_settings, NULL);
        else if (strcmp (key, "accel-profile") == 0)
          update_pointer_accel_profile (input_settings, settings, NULL);
@@ -231,7 +191,7 @@ index d41b5def2c8..35ebed70be8 100644
        else if (strcmp (key, "tap-to-click") == 0)
          update_touchpad_tap_enabled (input_settings, NULL);
        else if (strcmp (key, "tap-button-map") == 0)
-@@ -1240,6 +1298,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
+@@ -1233,6 +1291,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
          update_trackball_scroll_button (input_settings, NULL);
        else if (strcmp (key, "accel-profile") == 0)
          update_pointer_accel_profile (input_settings, settings, NULL);
@@ -240,7 +200,7 @@ index d41b5def2c8..35ebed70be8 100644
        else if (strcmp (key, "middle-click-emulation") == 0)
          update_middle_click_emulation (input_settings, settings, NULL);
      }
-@@ -1249,6 +1309,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
+@@ -1242,6 +1302,8 @@ meta_input_settings_changed_cb (GSettings  *settings,
          update_device_speed (input_settings, NULL);
        else if (strcmp (key, "accel-profile") == 0)
          update_pointer_accel_profile (input_settings, settings, NULL);
@@ -249,26 +209,13 @@ index d41b5def2c8..35ebed70be8 100644
        else if (strcmp (key, "scroll-method") == 0)
          update_pointing_stick_scroll_method (input_settings, settings, NULL);
      }
-@@ -2032,3 +2094,4 @@ meta_input_settings_get_tool_button_action (MetaInputSettings       *input_setti
+@@ -2058,3 +2120,4 @@ meta_input_settings_get_tool_button_action (MetaInputSettings       *input_setti
  
    return action;
  }
 +
--- 
-GitLab
-
-
-From 38ebfdfd9914aa5f669655ebac68eb3ced214bbb Mon Sep 17 00:00:00 2001
-From: Dallas Strouse <dallas.strouse2007@gmail.com>
-Date: Tue, 30 Sep 2025 18:53:17 -0500
-Subject: [PATCH 2/3] input-settings/native: Custom acceleration profiles
-
----
- .../native/meta-input-settings-native.c       | 68 ++++++++++++++++---
- 1 file changed, 59 insertions(+), 9 deletions(-)
-
 diff --git a/src/backends/native/meta-input-settings-native.c b/src/backends/native/meta-input-settings-native.c
-index 91d31712918..223c322adf5 100644
+index 09eddc3651c..192153c9ffa 100644
 --- a/src/backends/native/meta-input-settings-native.c
 +++ b/src/backends/native/meta-input-settings-native.c
 @@ -28,6 +28,9 @@

--- a/spec_files/mutter/mutter.spec
+++ b/spec_files/mutter/mutter.spec
@@ -1,87 +1,94 @@
 %global glib_version 2.81.1
+%global gobject_introspection_version 1.41.4
 %global gtk3_version 3.19.8
-%global gtk4_version 4.0.0
+%global gtk4_version 4.14.0
 %global gsettings_desktop_schemas_version 47~beta
-%global libinput_version 1.26.0
-%global pipewire_version 1.2.0
+%global libdrm_version 2.4.118
+%global libinput_version 1.27.0
+%global pixman_version 0.42
+%global pipewire_version 1.2.7
 %global lcms2_version 2.6
 %global colord_version 1.4.5
 %global libei_version 1.3.901
-%global _default_patch_fuzz 2
-
-%global mutter_api_version 17
+%global mutter_api_version 18
+%global wayland_protocols_version 1.45
+%global wayland_server_version 1.24
 
 %global major_version %%(echo %{version} | cut -d '.' -f1 | cut -d '~' -f 1)
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
+%global _default_patch_fuzz 2
+
 Name:          mutter
-Version:       49.3
+Version:       50.1
 Release:       %autorelease.bazzite
 Summary:       Window and compositing manager based on Clutter
 
 # Automatically converted from old format: GPLv2+ - review is highly recommended.
 License:       GPL-2.0-or-later
-URL:           https://www.gnome.org
-Source0:       https://download.gnome.org/sources/%{name}/%{major_version}/%{name}-%{tarball_version}.tar.xz
+URL:           http://www.gnome.org
+Source0:       http://download.gnome.org/sources/%{name}/%{major_version}/%{name}-%{tarball_version}.tar.xz
 Source1:       org.gnome.mutter.fedora.gschema.override
 
-# https://bugzilla.redhat.com/show_bug.cgi?id=1936991
 Patch0:        mutter-42.alpha-disable-tegra.patch
-
-# https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4296
 Patch10:       4296.patch
 
-BuildRequires: pkgconfig(gobject-introspection-1.0) >= 1.41.0
-BuildRequires: pkgconfig(sm)
-BuildRequires: pkgconfig(libadwaita-1)
-BuildRequires: pkgconfig(libwacom)
-BuildRequires: pkgconfig(xkbcommon)
+BuildRequires: cvt
+BuildRequires: desktop-file-utils
 BuildRequires: mesa-libEGL-devel
 BuildRequires: mesa-libGLES-devel
 BuildRequires: mesa-libGL-devel
 BuildRequires: mesa-libgbm-devel
+BuildRequires: pam-devel
+BuildRequires: pkgconfig(bash-completion)
+BuildRequires: pkgconfig(colord) >= %{colord_version}
+BuildRequires: pkgconfig(glib-2.0) >= %{glib_version}
+BuildRequires: pkgconfig(gobject-introspection-1.0) >= %{gobject_introspection_version}
+BuildRequires: pkgconfig(sm)
+BuildRequires: pkgconfig(lcms2) >= %{lcms2_version}
+BuildRequires: pkgconfig(libadwaita-1)
+BuildRequires: pkgconfig(libwacom)
+BuildRequires: pkgconfig(xkbcommon)
 BuildRequires: pkgconfig(glesv2)
 BuildRequires: pkgconfig(graphene-gobject-1.0)
-BuildRequires: pam-devel
 BuildRequires: pkgconfig(libdisplay-info)
 BuildRequires: pkgconfig(libpipewire-0.3) >= %{pipewire_version}
 BuildRequires: pkgconfig(sysprof-capture-4)
-BuildRequires: sysprof-devel
 BuildRequires: pkgconfig(libsystemd)
 BuildRequires: pkgconfig(umockdev-1.0)
-BuildRequires: desktop-file-utils
-BuildRequires: cvt
 BuildRequires: python3-argcomplete
 BuildRequires: python3-docutils
 # Bootstrap requirements
 BuildRequires: gettext-devel git-core
 BuildRequires: pkgconfig(libcanberra)
 BuildRequires: pkgconfig(gsettings-desktop-schemas) >= %{gsettings_desktop_schemas_version}
+BuildRequires: pkgconfig(gtk4) >= %{gtk4_version}
 BuildRequires: pkgconfig(gnome-settings-daemon)
 BuildRequires: meson
 BuildRequires: pkgconfig(gbm)
 BuildRequires: pkgconfig(glycin-2)
 BuildRequires: pkgconfig(gnome-desktop-4)
 BuildRequires: pkgconfig(gudev-1.0)
-BuildRequires: pkgconfig(libdrm)
-BuildRequires: pkgconfig(libstartup-notification-1.0)
-BuildRequires: pkgconfig(wayland-protocols)
-BuildRequires: pkgconfig(wayland-server)
-BuildRequires: pkgconfig(lcms2) >= %{lcms2_version}
-BuildRequires: pkgconfig(colord) >= %{colord_version}
+BuildRequires: pkgconfig(libdrm) >= %{libdrm_version}
 BuildRequires: pkgconfig(libei-1.0) >= %{libei_version}
 BuildRequires: pkgconfig(libeis-1.0) >= %{libei_version}
+BuildRequires: pkgconfig(libstartup-notification-1.0)
+BuildRequires: pkgconfig(wayland-protocols) >= %{wayland_protocols_version}
+BuildRequires: pkgconfig(wayland-server) >= %{wayland_server_version}
+BuildRequires: sysprof-devel
 
 BuildRequires: pkgconfig(libinput) >= %{libinput_version}
+BuildRequires: pkgconfig(pixman-1) >= %{pixman_version}
 BuildRequires: pkgconfig(xwayland)
-BuildRequires: pkgconfig(bash-completion)
 
 BuildRequires: python3-dbusmock
 
-Requires: control-center-filesystem
+Requires: gnome-control-center-filesystem
+Requires: glib2%{?_isa} >= %{glib_version}
 Requires: gsettings-desktop-schemas%{?_isa} >= %{gsettings_desktop_schemas_version}
 Requires: gnome-settings-daemon
 Requires: gtk4%{?_isa} >= %{gtk4_version}
+Requires: libeis%{?_isa} >= %{libei_version}
 Requires: libinput%{?_isa} >= %{libinput_version}
 Requires: pipewire%{_isa} >= %{pipewire_version}
 Requires: startup-notification
@@ -129,6 +136,7 @@ Common files used by Mutter and soft forks of Mutter
 %package devel
 Summary: Development package for %{name}
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: libei%{?_isa} >= %{libei_version}
 # for EGL/eglmesaext.h that's included from public cogl-egl-defines.h header
 Requires: mesa-libEGL-devel
 
@@ -141,10 +149,18 @@ Summary:  Tests for the %{name} package
 Requires: %{name}-devel%{?_isa} = %{version}-%{release}
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: gtk3%{?_isa} >= %{gtk3_version}
+Requires: libei%{?_isa} >= %{libei_version}
 
 %description tests
 The %{name}-tests package contains tests that can be used to verify
 the functionality of the installed %{name} package.
+
+%package devkit
+Summary: Mutter Development Kit
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description devkit
+Viewer for nested mutter instances.
 
 %prep
 %autosetup -S git -n %{name}-%{tarball_version}
@@ -162,18 +178,19 @@ install -p %{SOURCE1} %{buildroot}%{_datadir}/glib-2.0/schemas
 %files -f %{name}.lang
 %license COPYING
 %doc NEWS
-%{_bindir}/mutter
-%{_datadir}/polkit-1/actions/org.gnome.mutter.*.policy
 %{_bindir}/gdctl
 %{_bindir}/gnome-service-client
-%{_datadir}/bash-completion/completions/gdctl
+%{_bindir}/mutter
+%{_datadir}/polkit-1/actions/org.gnome.mutter.*.policy
 %{_libdir}/lib*.so.*
 %{_libdir}/mutter-%{mutter_api_version}/
+%exclude %{_libdir}/mutter-%{mutter_api_version}/*.gir
 %{_libexecdir}/mutter-backlight-helper
 %{_libexecdir}/mutter-x11-frames
 %{_mandir}/man1/mutter.1*
 %{_mandir}/man1/gdctl.1*
 %{_mandir}/man1/gnome-service-client.1*
+%{bash_completions_dir}/gdctl
 
 %files common
 %{_datadir}/GConf/gsettings/mutter-schemas.convert
@@ -184,19 +201,21 @@ install -p %{SOURCE1} %{buildroot}%{_datadir}/glib-2.0/schemas
 %{_udevrulesdir}/61-mutter.rules
 
 %files devel
-%{_datadir}/applications/org.gnome.Mutter.Mdk.desktop
-%{_datadir}/glib-2.0/schemas/org.gnome.mutter.devkit.gschema.xml
-%{_datadir}/icons/hicolor/*/apps/org.gnome.Mutter.Mdk*
-%{_includedir}/*
+%{_includedir}/mutter-%{mutter_api_version}/
 %{_libdir}/lib*.so
 %{_libdir}/mutter-%{mutter_api_version}/*.gir
 %{_libdir}/pkgconfig/*
-%{_libexecdir}/mutter-devkit
 
 %files tests
-%{_libexecdir}/installed-tests/mutter-%{mutter_api_version}
 %{_datadir}/installed-tests/mutter-%{mutter_api_version}
 %{_datadir}/mutter-%{mutter_api_version}/tests
+%{_libexecdir}/installed-tests/mutter-%{mutter_api_version}
+
+%files devkit
+%{_datadir}/applications/org.gnome.Mutter.Mdk.desktop
+%{_datadir}/glib-2.0/schemas/org.gnome.mutter.devkit.gschema.xml
+%{_datadir}/icons/hicolor/*/apps/org.gnome.Mutter.Mdk*
+%{_libexecdir}/mutter-devkit
 
 %changelog
 %autochangelog


### PR DESCRIPTION
Bump mutter from 49.3 to 50.0 for GNOME 50. API version 17 -> 18. F44 ships mutter 50.0.

Both patches still needed (unmerged upstream):
- Patch0: tegra disable (old Fedora workaround)
- Patch10: MR 4296 custom acceleration profiles

Note: gnome-shell must also be bumped to 50.0 to match the new API.