### PR TITLE
fix: set bazzite default wallpaper in plasmalogin

### DIFF
--- a/system_files/desktop/kinoite/usr/lib/plasmalogin/defaults.conf
+++ b/system_files/desktop/kinoite/usr/lib/plasmalogin/defaults.conf
@@ -1,0 +1,6 @@
+[Greeter]
+WallpaperPlugin=org.kde.image
+
+[Greeter][Wallpaper][org.kde.image][General]
+Image=file:///usr/share/backgrounds/default.jxl
+PreviewImage=file:///usr/share/backgrounds/default.jxl


### PR DESCRIPTION
It sucks to hardcode this, but this is good enough as there are
currently no light/dark variants of the default bazzite wallpaper.

<img width="1941" height="1253" alt="image" src="https://github.com/user-attachments/assets/dced9e19-de0d-4935-9e7e-eb75ddc160e8" />
