### PR TITLE
Revert "revertme: Disable -deck builds on :testing for now"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,10 @@ jobs:
         image:
           - bazzite
           - bazzite-gnome
+          - bazzite-deck
+          - bazzite-deck-gnome
+          - bazzite-deck-nvidia
+          - bazzite-deck-nvidia-gnome
           - bazzite-nvidia
           - bazzite-gnome-nvidia
           - bazzite-nvidia-open

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -13,6 +13,10 @@ REGISTRY = "ghcr.io/ublue-os/"
 IMAGES = [
     "bazzite",
     "bazzite-gnome",
+    "bazzite-deck",
+    "bazzite-deck-gnome",
+    "bazzite-deck-nvidia",
+    "bazzite-deck-nvidia-gnome",
     "bazzite-nvidia",
     "bazzite-gnome-nvidia",
     "bazzite-nvidia-open",
@@ -58,6 +62,11 @@ From previous `{target}` version `{prev}` there have been the following changes.
 | **Firmware** | {pkgrel:atheros-firmware} |
 | **Mesa** | {pkgrel:mesa-filesystem} |
 | **Gamescope** | {pkgrel:terra-gamescope} |
+| **Gamescope Session** | {pkgrel:gamescope-session} |
+| **InputPlumber** | {pkgrel:inputplumber} |
+| **OpenGamepadUI** | {pkgrel:opengamepadui} |
+| **PowerStation** | {pkgrel:powerstation} |
+| **SteamOS-Manager** | {pkgrel:steamos-manager-powerstation} |
 | **Bazaar** | {pkgrel:bazaar} |
 | **Gnome** | {pkgrel:gnome-control-center-filesystem} |
 | **KDE** | {pkgrel:plasma-desktop} |


### PR DESCRIPTION
This reverts commit bec8a0d556cd4ca69ba1bcc8a310d417719b3eda.

Fixes https://github.com/ublue-os/bazzite/issues/4770 & builds deck images again

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
