### PR TITLE
feat: use 127 layers for rechunking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,7 +429,7 @@ jobs:
           sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
               localhost/raw-img \
               rpm-ostree compose build-chunked-oci \
-              --bootc --max-layers 96 --format-version 2 \
+              --bootc --max-layers 127 --format-version 2 \
               --from localhost/raw-img --output containers-storage:localhost/chunked-img
           sudo podman untag raw-img
 


### PR DESCRIPTION
This will make updates a little bit smaller as the same content is now spread across more layers. We have been using this in Aurora.

We have to use 127 here as one additional layer is created for either the ostree export layer or the additional packages layer, I'm not too sure on the internals of build-chunked-oci. 128 is the absolute maximum we can allow to not break `docker pull`ing the image. This is very convenient for troubleshooting and we shouldn't break that on the most popular container engine in the world.

See: https://docs.docker.com/engine/storage/drivers/overlayfs-driver/#how-the-overlay2-driver-works


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
