### PR TITLE
fix: add fuse-libs to the Containerfile to ensure it is explicitly included in all Bazzite images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -210,6 +210,7 @@ RUN --mount=type=cache,dst=/var/cache \
         scx-tools && \
     dnf5 -y copr disable bieszczaders/kernel-cachyos-addons && \
     dnf5 -y install \
+        fuse-libs \
         uld \
         bazaar \
         iwd \


### PR DESCRIPTION
Context: This is in the Kinoite-based image but not Silverblue. We're not sure why - maybe a transitive dependency.
```
$ rpm -qa | grep fuse
fuse-common-3.18.2-1.fc44.x86_64
fuse3-libs-3.18.2-1.fc44.x86_64
fuse3-3.18.2-1.fc44.x86_64
fuse-sshfs-3.7.5-3.fc44.x86_64
fuse-libs-2.9.9-25.fc44.x86_64
fuse-overlayfs-1.16-2.fc44.x86_64
kio-fuse-5.1.1-3.fc44.x86_64
fuse-2.9.9-25.fc44.x86_64
```