### PR TITLE
fix: plasma-setup branding

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -406,6 +406,8 @@ RUN --mount=type=cache,dst=/var/cache \
             kcharselect \
             kde-partitionmanager \
             plasma-discover && \
+        dnf5 -y swap --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+            plasma-setup plasma-setup-"$(rpm -q --qf "%{VERSION}" plasma-desktop)"-*.bazzite && \
         sed -i '$r /usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/bazzite-pins.js' /usr/share/plasma/layout-templates/org.kde.plasma.desktop.defaultPanel/contents/layout.js && \
         ln -sf /usr/share/wallpapers/convergence.jxl /usr/share/backgrounds/default.jxl && \
         ln -sf /usr/share/wallpapers/convergence.jxl /usr/share/backgrounds/default-dark.jxl && \

--- a/installer/system_files/shared/etc/anaconda/profile.d/bazzite.conf
+++ b/installer/system_files/shared/etc/anaconda/profile.d/bazzite.conf
@@ -26,6 +26,7 @@ default_partitioning =
 [User Interface]
 hidden_webui_pages =
     network
+    UserSpoke
 
 [Localization]
 use_geolocation = False


### PR DESCRIPTION
This gives plasma setup the bazzite wallpapers. Needs
https://github.com/ublue-os/packages/pull/1231

We need to install it via this stupid way to avoid a possible mismatch
between plasma packages, as basically nobody tests mixing them. This is
especially important on major releases. we are maintaining our own
version and need to keep it updated, a failing build will force us to do
that.

The reason why we have patches in the first place is because of
https://invent.kde.org/plasma/plasma-setup/-/work_items/72