### PR TITLE
feat: add rocm-smi back to the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -248,6 +248,7 @@ RUN --mount=type=cache,dst=/var/cache \
         webapp-manager \
         btop \
         amdsmi \
+        rocm-smi \
         duf \
         fish \
         lshw \


### PR DESCRIPTION
The `rocm-smi` package was removed from the base images along with the whole ROCm suite in the Fedora 44 update. This broke reporting of GPU usage stats in `btop` for AMD GPUs. The `rocm-smi` package is tiny and doesn't depend on the rest of the ROCm suite. I did a local build with this change and found that adding the `rocm-smi` package back only added 2.9MB to the image size.