### PR TITLE
feat: add cockpit quadlet

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -482,6 +482,7 @@ RUN --mount=type=cache,dst=/var/cache \
     echo "import \"/usr/share/ublue-os/just/80-bazzite.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/81-bazzite-fixes.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/82-bazzite-apps.just\"" >> /usr/share/ublue-os/justfile && \
+    echo "import \"/usr/share/ublue-os/just/82-bazzite-cockpit.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/82-bazzite-beesd.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/82-bazzite-sunshine.just\"" >> /usr/share/ublue-os/justfile && \
     echo "import \"/usr/share/ublue-os/just/82-bazzite-waydroid.just\"" >> /usr/share/ublue-os/justfile && \

--- a/system_files/desktop/shared/usr/lib/containers/systemd/cockpit-container.container
+++ b/system_files/desktop/shared/usr/lib/containers/systemd/cockpit-container.container
@@ -1,0 +1,18 @@
+[Unit]
+Description=Cockpit Container
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+Image=quay.io/cockpit/ws:latest
+ContainerName=cockpit-ws
+Volume=/:/host
+PodmanArgs=--privileged --pid=host --cgroups=split
+Exec=/container/label-run
+Notify=yes
+Label=io.containers.autoupdate=registry
+Environment=NAME=cockpit-ws
+
+[Service]
+Restart=always
+KillMode=mixed

--- a/system_files/desktop/shared/usr/lib/systemd/system/cockpit.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cockpit.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cockpit Web Service
+Requires=cockpit-container.service
+After=cockpit-container.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cockpit.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cockpit.just
@@ -1,0 +1,30 @@
+# vim: set ft=make :
+
+# Manage Cockpit, a web-based graphical interface for servers. Options: status | enable | disable
+[group("apps")]
+cockpit ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    OPTION="{{ ACTION }}"
+
+    if [ "$OPTION" == "status" ]; then
+      systemctl is-enabled cockpit.service
+      exit $?
+    fi
+
+    if [ "$OPTION" == "" ]; then
+      echo "${bold}Cockpit${normal}"
+      OPTION=$(ugum choose "Enable" "Disable" "Exit without changes")
+    fi
+
+    case "$OPTION" in
+      Enable|enable)
+        sudo systemctl enable --now cockpit.service
+        ;;
+      Disable|disable)
+        sudo systemctl disable --now cockpit.service
+        ;;
+      *)
+        echo "No changes made."
+        ;;
+    esac


### PR DESCRIPTION
This adds a systemd quadlet for the Cockpit web service along with a "shim" service to allow enablement via ujust. If we put an install section, the Cockpit quadlet would be enabled by default.
