### PR TITLE
fix(flatpak): Remove filelight from flatpaks list

### DIFF
--- a/installer/kde_flatpaks/flatpaks
+++ b/installer/kde_flatpaks/flatpaks
@@ -3,7 +3,6 @@ app/org.kde.gwenview/x86_64/stable
 app/org.kde.okular/x86_64/stable
 app/org.kde.kcalc/x86_64/stable
 app/org.kde.haruna/x86_64/stable
-app/org.kde.filelight/x86_64/stable
 app/io.github.DenysMb.Kontainer/x86_64/stable
 app/com.github.tchx84.Flatseal/x86_64/stable
 app/com.github.Matoking.protontricks/x86_64/stable


### PR DESCRIPTION
Its already included as system package.
Fixes #4496