### PR TITLE
liveiso: block low memory installation

### DIFF
--- a/installer/system_files/shared/usr/bin/on_gui_login.sh
+++ b/installer/system_files/shared/usr/bin/on_gui_login.sh
@@ -6,6 +6,34 @@ if [[ ! -d /sys/firmware/efi ]]; then
         --text="Bazzite does not support CSM/Legacy Boot. Please boot into your UEFI/BIOS settings, disable CSM/Legacy Mode, and reboot." || true
     systemctl poweroff || shutdown -h now || true
 fi
+block_low_memory_install(){
+memory=$(sudo cat /proc/meminfo | grep 'MemTotal' | cut -d ":" -f 2 | cut -d "k" -f 1 | sed 's/ //g')
+gb_memory=$(
+  awk '/^MemTotal/{print $2*1024}' < /proc/meminfo |
+    numfmt --to=iec --format=%0f --suffix=B
+)
+echo "$memory"
+echo "$gb_memory"
+if [[ $memory -eq 0 ]]; then
+ echo "could not determine memory. Exiting."
+ return 1
+elif [[ $memory -lt  5000000 ]]; then
+ echo "detected memory less than approx. 5GB, warning user"
+else
+ return 0
+fi
+serve_docs
+   text="You need <b>at least 8GB of system memory</b>  to install Bazzite. \n\n Installation with 4GB or less memory will likely fail.\n\nDetected amount of memory: $gb_memory\n\n Please read <a href=\"http://127.0.0.1:1290/Gaming/Hardware_compatibility_for_gaming/#minimum-system-requirements\">here</a> about minimum system requirements for Bazzite."
+    title="Not enough memory"
+    while true; do
+    yad --undecorated --on-top --timeout=0 --button=Shutdown:0  --warning --buttons-layout=center --text-align=center --title="$title" --text="$text"
+     case $? in
+            0)  systemctl poweroff || shutdown -h now || true
+            break
+            ;;
+    esac
+done
+}
 serve_docs() {
     ADDRESS=127.0.0.1
     PORT=1290
@@ -164,7 +192,7 @@ nvidia_hardware_helper() {
         done
     fi
 }
-
+block_low_memory_install
 efi="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
 declare -A mount
 while read -r device path; do


### PR DESCRIPTION
The minimum required system memory for Bazzite is 8GB and in the past, we've frequently seen people try to install it on 4GB, only for the installer to fail every time.

This PR adds a new condition to on_gui_login.sh, that detects low memory configurations (approx. less than 4~5GB) and opens a windows informing the user of the problem. The window cannot be closed and the only option is to shutdown. 

This should hopefully result in less friction for users attempting to install with so little memory, only for the install to fail.
<img width="418" height="206" alt="Screenshot_20260424_151716" src="https://github.com/user-attachments/assets/713e22c3-68f9-4cd3-89a9-f50ae31ab7e6" />


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
