### PR TITLE
feat(KDE): improve Traditional Chinese and Indic languages support ootb for KDE image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -435,6 +435,7 @@ RUN --mount=type=cache,dst=/var/cache \
             kio-extras \
             krunner-bazaar \
             krdc \
+            tesseract-langpack-eng \
             tesseract-langpack-spa \
             tesseract-langpack-deu \
             tesseract-langpack-jpn \

--- a/Containerfile
+++ b/Containerfile
@@ -425,9 +425,11 @@ RUN --mount=type=cache,dst=/var/cache \
             kdeconnectd \
             kdeplasma-addons \
             rom-properties-kf6 \
+            fcitx5-chewing \
             fcitx5-mozc \
             fcitx5-chinese-addons \
             fcitx5-hangul \
+            fcitx5-m17n \
             kcm-fcitx5 \
             gnome-disk-utility \
             kio-extras \
@@ -446,6 +448,8 @@ RUN --mount=type=cache,dst=/var/cache \
             tesseract-langpack-tur \
             tesseract-langpack-chi_sim \
             tesseract-langpack-chi_sim_vert \
+            tesseract-langpack-chi_tra \
+            tesseract-langpack-chi_tra_vert \
             tesseract-langpack-ces \
             tesseract-langpack-ell \
             ptyxis && \


### PR DESCRIPTION
This PR adds the most commonly used Traditional Chinese input method module (fcitx5-chewing), and the tesseract language packs for Traditional Chinese to the KDE Plasma image. This should improve the ootb experience of KDE images for Traditional Chinese users. 
Also, the M17N input method module for fcitx5 is added to bring feature parity with GNOME based images, as M17N for ibus is shipped by default with fedora.
Finally, the English language pack of tesseract is included as well.