### PR TITLE
ci: Enable building Titanoboa ISOs from unstable branch for new image verification

### DIFF
--- a/.github/workflows/build_iso_titanoboa.yml
+++ b/.github/workflows/build_iso_titanoboa.yml
@@ -78,8 +78,10 @@ jobs:
         run: |
           TAG="stable"
 
-          if [[ "${{ github.ref_name }}" != "main" ]]; then
+          if [[ "${{ github.ref_name }}" == "testing" ]]; then
               TAG="testing"
+          elif [[ "${{ github.ref_name }}" == "unstable" ]]; then
+              TAG="unstable"
           fi
 
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
@@ -192,7 +194,7 @@ jobs:
           done
 
       - name: Upload ISOs and Checksum to Job Artifacts
-        if: github.ref_name == 'testing'
+        if: github.ref_name == 'testing' || github.ref_name == 'unstable'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.image_name }}-${{ steps.generate-tag.outputs.tag }}-${{ matrix.major_version}}


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
