### PR TITLE
fix(just): add setup-waydroid alias

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-waydroid.just
@@ -1,5 +1,7 @@
 # vim: set ft=make :
 
+alias setup-waydroid := configure-waydroid
+
 # Launch Waydroid configuration helper. Options: init | configure | gpu | integration | reset | helper
 [group("apps")]
 configure-waydroid ACTION="":


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Adding `setup-waydroid` back as an alias for `configure-waydroid` like it used to be, just the other way around for those users who's still using the old command (and docs for some time until recently)