### PR TITLE
fix: setup-virtualization overlay libvirt packages

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -50,6 +50,8 @@ setup-virtualization ACTION="":
     fi
     if [[ "${OPTION,,}" =~ (^enable[[:space:]]virtualization|virt-on) ]]; then
         if ! rpm -q virt-manager | grep -P "^virt-manager-" 1>/dev/null; then
+          echo "Installing libvirt..."
+          sudo rpm-ostree install libvirt qemu qemu-img qemu-kvm
           echo "Installing virt-manager..."
           flatpak install flathub org.virt_manager.virt-manager
           rpm-ostree kargs \
@@ -87,6 +89,8 @@ setup-virtualization ACTION="":
         echo "${red}Disabling${n} bazzite-libvirtd-setup"
         sudo systemctl disable --now bazzite-libvirtd-setup.service 2> /dev/null
       fi
+      echo "Removing libvirt..."
+      sudo rpm-ostree uninstall libvirt qemu qemu-img qemu-kvm
       echo "Removing virt-manager..."
       flatpak uninstall org.virt_manager.virt-manager
       rpm-ostree kargs \


### PR DESCRIPTION
That will add overlaying of libvirt packages in setup-virtualization ujust script, as they were removed from base image in 44 release.

I was also thinking, if it would be better to just show a deprecation notice for such use case and offer to rebase to DX variant. Let me know, if such variant would be better, I will change the PR.

Thanks!


<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
