### PR TITLE
chore(gnome): explicitly set nodejs22

### DIFF
--- a/build_files/build-gnome-extensions
+++ b/build_files/build-gnome-extensions
@@ -6,7 +6,7 @@ echo "::group::Executing build-gnome-extensions"
 trap 'echo "::endgroup::"' EXIT
 
 # Install tooling
-dnf5 -y --setopt=install_weak_deps=False install glib2-devel nodejs-npm
+dnf5 -y --setopt=install_weak_deps=False install glib2-devel nodejs22-npm
 
 # Build Extensions
 glib-compile-schemas /usr/share/gnome-shell/extensions/compiz-windows-effect@hermes83.github.com/schemas
@@ -59,5 +59,5 @@ done
 unset -v ext
 
 # Cleanup
-dnf5 -y remove glib2-devel nodejs-npm
+dnf5 -y remove glib2-devel nodejs22-npm
 rm -rf /usr/share/gnome-shell/extensions/tmp


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
unstable now has a leftover of NodeJS because of package name change happened in F44. I removed locale gen support in #4728 but figured I shouldn't do two changes at once