### PR TITLE
feat: hide makemkv desktop entry

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -177,6 +177,7 @@ RUN --mount=type=cache,dst=/var/cache \
         libbluray \
         libbluray-utils \
         makemkv && \
+    desktop-file-edit --set-key=Hidden --set-value=true /usr/share/applications/makemkv.desktop && \
     ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libaacs.so.0 && \
     ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libaacs.so.0.7.2 && \
     ln -sf /usr/lib64/libmmbd.so.0 /usr/lib64/libbdplus.so.0 && \


### PR DESCRIPTION
The intention with this was to abuse the shipped libmmbd in makemkv to make open source programs use the makemkv provided decryption engine in 3f4b939826 which should make it possible to play commercial/decrypted blu-rays with them.

I think it was not intended to actually expose the full application here. Hiding the desktop entry seems to be the most maintainable option in my opinion as it would still allow users to unhide the desktop entry, if they know it exists in the first place, without undoing significant amounts of work of the packaging of makemkv here in Bazzite just to ship those 3 symlinks.

Although I'm a little bit confused what specific usecase this commit mentioned above actually fixes as applications like VLC would be installed as a flatpak which will not use system provided libraries.

@dylanmtaylor thoughts?
