### PR TITLE
fix: add toolbox back for konsole

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -195,7 +195,6 @@ RUN --mount=type=cache,dst=/var/cache \
         ublue-os-update-services \
         firefox \
         firefox-langpacks \
-        toolbox \
         htop && \
     /ctx/cleanup
 


### PR DESCRIPTION
While the [reason for the removal](https://github.com/ublue-os/bazzite/pull/3084) of this was that toolbox is inferior in every way compared to distrobox, konsole currently hard depends on toolbox being present to do any amount of container detection. This new konsole feature would be useless if we wouldn't install it.

upstream bug: https://bugs.kde.org/show_bug.cgi?id=519468