### PR TITLE
fix(build): remove libaacs and libbdplus (post-RPM Fusion cleanup)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -174,8 +174,6 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf5 -y install \
         libfreeaptx && \
     dnf5 -y install --enable-repo="*fedora-multimedia*" \
-        libaacs \
-        libbdplus \
         libbluray \
         libbluray-utils && \
     /ctx/cleanup


### PR DESCRIPTION
The build was failing because libaacs and libbdplus are no longer available in the repositories after dropping RPM Fusion. This PR removes them from the Containerfile to restore CI stability.

Log error:
```
No match for argument: libaacs
No match for argument: libbdplus
```