### PR TITLE
fix: Make sure cockpit is completely stopped/removed on disable

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cockpit.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cockpit.just
@@ -23,6 +23,8 @@ cockpit ACTION="":
         ;;
       Disable|disable)
         sudo systemctl disable --now cockpit.service
+        sudo systemctl stop cockpit-container.service
+        sudo podman rm -f cockpit-ws
         ;;
       *)
         echo "No changes made."


### PR DESCRIPTION
It was pointed out by a user that running disable did not rm the container. This improves that behavior. Enable/disable were both tested on a Bazzite 44 install on my desktop.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
