### PR TITLE
fix: window rules causing incorrect steam behavior

### DIFF
--- a/spec_files/steamdeck-kde-presets/0001-steam-virtual-keyboard.patch
+++ b/spec_files/steamdeck-kde-presets/0001-steam-virtual-keyboard.patch
@@ -1,5 +1,5 @@
 diff --git a/etc/xdg/kwinrulesrc b/etc/xdg/kwinrulesrc
-index 80b8acd..87ebb13 100644
+index 80b8acd..bd7a15c 100644
 --- a/etc/xdg/kwinrulesrc
 +++ b/etc/xdg/kwinrulesrc
 @@ -5,13 +5,13 @@ update_info=kwinrules.upd:replace-placement-string-to-enum,kwinrules.upd:use-vir
@@ -11,7 +11,8 @@ index 80b8acd..87ebb13 100644
  skiptaskbarrule=2
  title=Steam Keyboard
 -titlematch=2
- type=16
+-type=16
++types=256
  typerule=2
 -wmclass=steam
 +wmclass=steamwebhelper steam

--- a/spec_files/steamdeck-kde-presets/steamdeck-kde-presets.spec
+++ b/spec_files/steamdeck-kde-presets/steamdeck-kde-presets.spec
@@ -4,7 +4,7 @@
 
 Name:           steamdeck-kde-presets
 Version:        {{{ git_dir_version }}}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        KDE Presets from Valve's SteamOS 3.0
 License:        GPLv2
 URL:            https://github.com/ublue-os/bazzite


### PR DESCRIPTION
fixes https://github.com/ublue-os/bazzite/issues/4651

the type= was wrong resulting in steam not able to be minimized
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
