### PR TITLE
chore(gnome): enable i18n support for few extensions

### DIFF
--- a/build_files/build-gnome-extensions
+++ b/build_files/build-gnome-extensions
@@ -42,6 +42,24 @@ mv /usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io/sr
 mkdir -p /usr/share/gnome-shell/extensions/reboottouefi@ubaygd.com
 mv /usr/share/gnome-shell/extensions/tmp/reboottouefi@ubaygd.com/src/* /usr/share/gnome-shell/extensions/reboottouefi@ubaygd.com/
 
+# I18n support for few extensions
+mv /usr/share/gnome-shell/extensions/caffeine@patapon.info/locale /usr/share/gnome-shell/extensions/caffeine@patapon.info/po
+mv /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/locale /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/po
+for ext in \
+    logomenu@aryan_k \
+    reboottouefi@ubaygd.com \
+    appindicatorsupport@rgcjonas.gmail.com \
+    caffeine@patapon.info;
+do
+    echo "Enabling i18n support for $ext GNOME extension";
+    find "/usr/share/gnome-shell/extensions/${ext}/po" -name '*.po' -type f -printf "%P\n" | cut -f1 -d . | while read -r locale; do
+        mkdir -p /usr/share/locale/${locale}/LC_MESSAGES;
+        msgfmt /usr/share/gnome-shell/extensions/${ext}/po/${locale}.po -o /usr/share/locale/${locale}/LC_MESSAGES/${ext}.mo;
+    done;
+    unset -v locale;
+done
+unset -v ext
+
 # Cleanup
 dnf5 -y remove glib2-devel
 rm -rf /usr/share/gnome-shell/extensions/tmp


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
There's still some few extensions which are missing other locales other than English, hopefully this code will bring localization for other users who don't speak English at all :slightly_smiling_face: 

Those were added directly without doing a proper build