### PR TITLE
feat: add MakeMKV and symlink libmmbd for Blu-ray playback

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -175,7 +175,12 @@ RUN --mount=type=cache,dst=/var/cache \
         libfreeaptx && \
     dnf5 -y install --enable-repo="*fedora-multimedia*" \
         libbluray \
-        libbluray-utils && \
+        libbluray-utils \
+        makemkv && \
+    ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libaacs.so.0 && \
+    ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libaacs.so.0.7.2 && \
+    ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libbdplus.so.0 && \
+    ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libbdplus.so.0.2.0 && \
     /ctx/cleanup
 
 # Remove unneeded packages


### PR DESCRIPTION
"MakeMKV comes with a library called libmmbd. This library exposes an AACS- and BD+-compatible API but routes all decryption to MakeMKV engine in the background. If you replace the system's libaacs and libbdplus with libmmbd, then any program that uses the open-source libbluray library for Blu-ray playback (like VLC or mplayer) will magically start to play all encrypted discs."
https://forum.makemkv.com/forum/viewtopic.php?f=3&t=7009
