### PR TITLE
fix: changed the wording of french in steam-first-run

### DIFF
--- a/system_files/desktop/shared/usr/bin/bazzite-steam-firstrun
+++ b/system_files/desktop/shared/usr/bin/bazzite-steam-firstrun
@@ -26,7 +26,7 @@ case $lang in
     ;;
 #french
     "fr")
-    info_text=("Steam est en cours de téléchargement. S'il vous plaît, attendez. Cela peut prendre quelques minutes.")
+    info_text=("Steam est en cours de téléchargement. Veuillez patienter, cela peut prendre quelques minutes.")
     ;;
 #italian
     "it")


### PR DESCRIPTION
Hi ! 

The translation sounded too direct/aggressive in French; I changed it to a more cordial manner of saying it. :+1: 

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
