### PR TITLE
chore: bump anaconda to 44.30 for F44

### DIFF
--- a/spec_files/anaconda/anaconda.spec
+++ b/spec_files/anaconda/anaconda.spec
@@ -1,6 +1,6 @@
 Summary: Graphical system installer
 Name:    anaconda
-Version: 41.35
+Version: 44.30
 Release: 101.bazzite
 License: GPL-2.0-or-later
 URL:     http://fedoraproject.org/wiki/Anaconda
@@ -13,6 +13,8 @@ URL:     http://fedoraproject.org/wiki/Anaconda
 Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{version}/%{name}-%{version}.tar.bz2
 
 Patch0:  bazzite.patch
+Patch1:  bazzite-800p.patch
+Patch2:  bazzite-scale.patch
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).

--- a/spec_files/anaconda/bazzite-800p.patch
+++ b/spec_files/anaconda/bazzite-800p.patch
@@ -1,0 +1,16 @@
+--- a/pyanaconda/display.py
++++ b/pyanaconda/display.py
+@@ -266,6 +266,13 @@ def set_resolution(runres):
+     :param str runres: a resolution specification string
+     """
+     try:
++        # Get product name
++        with open("/sys/devices/virtual/dmi/id/product_name") as f:
++            dmi = f.read().strip()
++
++        if "Jupiter" in dmi or "Galileo" in dmi or "NEXT" in dmi:
++            runres = "1280x800"
++
+         log.info("Setting the screen resolution to: %s.", runres)
+         mutter_display = MutterDisplay()
+         mutter_display.set_resolution(runres)

--- a/spec_files/anaconda/bazzite-scale.patch
+++ b/spec_files/anaconda/bazzite-scale.patch
@@ -1,0 +1,16 @@
+--- a/pyanaconda/ui/gui/__init__.py
++++ b/pyanaconda/ui/gui/__init__.py
+@@ -584,6 +584,13 @@ class GraphicalUserInterface(UserInterface):
+         if not primary_monitor:
+             return
+ 
++        with open("/sys/devices/virtual/dmi/id/product_name") as f:
++            dmi = f.read().strip()
++
++        if "Jupiter" in dmi or "Galileo" in dmi or "NEXT" in dmi:
++            util.setenv("GDK_SCALE", "1")
++            return
++
+         monitor_geometry = primary_monitor.get_geometry()
+         monitor_scale = primary_monitor.get_scale_factor()
+         monitor_width_mm = primary_monitor.get_width_mm()

--- a/spec_files/anaconda/bazzite.patch
+++ b/spec_files/anaconda/bazzite.patch
@@ -1,14 +1,3 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Antheas Kapenekakis <git@antheas.dev>
-Date: Mon, 12 May 2025 23:08:02 +0200
-Subject: feat: allow for custom version branding
-
----
- pyanaconda/core/product.py | 8 ++++++++
- 1 file changed, 8 insertions(+)
-
-diff --git a/pyanaconda/core/product.py b/pyanaconda/core/product.py
-index 329b8595c7..b93332055c 100644
 --- a/pyanaconda/core/product.py
 +++ b/pyanaconda/core/product.py
 @@ -93,6 +93,14 @@ def get_product_values():
@@ -21,62 +10,8 @@ index 329b8595c7..b93332055c 100644
 +            if bazzite_version:
 +                product_version = bazzite_version
 +    except Exception:
-+        product_version = "42"
++        product_version = "44"
 +
      # for use in device names, eg: "fedora", "rhel"
      product_short_name = shorten_product_name(product_name)
  
--- 
-2.49.0
-
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Antheas Kapenekakis <git@antheas.dev>
-Date: Mon, 12 May 2025 23:10:36 +0200
-Subject: fix: fix scaling on 800p devices
-
----
- pyanaconda/display.py         | 8 ++++++++
- pyanaconda/ui/gui/__init__.py | 7 +++++++
- 2 files changed, 15 insertions(+)
-
-diff --git a/pyanaconda/display.py b/pyanaconda/display.py
-index c527b66b57..feb96bfe02 100644
---- a/pyanaconda/display.py
-+++ b/pyanaconda/display.py
-@@ -250,6 +250,14 @@ def do_extra_x11_actions(runres, gui_mode):
-     :param str runres: a resolution specification string
-     :param gui_mode: an Anaconda display mode
-     """
-+
-+    # Get product name
-+    with open("/sys/devices/virtual/dmi/id/product_name") as f:
-+        dmi = f.read().strip()
-+
-+    if "Jupiter" in dmi or "Galileo" in dmi or "NEXT" in dmi:
-+        runres = "1280x800"
-+
-     if runres and gui_mode and not flags.usevnc:
-         set_x_resolution(runres)
- 
-diff --git a/pyanaconda/ui/gui/__init__.py b/pyanaconda/ui/gui/__init__.py
-index dfa8e3462d..d47dec86cb 100644
---- a/pyanaconda/ui/gui/__init__.py
-+++ b/pyanaconda/ui/gui/__init__.py
-@@ -576,6 +576,13 @@ class GraphicalUserInterface(UserInterface):
-         if not primary_monitor:
-             return
- 
-+        with open("/sys/devices/virtual/dmi/id/product_name") as f:
-+            dmi = f.read().strip()
-+
-+        if "Jupiter" in dmi or "Galileo" in dmi or "NEXT" in dmi:
-+            util.setenv("GDK_SCALE", "1")
-+            return
-+
-         monitor_geometry = primary_monitor.get_geometry()
-         monitor_scale = primary_monitor.get_scale_factor()
-         monitor_width_mm = primary_monitor.get_width_mm()
--- 
-2.49.0
-


### PR DESCRIPTION
Bump anaconda from 41.35 to 44.30. F44 ships 44.30. This is a major version jump (3 Fedora releases). The bazzite patch (custom version branding + Steam Deck 800p scaling) should still apply but may need rediffing against the new codebase.