### PR TITLE
fix: install Fedora-version-specific cicpoffs RPM

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -248,7 +248,7 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=tmpfs,dst=/tmp \ 
     --mount=type=secret,id=GITHUB_TOKEN \
     dnf5 -y install \
-        $(/ctx/ghcurl https://api.github.com/repos/ublue-os/cicpoffs/releases/latest | jq -r '.assets[] | select(.name| test(".*rpm$")).browser_download_url') && \
+        $(/ctx/ghcurl https://api.github.com/repos/ublue-os/cicpoffs/releases/latest | jq -r --arg name "cicpoffs-fc${FEDORA_VERSION}.rpm" '.assets[] | select(.name == $name).browser_download_url') && \
     dnf5 -y copr enable bieszczaders/kernel-cachyos-addons && \
     dnf5 -y install \
         scx-scheds \


### PR DESCRIPTION
cicpoffs now publishes per-Fedora-version RPMs (fc43, fc44) due to the libfuse ABI change. Select the correct one using FEDORA_VERSION.