### PR TITLE
feat(ci): misc fixes for dnf cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,13 +261,11 @@ jobs:
           IMAGE: ${{ matrix.image }}
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
+          FEDORA_VERSION: ${{ matrix.fedora_version }}
         run: |
           set -eoux pipefail
-          if [[ "${IMAGE}" =~ gnome ]]; then
-            CACHE_NAME="gnome"
-          else
-            CACHE_NAME="kde"
-          fi
+
+          CACHE_NAME="bazzite-${FEDORA_VERSION}"
 
           ALLOW_CACHE_WRITE="false"
 
@@ -275,6 +273,7 @@ jobs:
           # TODO: remove testing here when we have cache on main branch
           # PR caches are useless and may wipe cache on main
           if [[ "${IMAGE}" =~ "-deck" ]] && \
+             [[ ! "${IMAGE}" =~ "gnome" ]] && \
              [[ "${EVENT_NAME}" != "pull_request" ]] && \
              [[ "${REF_NAME}" == "main" || "${REF_NAME}" == "testing" ]]; then
             ALLOW_CACHE_WRITE="true"
@@ -290,7 +289,10 @@ jobs:
           ALLOW_CACHE_WRITE: ${{ steps.cache-prep.outputs.allow_cache_write }}
         with:
           path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-buildah-${{ env.CACHE_NAME }}
+          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-
+            ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
 
       # Build image using buildah and save it to raw-img
       - name: Build Image
@@ -318,7 +320,7 @@ jobs:
           ALLOW_CACHE_WRITE: ${{ steps.cache-prep.outputs.allow_cache_write }}
         with:
           path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-buildah-${{ env.CACHE_NAME }}
+          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
 
       - name: Setup Syft
         id: setup-syft


### PR DESCRIPTION
Tries to mirror what I have implemented for aurora where cache would get stale after a certain time as it can't be updated.

https://github.com/ublue-os/aurora/pull/2031

Having a separate cache for gnome and kde isn't really worth it as most packages are the same, the only image that is now allowed to write cache is bazzite-deck.

This also fixes caching for F44 based builds (well as soon as deck starts to get built in testing and unstable) as the fedora version is now incorporated in the cache name.

I have not tested this here so this might not work.


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
