### PR TITLE
chore(gnome): Fractional scaling and XWayland native scaling are now default

### DIFF
--- a/spec_files/mutter/org.gnome.mutter.fedora.gschema.override
+++ b/spec_files/mutter/org.gnome.mutter.fedora.gschema.override
@@ -1,2 +1,2 @@
 [org.gnome.mutter:GNOME]
-experimental-features=['variable-refresh-rate', scale-monitor-framebuffer', 'xwayland-native-scaling', 'kms-modifiers']
+experimental-features=['kms-modifiers']

--- a/system_files/desktop/silverblue/usr/share/glib-2.0/schemas/zz0-00-bazzite-desktop-silverblue-global.gschema.override
+++ b/system_files/desktop/silverblue/usr/share/glib-2.0/schemas/zz0-00-bazzite-desktop-silverblue-global.gschema.override
@@ -17,7 +17,6 @@ sort-directories-first=true
 show-create-link=true
 
 [org.gnome.mutter]
-experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling']
 check-alive-timeout=uint32 20000
 
 [org.gnome.software]

--- a/system_files/nvidia/silverblue/usr/share/glib-2.0/schemas/zz0-20-bazzite-nvidia-silverblue-global.gschema.override
+++ b/system_files/nvidia/silverblue/usr/share/glib-2.0/schemas/zz0-20-bazzite-nvidia-silverblue-global.gschema.override
@@ -3,4 +3,4 @@ enabled-extensions=['logomenu@aryan_k', 'appindicatorsupport@rgcjonas.gmail.com'
 disabled-extensions=['background-logo@fedorahosted.org']
 
 [org.gnome.mutter]
-experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling', 'kms-modifiers']
+experimental-features=['kms-modifiers']


### PR DESCRIPTION
- [MR !4877 — "Make framebuffer and Xwayland native scaling non-experimental"](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4877) by 
jadahl, merged Feb 3, 2026 (commit 74965cd)
