### PR TITLE
fix(liveiso): Fix bootloader_restore

### DIFF
--- a/installer/build.sh
+++ b/installer/build.sh
@@ -29,6 +29,25 @@ else
     podman pull "$INSTALL_IMAGE_PAYLOAD"
 fi
 
+# Determine desktop environment
+if [[ ${BASE_IMAGE} == *-gnome* ]]; then
+    desktop_env="gnome"
+else
+    desktop_env="kde"
+fi
+
+# Copy system files
+echo "Copying shared system files..."
+cp -af /src/system_files/shared/. /
+
+if [[ "$desktop_env" == "gnome" ]]; then
+    echo "Copying GNOME-specific system files..."
+    cp -a /src/system_files/gnome/. /
+elif [[ "$desktop_env" == "kde" ]]; then
+    echo "Copying KDE-specific system files..."
+    cp -a /src/system_files/kde/. /
+fi
+
 # Run the preinitramfs hook
 "$SCRIPT_DIR/titanoboa_hook_preinitramfs.sh"
 

--- a/installer/system_files/shared/etc/dracut.conf.d/liveos-nvme.conf
+++ b/installer/system_files/shared/etc/dracut.conf.d/liveos-nvme.conf
@@ -1,1 +1,0 @@
-force_drivers+=" nvme nvme-core "

--- a/installer/system_files/shared/etc/dracut.conf.d/liveos-nvme.conf
+++ b/installer/system_files/shared/etc/dracut.conf.d/liveos-nvme.conf
@@ -1,0 +1,1 @@
+force_drivers+=" nvme nvme-core "

--- a/installer/system_files/shared/usr/bin/bootloader_restore
+++ b/installer/system_files/shared/usr/bin/bootloader_restore
@@ -100,8 +100,8 @@ else
         rm -vf $MNT/boot/bootupd-state.json &&
             info "Removed existing bootupd-state.json"
     fi
-    run0 --user="$PKEXEC_UID" --
-    ptyxis --title="$_APP_NAME - Restoring bootloader" -- \
+    run0 --user="$PKEXEC_UID" -- \
+        xdg-terminal-exec --title="$_APP_NAME - Restoring bootloader" -- \
         pkexec bash -c "bootupctl backend install
             -vvvv
         --auto

--- a/installer/titanoboa_hook_postrootfs.sh
+++ b/installer/titanoboa_hook_postrootfs.sh
@@ -298,17 +298,6 @@ rm -vf /etc/profile.d/verify_motd.sh
     rm -f /usr/share/backgrounds/default.xml
 )
 
-echo "Copying shared system files..."
-cp -af /src/system_files/shared/. /
-
-if [[ "$desktop_env" == "gnome" ]]; then
-    echo "Copying GNOME-specific system files..."
-    cp -a /src/system_files/gnome/. /
-elif [[ "$desktop_env" == "kde" ]]; then
-    echo "Copying KDE-specific system files..."
-    cp -a /src/system_files/kde/. /
-fi
-
 # Enable on-screen keyboard
 if [[ $imageref == *-deck* ]]; then
     # Enable keyboard here


### PR DESCRIPTION
- Fix missing backslash in bootloader_restore script
- Replace direct ptyxis call with xdg-terminal-exec for better compatibility
- Move the logic that copies shared and desktop-specific system files from
the postrootfs hook to the main build script. This ensures these files
are present before the initramfs is rebuilt, allowing any configuration
contained within them (such as dracut configs) to be included in the
boot image.

