### PR TITLE
chore: sync bluez spec with upstream Fedora for 5.86

### DIFF
--- a/spec_files/bluez/bluez.spec
+++ b/spec_files/bluez/bluez.spec
@@ -26,7 +26,7 @@ Patch16: 0021-valve-bluetooth-ll-privacy.patch
 
 BuildRequires: dbus-devel >= 1.6
 BuildRequires: glib2-devel
-BuildRequires: libell-devel >= 0.37
+BuildRequires: libell-devel >= 0.39
 BuildRequires: libical-devel
 BuildRequires: make
 BuildRequires: readline-devel
@@ -180,6 +180,9 @@ install -m0755 tools/avinfo $RPM_BUILD_ROOT%{_bindir}
 # some issues and to set the MAC address on HCIs which don't have their
 # MAC address configured 
 install -m0755 tools/btmgmt $RPM_BUILD_ROOT%{_bindir}
+
+# btmgmt man page needs manual install in 5.86+
+install -m0644 doc/btmgmt.1 $RPM_BUILD_ROOT%{_mandir}/man1/
 
 # Remove libtool archive
 find $RPM_BUILD_ROOT -name '*.la' -delete


### PR DESCRIPTION
Sync bluez spec with upstream Fedora 5.86-4 changes:

- Install btmgmt.1 man page manually (moved to doc/ in 5.86)
- Bump libell-devel minimum to 0.39 to match upstream

Fixes the COPR build failure:
```
File not found: /builddir/build/BUILD/bluez-5.86-build/BUILDROOT/usr/share/man/man1/btmgmt.1.*
```