### PR TITLE
revertme: disable dx kickoff for the time being

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -579,15 +579,15 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/generate_release.yml
 
-  kickoff_bazzite_dx:
-    runs-on: ubuntu-24.04
-    needs: [generate_release]
-    if: github.repository == 'ublue-os/bazzite' && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-    steps:
-      - name: Kickoff Bazzite-DX
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
-        continue-on-error: true
-        with:
-          token: ${{ secrets.PAT }}
-          repository: ublue-os/bazzite-dx
-          event-type: build
+  # kickoff_bazzite_dx:
+  #   runs-on: ubuntu-24.04
+  #   needs: [generate_release]
+  #   if: github.repository == 'ublue-os/bazzite' && github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+  #   steps:
+  #     - name: Kickoff Bazzite-DX
+  #       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+  #       continue-on-error: true
+  #       with:
+  #         token: ${{ secrets.PAT }}
+  #         repository: ublue-os/bazzite-dx
+  #         event-type: build


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
There's no reason to do DX builds since -deck is still on F43