### PR TITLE
fix(gnome): set home env for reboottouefi and gen locales to different dir

### DIFF
--- a/build_files/build-gnome-extensions
+++ b/build_files/build-gnome-extensions
@@ -9,14 +9,11 @@ trap 'echo "::endgroup::"' EXIT
 dnf5 -y --setopt=install_weak_deps=False install glib2-devel nodejs-npm
 
 # Build Extensions
-glib-compile-schemas /usr/share/gnome-shell/extensions/logomenu@aryan_k/schemas
 glib-compile-schemas /usr/share/gnome-shell/extensions/compiz-windows-effect@hermes83.github.com/schemas
 glib-compile-schemas /usr/share/gnome-shell/extensions/compiz-alike-magic-lamp-effect@hermes83.github.com/schemas
 glib-compile-schemas /usr/share/gnome-shell/extensions/hotedge@jonathan.jdoda.ca/schemas
-glib-compile-schemas /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/schemas
 glib-compile-schemas /usr/share/gnome-shell/extensions/add-to-steam@pupper.space/schemas
 mv /usr/share/gnome-shell/extensions/tmp/caffeine/caffeine@patapon.info /usr/share/gnome-shell/extensions/caffeine@patapon.info
-glib-compile-schemas /usr/share/gnome-shell/extensions/caffeine@patapon.info/schemas
 
 # Burn My Windows
 make -C /usr/share/gnome-shell/extensions/burn-my-windows@schneegans.github.com
@@ -39,11 +36,11 @@ mkdir -p /usr/share/gnome-shell/extensions/bazaar-integration@kolunmi.github.io
 mv /usr/share/gnome-shell/extensions/tmp/bazaar-integration@kolunmi.github.io/src/* /usr/share/gnome-shell/extensions/bazaar-integration@kolunmi.github.io/
 
 # Reboot to UEFI
-make -C /usr/share/gnome-shell/extensions/tmp/reboottouefi@ubaygd.com pack
+env HOME=/tmp make -C /usr/share/gnome-shell/extensions/tmp/reboottouefi@ubaygd.com pack
 mkdir -p /usr/share/gnome-shell/extensions/reboottouefi@ubaygd.com
 unzip -o /usr/share/gnome-shell/extensions/tmp/reboottouefi@ubaygd.com/reboottouefi@ubaygd.com-*.zip -d /usr/share/gnome-shell/extensions/reboottouefi@ubaygd.com
 
-# I18n support for few extensions
+# Generate locales for few extensions
 mv /usr/share/gnome-shell/extensions/caffeine@patapon.info/locale /usr/share/gnome-shell/extensions/caffeine@patapon.info/po
 mv /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/locale /usr/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/po
 for ext in \
@@ -51,16 +48,16 @@ for ext in \
     appindicatorsupport@rgcjonas.gmail.com \
     caffeine@patapon.info;
 do
-    echo "Enabling i18n support for $ext GNOME extension";
+    echo "Generating locales for $ext GNOME extension";
     find "/usr/share/gnome-shell/extensions/${ext}/po" -name '*.po' -type f -printf "%P\n" | cut -f1 -d . | while read -r locale; do
-        mkdir -p /usr/share/locale/${locale}/LC_MESSAGES;
-        msgfmt /usr/share/gnome-shell/extensions/${ext}/po/${locale}.po -o /usr/share/locale/${locale}/LC_MESSAGES/${ext}.mo;
+        mkdir -p /usr/share/gnome-shell/extensions/${ext}/locale/${locale}/LC_MESSAGES;
+        msgfmt /usr/share/gnome-shell/extensions/${ext}/po/${locale}.po -o /usr/share/gnome-shell/extensions/${ext}/locale/${locale}/LC_MESSAGES/${ext}.mo;
     done;
     unset -v locale;
+    glib-compile-schemas /usr/share/gnome-shell/extensions/$ext/schemas;
 done
 unset -v ext
 
 # Cleanup
 dnf5 -y remove glib2-devel nodejs-npm
 rm -rf /usr/share/gnome-shell/extensions/tmp
-rm -rf /root/.npm

--- a/build_files/build-gnome-extensions
+++ b/build_files/build-gnome-extensions
@@ -54,7 +54,7 @@ do
         msgfmt /usr/share/gnome-shell/extensions/${ext}/po/${locale}.po -o /usr/share/gnome-shell/extensions/${ext}/locale/${locale}/LC_MESSAGES/${ext}.mo;
     done;
     unset -v locale;
-    glib-compile-schemas /usr/share/gnome-shell/extensions/$ext/schemas;
+    glib-compile-schemas /usr/share/gnome-shell/extensions/${ext}/schemas;
 done
 unset -v ext
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
npm apparently fails once it finds out that /root is a symlink and not an actual dir, and honestly I'm Not Sure in which way building extension properly differs from generating locales this way. In my testings none of those 3 extensions picked up different locales no matter what I did with them :slightly_frowning_face:

And I'm not sure if generating schemas this late would make any difference. If even this wouldn't help then it's safe to just remove this entire loop since it doesn't do anything