### PR TITLE
fix(cockpit): move quadlet to /usr/share and fix service hang

### DIFF
--- a/system_files/desktop/shared/usr/share/containers/systemd/cockpit-container.container
+++ b/system_files/desktop/shared/usr/share/containers/systemd/cockpit-container.container
@@ -9,7 +9,6 @@ ContainerName=cockpit-ws
 Volume=/:/host
 PodmanArgs=--privileged --pid=host --cgroups=split
 Exec=/container/label-run
-Notify=yes
 Label=io.containers.autoupdate=registry
 Environment=NAME=cockpit-ws
 


### PR DESCRIPTION
The previous PR did not work on my installed system when testing it out. This PR moves the Cockpit Quadlet to /usr/share to match standard search paths and removes Notify=yes to prevent a service hang in the activating state.