### PR TITLE
chore(yafti): explicitly add ublue tap command to every cask

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -493,35 +493,35 @@ screens:
     description: "Brew Taps and Casks"
     actions:
       - id: "ublue-tap"
-        title: "Add the Ublue tap"
-        description: "Adds the Ublue Brew tap"
+        title: "Add Universal Blue tap"
+        description: "Adds Universal Blue's Brew tap"
         default: false
         script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap'
       - id: "visual-studio-code-linux"
-        title: "Install Visual Studio Code (Needs Ublue Tap)"
+        title: "Install Visual Studio Code"
         description: "Installs Visual Studio Code editor"
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install --cask visual-studio-code-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask visual-studio-code-linux'
       - id: "antigravity-linux"
-        title: "Install Antigravity (Needs Ublue Tap)"
+        title: "Install Antigravity"
         description: "Installs Antigravity"
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install --cask antigravity-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask antigravity-linux'
       - id: "lm-studio-linux"
-        title: "Install LM Studio (Needs Ublue Tap)"
+        title: "Install LM Studio"
         description: "Installs LM Studio"
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install --cask lm-studio-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask lm-studio-linux'
       - id: "jetbrains-toolbox-linux"
-        title: "Install JetBrains Toolbox (Needs Ublue Tap)"
+        title: "Install JetBrains Toolbox"
         description: "Installs JetBrains Toolbox"
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install --cask jetbrains-toolbox-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask jetbrains-toolbox-linux'
       - id: "vscodium-linux"
-        title: "Install VSCodium (Needs Ublue Tap)"
+        title: "Install VSCodium"
         description: "Installs VSCodium editor"
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install --cask vscodium-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask vscodium-linux'
   - title: "System Management"
     description: "System updates and configuration"
     actions:


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
The separate "Add Universal Blue tap" is still there if users need it