### PR TITLE
feat(portal): bring portal to 1:1 parity with all the just scripts that exists in the shared desktop image

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -813,15 +813,35 @@ configure-snapshots ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     OPTION={{ ACTION }}
+    get_status_token() {
+      configs="$(sed -n 's/^SNAPPER_CONFIGS="\([^"]*\)".*/\1/p' /etc/sysconfig/snapper 2>/dev/null || true)"
+      if [[ " $configs " == *" root "* ]]; then
+        echo "enable"
+      else
+        echo "disable"
+      fi
+    }
+    get_current_status() {
+      if [[ "$(get_status_token)" == "enable" ]]; then
+        echo "${green}${bold}Enabled${normal}"
+      else
+        echo "${yellow}${bold}Disabled${normal}"
+      fi
+    }
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust configure-snapshots <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'status' to print the current status"
       echo "  Use 'enable' enable snapshotting of /var/home"
       echo "  Use 'disable' disable snapshotting of /var/home"
       echo "  Use 'wipe' disable snapshotting and remove all automatic snapshots of /var/home"
       exit 0
+    elif [ "$OPTION" == "status" ]; then
+      get_status_token
+      exit 0
     elif [ "$OPTION" == "" ]; then
       echo "${bold}Snapper setup and configuration${normal}"
+      echo "Current status: $(get_current_status)"
       OPTION=$(Choose "Enable Snapper" "Disable Snapper" "Wipe Snapper config and automatic snapshots")
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -834,7 +834,7 @@ configure-snapshots ACTION="":
 
 # Enable a Bluefin-style CLI experience
 [group("development")]
-bazzite-cli:
+bazzite-cli ACTION="":
     #!/usr/bin/bash
     #shellcheck disable=SC2154
 
@@ -842,6 +842,7 @@ bazzite-cli:
 
     # Source libujust for colors/ugum
     source /usr/lib/ujust/ujust.sh
+    OPTION="{{ ACTION }}"
 
     # Exit Handling
     function Exiting(){
@@ -965,21 +966,26 @@ bazzite-cli:
     # Get Shell
     shell=$(basename "$SHELL")
     reentry="$1"
-    clear
-    if [[ -n "${reentry:-}" ]]; then
-        printf "%s%s%s\n\n" "${bold}" "$reentry" "$normal"
-    fi
-
-    # Check if bling is enabled and display
-    printf "Shell:\t%s%s%s%s\n" "${green}" "${bold}" "${shell}" "${normal}"
-    if ! check-bling "${shell}"; then
-        printf "Bling:\t%s%sEnabled%s\n" "${green}" "${bold}" "${normal}"
-    else
-        printf "Bling:\t%s%sDisabled%s\n" "${red}" "${bold}" "${normal}"
-    fi
 
     # ugum enable/disable
-    CHOICE=$(Choose enable disable cancel)
+    if [[ -n "${OPTION}" ]]; then
+        CHOICE="${OPTION,,}"
+    else
+        clear
+        if [[ -n "${reentry:-}" ]]; then
+            printf "%s%s%s\n\n" "${bold}" "$reentry" "$normal"
+        fi
+
+        # Check if bling is enabled and display
+        printf "Shell:\t%s%s%s%s\n" "${green}" "${bold}" "${shell}" "${normal}"
+        if ! check-bling "${shell}"; then
+            printf "Bling:\t%s%sEnabled%s\n" "${green}" "${bold}" "${normal}"
+        else
+            printf "Bling:\t%s%sDisabled%s\n" "${red}" "${bold}" "${normal}"
+        fi
+
+        CHOICE=$(Choose enable disable cancel)
+    fi
 
     # Enable/Disable. Recurse if bad option.
     if [[ "${CHOICE}" == "enable" ]]; then
@@ -987,12 +993,18 @@ bazzite-cli:
             trap ctrl_c SIGINT
             add-bling "${shell}"
             printf "%s%sInstallation Complete%s ... please close and reopen your terminal!" "${green}" "${bold}" "${normal}"
+        elif [[ -n "${OPTION}" ]]; then
+            printf "%s%sBling is already configured ...%s\n" "${yellow}" "${bold}" "${normal}"
         else
             main "Bling is already configured ..."
         fi
     elif [[ "${CHOICE}" == "disable" ]]; then
         if check-bling "${shell}"; then
-            main "Bling is not yet configured ..."
+            if [[ -n "${OPTION}" ]]; then
+                printf "%s%sBling is not yet configured ...%s\n" "${yellow}" "${bold}" "${normal}"
+            else
+                main "Bling is not yet configured ..."
+            fi
         else
             remove-bling "${shell}"
             trap ctrl_c SIGINT
@@ -1004,7 +1016,22 @@ bazzite-cli:
     }
 
     # Entrypoint
-    main ""
+    case "${OPTION,,}" in
+      enable|disable|"")
+        main ""
+        ;;
+      help)
+        echo "Usage: ujust bazzite-cli <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'enable' to enable Bazzite CLI shell enhancements"
+        echo "  Use 'disable' to disable Bazzite CLI shell enhancements"
+        ;;
+      *)
+        echo "Invalid option: $OPTION"
+        echo "Usage: ujust bazzite-cli [enable|disable]"
+        exit 1
+        ;;
+    esac
 
 # Run a one minute system benchmark
 [group("utilities")]

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -768,28 +768,40 @@ enable-framework-fan-control:
 configure-watchdog ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    WATCHDOG_STATE="$(rpm-ostree kargs)"
-    CPU_MODEL=$(lscpu --json | jq -r '."lscpu"[7]."data"')
     OPTION={{ ACTION }}
-    if [[ "$WATCHDOG_STATE" =~ (nowatchdog|modprobe\.blacklist=(iTCO_wdt|sp5100_tco)) ]]; then
-        WATCHDOG_STATE="${red}${b}Disabled${n}"
-    else
-        WATCHDOG_STATE="${green}${b}Enabled${n}"
-    fi
+    get_status_token() {
+      if [[ "$(cat /proc/cmdline)" =~ (nowatchdog|modprobe\.blacklist=(iTCO_wdt|sp5100_tco)) ]]; then
+        echo "disable"
+      else
+        echo "enable"
+      fi
+    }
+    get_current_status() {
+      WATCHDOG_STATE="$(rpm-ostree kargs)"
+      if [[ "$WATCHDOG_STATE" =~ (nowatchdog|modprobe\.blacklist=(iTCO_wdt|sp5100_tco)) ]]; then
+        echo "${yellow}${bold}Disabled${normal}"
+      else
+        echo "${green}${bold}Enabled${normal}"
+      fi
+    }
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust configure-watchdog <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'enable' to select Enable Watchdog"
       echo "  Use 'disable' to select Disable Watchdog"
       exit 0
+    elif [ "$OPTION" == "status" ]; then
+      get_status_token
+      exit 0
     elif [ "$OPTION" == "" ]; then
       echo "${bold}Watchdog configuration${normal}"
       echo "Having the watchdog enabled will let it recover the system in the event of a malfunction, however"
       echo "disabling the watchdog can give a potential performance improvement due to fewer interrupts"
-      echo "Watchdog is $WATCHDOG_STATE"
+      echo "Watchdog is $(get_current_status)"
       OPTION=$(Choose "Enable Watchdog" "Disable Watchdog")
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then
+      CPU_MODEL=$(lscpu --json | jq -r '."lscpu"[7]."data"')
       WATCHDOG_KARGS="--delete-if-present=nowatchdog"
       if [[ "$CPU_MODEL" =~ "Intel" ]]; then
         WATCHDOG_KARGS="$WATCHDOG_KARGS --delete-if-present=modprobe.blacklist=iTCO_wdt"
@@ -798,6 +810,7 @@ configure-watchdog ACTION="":
       fi
       rpm-ostree kargs $WATCHDOG_KARGS
     elif [[ "${OPTION,,}" =~ ^disable ]]; then
+      CPU_MODEL=$(lscpu --json | jq -r '."lscpu"[7]."data"')
       WATCHDOG_KARGS="--append-if-missing=nowatchdog"
       if [[ "$CPU_MODEL" =~ "Intel" ]]; then
         WATCHDOG_KARGS="$WATCHDOG_KARGS --append-if-missing=modprobe.blacklist=iTCO_wdt"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -453,8 +453,16 @@ toggle-save-panics ACTION="":
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust toggle-save-panics <option>"
       echo "  <option>: Specify the option to skip the interactive prompt"
+      echo "  Use 'status' to print the current portal status"
       echo "  Use 'enable' to enable ramoops"
       echo "  Use 'disable' to disable ramoops"
+      exit 0
+    elif [ "$OPTION" == "status" ]; then
+      if [ "$STATUS" == "Enabled" ]; then
+        echo "enable"
+      else
+        echo "disable"
+      fi
       exit 0
     elif [ "$OPTION" == "" ]; then
       echo Ramoops is a kernel module that will save panic information across a reboot and allow it to be

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -47,18 +47,44 @@ fix-reset-steam:
 
 # Toggle Bluetooth headset profile mode. If enabled, mic will be disabled on the Bluetooth device preventing the switch to headset profile, which has poor audio quality. Disable to restore mic functionality.
 [group("audio")]
-toggle-bt-mic:
+toggle-bt-mic ACTION="":
     #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
     CONFIG_FILE="/etc/wireplumber/wireplumber.conf.d/51-mitigate-annoying-profile-switch.conf"
+    OPTION="{{ ACTION }}"
     # Check current status
     CURRENT_STATE="Disabled"
     if [ -f "$CONFIG_FILE" ]; then
       CURRENT_STATE="Enabled"
     fi
+
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-bt-mic <option>"
+      echo "  <option>: Specify the option to skip the interactive prompt"
+      echo "  Use 'status' to print the current portal status"
+      echo "  Use 'enable' to disable Bluetooth headset profile switching"
+      echo "  Use 'disable' to restore Bluetooth headset profile switching"
+      exit 0
+    elif [ "$OPTION" == "status" ]; then
+      if [ "$CURRENT_STATE" == "Enabled" ]; then
+        echo "enable"
+      else
+        echo "disable"
+      fi
+      exit 0
+    fi
+
     # Prompt user for action
-    echo "Bluetooth headset profile mitigation is currently: ${bold}${CURRENT_STATE}${normal}"
-    echo "Enable or Disable Bluetooth headset profile mitigation?"
-    OPTION=$(ugum choose Enable Disable)
+    if [ "$OPTION" == "" ]; then
+      echo "Enable or Disable Bluetooth headset profile mitigation?"
+      if [ "$CURRENT_STATE" == "Enabled" ]; then
+        echo -e "${bold}Bluetooth headset profile mitigation:${normal} ${green}${CURRENT_STATE}${normal}"
+      else
+        echo -e "${bold}Bluetooth headset profile mitigation:${normal} ${red}${CURRENT_STATE}${normal}"
+      fi
+      OPTION=$(ugum choose Enable Disable)
+    fi
+
     if [[ "${OPTION,,}" == "enable" ]]; then
       echo "You chose to enable mitigation. This will disable headset mic functionality."
       echo "Requesting root privileges..."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -286,22 +286,79 @@ iwd ACTION="":
 
 # enable or disable a fix for 7th and 8th generation Intel chips not being able to sleep
 [group("hardware")]
-toggle-i915-sleep-fix:
+toggle-i915-sleep-fix ACTION="":
     #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    OPTION="{{ ACTION }}"
+
     # Explain the purpose of the script
-    echo -e "This script manages the i915.enable_dc kernel parameter, which controls a power-saving feature for Intel graphics"
-    echo -e "Enabling this setting can reduce power consumption, but may cause issues like random reboots or failed suspend on certain devices"
-    echo -e "Disabling it ensures stability at the cost of slightly higher power usage"
+    if [ "$OPTION" != "status" ]; then
+      echo -e "This script manages the i915.enable_dc kernel parameter, which controls a power-saving feature for Intel graphics"
+      echo -e "Enabling this setting can reduce power consumption, but may cause issues like random reboots or failed suspend on certain devices"
+      echo -e "Disabling it ensures stability at the cost of slightly higher power usage"
+    fi
+
     # Get the current i915.enable_dc setting
     get_current_status() {
       local karg_status
-      karg_status=$(cat /proc/cmdline | grep -o 'i915.enable_dc=[-0-9]' | cut -d= -f2)
+      local kargs
+      kargs=$(rpm-ostree kargs 2>/dev/null)
+      if [[ -z "$kargs" ]]; then
+        kargs=$(cat /proc/cmdline)
+      fi
+      karg_status=$(grep -o 'i915.enable_dc=[-0-9]' <<< "$kargs" | tail -n1 | cut -d= -f2)
       if [[ -z "$karg_status" ]]; then
         echo "Not Set"
       else
         echo "$karg_status"
       fi
     }
+
+    get_status_token() {
+      local current_status
+      current_status=$(get_current_status)
+      case "$current_status" in
+        -1)
+          echo "auto"
+          ;;
+        0)
+          echo "disable"
+          ;;
+        1)
+          echo "level-1"
+          ;;
+        2)
+          echo "level-2"
+          ;;
+        3)
+          echo "level-3"
+          ;;
+        4)
+          echo "level-4"
+          ;;
+        *)
+          echo "unset"
+          ;;
+      esac
+    }
+
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-i915-sleep-fix <option>"
+      echo "  <option>: Specify the option to skip the interactive prompt"
+      echo "  Use 'status' to print the current portal status"
+      echo "  Use 'auto' to set i915.enable_dc=-1"
+      echo "  Use 'disable' to set i915.enable_dc=0"
+      echo "  Use 'level-1' to set i915.enable_dc=1"
+      echo "  Use 'level-2' to set i915.enable_dc=2"
+      echo "  Use 'level-3' to set i915.enable_dc=3"
+      echo "  Use 'level-4' to set i915.enable_dc=4"
+      echo "  Use 'unset' to remove i915.enable_dc"
+      exit 0
+    elif [ "$OPTION" == "status" ]; then
+      get_status_token
+      exit 0
+    fi
+
     # Toggle i915.enable_dc kernel parameter
     update_karg() {
       local new_value=$1
@@ -320,42 +377,63 @@ toggle-i915-sleep-fix:
         echo -e "\nInvalid value for i915.enable_dc. Please choose a valid value.\n"
         return
       fi
-      rpm-ostree kargs --replace "i915.enable_dc=$new_value"
+      rpm-ostree kargs \
+        --delete-if-present="i915.enable_dc=-1" \
+        --delete-if-present="i915.enable_dc=0" \
+        --delete-if-present="i915.enable_dc=1" \
+        --delete-if-present="i915.enable_dc=2" \
+        --delete-if-present="i915.enable_dc=3" \
+        --delete-if-present="i915.enable_dc=4" \
+        --append-if-missing="i915.enable_dc=$new_value"
       echo -e "Kernel parameter updated. Reboot required to apply changes."
     }
-    # Display current status
-    current_status=$(get_current_status)
-    echo -e "\nCurrent i915.enable_dc setting: $current_status\n"
     # Prompt user for action
-    CHOICE=$(ugum choose "Set to Auto (i915.enable_dc=-1)" "Disable Power Saving (i915.enable_dc=0)" "Set to Level 1 (i915.enable_dc=1)" "Set to Level 2 (i915.enable_dc=2)" "Set to Level 3 (i915.enable_dc=3)" "Set to Level 4 (i915.enable_dc=4)" "Unset Parameter" "Exit without changes")
+    if [ "$OPTION" == "" ]; then
+      current_status=$(get_current_status)
+      if [ "$current_status" == "Not Set" ]; then
+        echo -e "${bold}Current i915.enable_dc setting:${normal} ${red}$current_status${normal}"
+      else
+        echo -e "${bold}Current i915.enable_dc setting:${normal} ${green}$current_status${normal}"
+      fi
+      CHOICE=$(ugum choose "Set to Auto (i915.enable_dc=-1)" "Disable Power Saving (i915.enable_dc=0)" "Set to Level 1 (i915.enable_dc=1)" "Set to Level 2 (i915.enable_dc=2)" "Set to Level 3 (i915.enable_dc=3)" "Set to Level 4 (i915.enable_dc=4)" "Unset Parameter" "Exit without changes")
+    else
+      CHOICE="$OPTION"
+    fi
+
     case "$CHOICE" in
-      "Set to Auto (i915.enable_dc=-1)")
+      "Set to Auto (i915.enable_dc=-1)"|auto|-1)
         echo "Setting power-saving mode to auto (i915.enable_dc=-1)..."
         update_karg -1
         ;;
-      "Disable Power Saving (i915.enable_dc=0)")
+      "Disable Power Saving (i915.enable_dc=0)"|disable|0)
         echo "Disabling power-saving mode (i915.enable_dc=0)..."
         update_karg 0
         ;;
-      "Set to Level 1 (i915.enable_dc=1)")
+      "Set to Level 1 (i915.enable_dc=1)"|level-1|1)
         echo "Setting power-saving mode to level 1 (i915.enable_dc=1)..."
         update_karg 1
         ;;
-      "Set to Level 2 (i915.enable_dc=2)")
+      "Set to Level 2 (i915.enable_dc=2)"|level-2|2)
         echo "Setting power-saving mode to level 2 (i915.enable_dc=2)..."
         update_karg 2
         ;;
-      "Set to Level 3 (i915.enable_dc=3)")
+      "Set to Level 3 (i915.enable_dc=3)"|level-3|3)
         echo "Setting power-saving mode to level 3 (i915.enable_dc=3)..."
         update_karg 3
         ;;
-      "Set to Level 4 (i915.enable_dc=4)")
+      "Set to Level 4 (i915.enable_dc=4)"|level-4|4)
         echo "Setting power-saving mode to level 4 (i915.enable_dc=4)..."
         update_karg 4
         ;;
-      "Unset Parameter")
+      "Unset Parameter"|unset)
         echo "Unsetting i915.enable_dc..."
-        rpm-ostree kargs --delete "i915.enable_dc=[-0-9]"
+        rpm-ostree kargs \
+          --delete-if-present="i915.enable_dc=-1" \
+          --delete-if-present="i915.enable_dc=0" \
+          --delete-if-present="i915.enable_dc=1" \
+          --delete-if-present="i915.enable_dc=2" \
+          --delete-if-present="i915.enable_dc=3" \
+          --delete-if-present="i915.enable_dc=4"
         echo -e "Kernel parameter unset. Reboot required to apply changes."
         ;;
       "Exit without changes")

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -139,46 +139,110 @@ install-coolercontrol ACTION="":
         exit 0
     fi
 
-# Install Displaylink, Needed for some laptop docks to output video
+# Manage DisplayLink, needed for some laptop docks to output video. Options: status | install | uninstall
 [group("apps")]
-install-displaylink:
+install-displaylink ACTION="":
     #!/usr/bin/env bash
     set -eo pipefail
+    source /usr/lib/ujust/ujust.sh
 
-    cat <<'EOF'
-    {{ YELLOW }}This recipe will proceed to {{ BOLD }}layer{{ NORMAL }} {{ YELLOW }}Displaylink{{ NORMAL }}.
-    {{ YELLOW }}If updates start to fail, please use "{{ BOLD }}rpm-ostree reset{{ NORMAL }}"
-    {{ YELLOW }}See https://docs.bazzite.gg/Installing_and_Managing_Software/rpm-ostree/#major-caveats-using-rpm-ostree{{ NORMAL }}
-    EOF
-
-    layered() {
+    layered_package() {
         local pkg="$1"
         rpm-ostree status --json | jq -e ".deployments[] | select(.booted == true) | .packages | index(\"$pkg\")" > /dev/null
     }
-    packages=()
-    for pkg in displaylink; do
-        if layered "$pkg"; then
-            echo "$pkg is already layered, skipping."
+
+    get_status_token() {
+        if layered_package displaylink; then
+            echo "install"
         else
-            packages+=("$pkg")
+            echo "uninstall"
         fi
-    done
+    }
 
-    if [ ${#packages[@]} -gt 0 ]; then
-        repo_path="/etc/yum.repos.d/negativo17-fedora-multimedia.repo"
-
-        if ( ! grep -q "enabled=0" "$repo_path" ); then  # if not matches found
-            echo 'Negativo17 Multimedia Repository is already enabled, skipping.'
+    get_current_status() {
+        if [[ "$(get_status_token)" == "install" ]]; then
+            echo "Installed"
         else
-            echo 'Enabling Negativo17 Multimedia Repository.'
-            sudo sed -i 's@enabled=0@enabled=1@g' "$repo_path"
+            echo "Not Installed"
         fi
+    }
 
-        echo "Installing: ${packages[*]}"
-        rpm-ostree install -y "${packages[@]}"
-        echo 'Complete, please reboot to apply changes.'
-    else
-        echo "No changes were made."
+    install_displaylink() {
+        echo '{{ YELLOW }}This recipe will proceed to {{ BOLD }}layer{{ NORMAL }} {{ YELLOW }}DisplayLink{{ NORMAL }}.'
+        echo '{{ YELLOW }}If updates start to fail, please use "{{ BOLD }}rpm-ostree reset{{ NORMAL }}"'
+        echo '{{ YELLOW }}See https://docs.bazzite.gg/Installing_and_Managing_Software/rpm-ostree/#major-caveats-using-rpm-ostree{{ NORMAL }}'
+
+        packages=()
+        for pkg in displaylink; do
+            if layered_package "$pkg"; then
+                echo "$pkg is already layered, skipping."
+            else
+                packages+=("$pkg")
+            fi
+        done
+
+        if [ ${#packages[@]} -gt 0 ]; then
+            repo_path="/etc/yum.repos.d/negativo17-fedora-multimedia.repo"
+
+            if ( ! grep -q "enabled=0" "$repo_path" ); then  # if not matches found
+                echo 'Negativo17 Multimedia Repository is already enabled, skipping.'
+            else
+                echo 'Enabling Negativo17 Multimedia Repository.'
+                sudo sed -i 's@enabled=0@enabled=1@g' "$repo_path"
+            fi
+
+            echo "Installing: ${packages[*]}"
+            rpm-ostree install -y "${packages[@]}"
+            echo 'Complete, please reboot to apply changes.'
+        else
+            echo "No changes were made."
+        fi
+    }
+
+    uninstall_displaylink() {
+        if layered_package displaylink; then
+            echo "Uninstalling: displaylink"
+            rpm-ostree uninstall -y displaylink
+            echo 'Complete, please reboot to apply changes.'
+        else
+            echo "DisplayLink is not layered."
+        fi
+    }
+
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+        echo "Usage: ujust install-displaylink <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'status' to print the current portal token"
+        echo "  Use 'install' to install DisplayLink"
+        echo "  Use 'uninstall' to uninstall DisplayLink"
+        exit 0
+    elif [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit 0
+    elif [[ "$OPTION" == "install" ]]; then
+        install_displaylink
+        exit 0
+    elif [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_displaylink
+        exit 0
+    elif [[ -z "$OPTION" ]]; then
+        current_status=$(get_current_status)
+        echo "${bold}DisplayLink${normal}"
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Install" "Uninstall" "Exit without changes")
+        case "$OPTION" in
+            "Install")
+                install_displaylink
+                ;;
+            "Uninstall")
+                uninstall_displaylink
+                ;;
+            *)
+                echo "No changes made."
+                ;;
+        esac
+        exit 0
     fi
 
 # Install JetBrains Toolbox | https://www.jetbrains.com/toolbox-app/

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -24,46 +24,119 @@ _install_appimage_file $APPIMAGE_SRC $filename="":
     sleep 3
     LC_ALL=C flatpak run it.mijorus.gearlever "$appimage_file" <&-
 
-# Install CoolerControl, a GUI for viewing all your system's sensors and for creating custom fan and pump profiles based on any available temperature sensor28
+# Manage CoolerControl, a GUI for viewing sensors and creating fan and pump profiles. Options: status | install | uninstall
 [group("apps")]
-install-coolercontrol:
+install-coolercontrol ACTION="":
     #!/usr/bin/env bash
     set -eo pipefail
+    source /usr/lib/ujust/ujust.sh
 
-    cat <<'EOF'
-    {{ YELLOW }}This recipe will proceed to {{ BOLD }}layer{{ NORMAL }} {{ YELLOW }}CoolerControl{{ NORMAL }}.
-    {{ YELLOW }}If updates start to fail, please use "{{ BOLD }}rpm-ostree reset{{ NORMAL }}"
-    {{ YELLOW }}See https://docs.bazzite.gg/Installing_and_Managing_Software/rpm-ostree/#major-caveats-using-rpm-ostree{{ NORMAL }}
-    EOF
-
-    layered() {
+    layered_package() {
         local pkg="$1"
         rpm-ostree status --json | jq -e ".deployments[] | select(.booted == true) | .packages | index(\"$pkg\")" > /dev/null
     }
-    packages=()
-    for pkg in liquidctl coolercontrol; do
-        if layered "$pkg"; then
-            echo "$pkg is already layered, skipping."
+
+    get_status_token() {
+        if layered_package liquidctl && layered_package coolercontrol; then
+            echo "install"
         else
-            packages+=("$pkg")
+            echo "uninstall"
         fi
-    done
+    }
 
-    if [ ${#packages[@]} -gt 0 ]; then
-        repo_path="/etc/yum.repos.d/terra.repo"
-
-        if ( ! grep -q "enabled=0" "$repo_path" ); then  # if not matches found
-            echo 'Terra Repository is already enabled, skipping.'
+    get_current_status() {
+        if layered_package liquidctl && layered_package coolercontrol; then
+            echo "Installed"
+        elif layered_package liquidctl || layered_package coolercontrol; then
+            echo "Partially Installed"
         else
-            echo 'Enabling Terra Repository.'
-            sudo sed -i 's@enabled=0@enabled=1@g' "$repo_path"
+            echo "Not Installed"
         fi
+    }
 
-        echo "Installing: ${packages[*]}"
-        rpm-ostree install -y "${packages[@]}"
-        echo 'Complete, please reboot to apply changes.'
-    else
-        echo "No changes were made."
+    install_coolercontrol() {
+        echo '{{ YELLOW }}This recipe will proceed to {{ BOLD }}layer{{ NORMAL }} {{ YELLOW }}CoolerControl{{ NORMAL }}.'
+        echo '{{ YELLOW }}If updates start to fail, please use "{{ BOLD }}rpm-ostree reset{{ NORMAL }}"'
+        echo '{{ YELLOW }}See https://docs.bazzite.gg/Installing_and_Managing_Software/rpm-ostree/#major-caveats-using-rpm-ostree{{ NORMAL }}'
+
+        packages=()
+        for pkg in liquidctl coolercontrol; do
+            if layered_package "$pkg"; then
+                echo "$pkg is already layered, skipping."
+            else
+                packages+=("$pkg")
+            fi
+        done
+
+        if [ ${#packages[@]} -gt 0 ]; then
+            repo_path="/etc/yum.repos.d/terra.repo"
+
+            if ( ! grep -q "enabled=0" "$repo_path" ); then  # if not matches found
+                echo 'Terra Repository is already enabled, skipping.'
+            else
+                echo 'Enabling Terra Repository.'
+                sudo sed -i 's@enabled=0@enabled=1@g' "$repo_path"
+            fi
+
+            echo "Installing: ${packages[*]}"
+            rpm-ostree install -y "${packages[@]}"
+            echo 'Complete, please reboot to apply changes.'
+        else
+            echo "No changes were made."
+        fi
+    }
+
+    uninstall_coolercontrol() {
+        packages=()
+        for pkg in liquidctl coolercontrol; do
+            if layered_package "$pkg"; then
+                packages+=("$pkg")
+            fi
+        done
+
+        if [ ${#packages[@]} -gt 0 ]; then
+            echo "Uninstalling: ${packages[*]}"
+            rpm-ostree uninstall -y "${packages[@]}"
+            echo 'Complete, please reboot to apply changes.'
+        else
+            echo "CoolerControl is not layered."
+        fi
+    }
+
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+        echo "Usage: ujust install-coolercontrol <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'status' to print the current portal token"
+        echo "  Use 'install' to install CoolerControl"
+        echo "  Use 'uninstall' to uninstall CoolerControl"
+        exit 0
+    elif [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit 0
+    elif [[ "$OPTION" == "install" ]]; then
+        install_coolercontrol
+        exit 0
+    elif [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_coolercontrol
+        exit 0
+    elif [[ -z "$OPTION" ]]; then
+        current_status=$(get_current_status)
+        echo "${bold}CoolerControl${normal}"
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Install" "Uninstall" "Exit without changes")
+        case "$OPTION" in
+            "Install")
+                install_coolercontrol
+                ;;
+            "Uninstall")
+                uninstall_coolercontrol
+                ;;
+            *)
+                echo "No changes made."
+                ;;
+        esac
+        exit 0
     fi
 
 # Install Displaylink, Needed for some laptop docks to output video

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -338,35 +338,129 @@ get-steamcmd ACTION="":
         exit 0
     fi
 
-# Install OpenRazer for Razer gaming hardware
+# Manage OpenRazer for Razer gaming hardware. Options: status | install | uninstall
 [group("hardware")]
-install-openrazer:
+install-openrazer ACTION="":
     #!/usr/bin/bash
+    set -eo pipefail
     source /usr/lib/ujust/ujust.sh
-    OPENRAZER_CONFIGURATOR_APP="None of openrazer frontend apps"
-    sudo curl -Lo /etc/yum.repos.d/hardware:razer.repo https://openrazer.github.io/hardware:razer.repo && \
-    rpm-ostree install -y openrazer-daemon && \
-        if ! grep -q "plugdev" /etc/group; then \
-      sudo bash -c 'grep "plugdev" /lib/group >> /etc/group' \
-    ; fi && \
-    sudo usermod -a -G plugdev $USER && \
-    echo "${bold}Select OpenRazer Frontend Apps${normal}"
-    OPTION=$(Choose "Razer Genie" "Polychromatic" "None")
-    if [[ "${OPTION,,}" =~ ^razer[[:space:]]genie ]]; then
-        echo "Installing Razer Genie..."
-        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak --system install -y flathub xyz.z3ntu.razergenie
-        OPENRAZER_CONFIGURATOR_APP="Razer Genie"
-    elif [[ "${OPTION,,}" =~ ^polychromatic ]]; then
-        echo "Installing Polychromatic..."
-        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak --system install -y flathub app.polychromatic.controller
-        OPENRAZER_CONFIGURATOR_APP="Polychromatic"
-    else
-        echo "Not Selecting GUI Frontend"
+    layered_package() {
+        local pkg="$1"
+        rpm-ostree status --json | jq -e ".deployments[] | select(.booted == true) | .packages | index(\"$pkg\")" > /dev/null
+    }
+    flatpak_installed() {
+        local app="$1"
+        flatpak list --system --columns=application 2>/dev/null | grep -Fx "$app" >/dev/null
+    }
+    get_status_token() {
+        if ! layered_package openrazer-daemon; then
+            echo "uninstall"
+        elif flatpak_installed xyz.z3ntu.razergenie; then
+            echo "install-razer-genie"
+        elif flatpak_installed app.polychromatic.controller; then
+            echo "install-polychromatic"
+        else
+            echo "install"
+        fi
+    }
+    get_current_status() {
+        if ! layered_package openrazer-daemon; then
+            echo "Not Installed"
+        elif flatpak_installed xyz.z3ntu.razergenie; then
+            echo "Installed (Razer Genie)"
+        elif flatpak_installed app.polychromatic.controller; then
+            echo "Installed (Polychromatic)"
+        else
+            echo "Installed"
+        fi
+    }
+    install_openrazer() {
+        local FRONTEND_OPTION="${1:-}"
+        OPENRAZER_CONFIGURATOR_APP="None of openrazer frontend apps"
+        if [[ -z "$FRONTEND_OPTION" ]]; then
+            echo "${bold}Select OpenRazer Frontend Apps${normal}"
+            FRONTEND_OPTION=$(ugum choose "Razer Genie" "Polychromatic" "None")
+        fi
+        if [[ "${FRONTEND_OPTION,,}" =~ ^razer[[:space:]]genie ]]; then
+            echo "Installing Razer Genie..."
+            flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+            flatpak --system install -y flathub xyz.z3ntu.razergenie
+            OPENRAZER_CONFIGURATOR_APP="Razer Genie"
+        elif [[ "${FRONTEND_OPTION,,}" =~ ^polychromatic ]]; then
+            echo "Installing Polychromatic..."
+            flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+            flatpak --system install -y flathub app.polychromatic.controller
+            OPENRAZER_CONFIGURATOR_APP="Polychromatic"
+        else
+            echo "Not Selecting GUI Frontend"
+        fi
+        sudo curl -Lo /etc/yum.repos.d/hardware:razer.repo https://openrazer.github.io/hardware:razer.repo
+        rpm-ostree install -y openrazer-daemon
+        if ! grep -q "plugdev" /etc/group; then
+            sudo bash -c 'grep "plugdev" /lib/group >> /etc/group'
+        fi
+        sudo usermod -a -G plugdev "$USER"
+        echo "$OPENRAZER_CONFIGURATOR_APP is installed"
+        echo "Please reboot to apply needed changes."
+    }
+    uninstall_openrazer() {
+        if layered_package openrazer-daemon; then
+            rpm-ostree uninstall -y openrazer-daemon
+            echo "OpenRazer daemon has been uninstalled."
+        else
+            echo "OpenRazer daemon is not layered."
+        fi
+        if flatpak_installed xyz.z3ntu.razergenie; then
+            flatpak --system remove -y xyz.z3ntu.razergenie
+        fi
+        if flatpak_installed app.polychromatic.controller; then
+            flatpak --system remove -y app.polychromatic.controller
+        fi
+        echo "Please reboot to apply needed changes."
+    }
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+        echo "Usage: ujust install-openrazer <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'status' to print the current portal token"
+        echo "  Use 'install' to install OpenRazer without a frontend"
+        echo "  Use 'install-razer-genie' to install OpenRazer with Razer Genie"
+        echo "  Use 'install-polychromatic' to install OpenRazer with Polychromatic"
+        echo "  Use 'uninstall' to uninstall OpenRazer"
+        exit 0
+    elif [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit 0
+    elif [[ "$OPTION" == "install" ]]; then
+        install_openrazer "None"
+        exit 0
+    elif [[ "$OPTION" == "install-razer-genie" ]]; then
+        install_openrazer "Razer Genie"
+        exit 0
+    elif [[ "$OPTION" == "install-polychromatic" ]]; then
+        install_openrazer "Polychromatic"
+        exit 0
+    elif [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_openrazer
+        exit 0
+    elif [[ -z "$OPTION" ]]; then
+        current_status=$(get_current_status)
+        echo "${bold}OpenRazer${normal}"
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Install" "Uninstall" "Exit without changes")
+        case "$OPTION" in
+            "Install")
+                install_openrazer
+                ;;
+            "Uninstall")
+                uninstall_openrazer
+                ;;
+            *)
+                echo "No changes made."
+                ;;
+        esac
+        exit 0
     fi
-    echo "$OPENRAZER_CONFIGURATOR_APP is installed"
-    echo "Please reboot to apply needed changes."
 
 # Install EmuDeck (https://www.emudeck.com/). Options: status | install | uninstall
 [group("gaming")]

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -363,14 +363,97 @@ openrgb ACTION="":
         exit 0
     fi
 
-# Install Boxtron, a Steam Play compatibility tool to run DOS games using native Linux DOSBox
+# Manage Boxtron, a Steam Play compatibility tool to run DOS games using native Linux DOSBox. Options: status | install | uninstall
 [group("gaming")]
-install-boxtron: distrobox-check-fedora
-    distrobox enter -n fedora -- bash -c '\
-      sudo dnf install dosbox-staging inotify-tools timidity++ fluid-soundfont-gm -y && \
-      cd ~/.steam/root/compatibilitytools.d/ && \
-      curl -L https://github.com/dreamer/boxtron/releases/download/v0.5.4/boxtron.tar.xz | tar xJf - && \
-      distrobox-export --bin /usr/bin/dosbox'
+install-boxtron ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    boxtron_installed() {
+        for base in "$HOME/.steam/root/compatibilitytools.d" "$HOME/.local/share/Steam/compatibilitytools.d"; do
+            if [[ -d "$base/boxtron" ]] || [[ -d "$base/Boxtron" ]]; then
+                return 0
+            fi
+        done
+        return 1
+    }
+    get_status_token() {
+        if boxtron_installed; then
+            echo "install"
+        else
+            echo "uninstall"
+        fi
+    }
+    get_current_status() {
+        if [[ "$(get_status_token)" == "install" ]]; then
+            echo "Installed"
+        else
+            echo "Not Installed"
+        fi
+    }
+    install_boxtron() {
+        just distrobox-check-fedora
+        distrobox enter -n fedora -- bash -c '\
+          sudo dnf install dosbox-staging inotify-tools timidity++ fluid-soundfont-gm -y && \
+          cd ~/.steam/root/compatibilitytools.d/ && \
+          curl -L https://github.com/dreamer/boxtron/releases/download/v0.5.4/boxtron.tar.xz | tar xJf - && \
+          distrobox-export --bin /usr/bin/dosbox'
+    }
+    uninstall_boxtron() {
+        removed=false
+        for path in \
+            "$HOME/.steam/root/compatibilitytools.d/boxtron" \
+            "$HOME/.steam/root/compatibilitytools.d/Boxtron" \
+            "$HOME/.local/share/Steam/compatibilitytools.d/boxtron" \
+            "$HOME/.local/share/Steam/compatibilitytools.d/Boxtron"; do
+            if [[ -e "$path" ]]; then
+                rm -rf "$path"
+                removed=true
+            fi
+        done
+        if distrobox list 2>/dev/null | grep -qE '(^|[[:space:]])fedora([[:space:]]|$)'; then
+            distrobox enter -n fedora -- bash -c 'distrobox-export --bin /usr/bin/dosbox --delete || true'
+        fi
+        if [[ "$removed" == "true" ]]; then
+            echo "Boxtron has been uninstalled."
+        else
+            echo "Boxtron is not installed."
+        fi
+    }
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+        echo "Usage: ujust install-boxtron <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'status' to print the current portal token"
+        echo "  Use 'install' to install Boxtron"
+        echo "  Use 'uninstall' to uninstall Boxtron"
+        exit 0
+    elif [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit 0
+    elif [[ "$OPTION" == "install" ]]; then
+        install_boxtron
+        exit 0
+    elif [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_boxtron
+        exit 0
+    elif [[ -z "$OPTION" ]]; then
+        current_status=$(get_current_status)
+        echo "${bold}Boxtron${normal}"
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Install" "Uninstall" "Exit without changes")
+        case "$OPTION" in
+            "Install")
+                install_boxtron
+                ;;
+            "Uninstall")
+                uninstall_boxtron
+                ;;
+            *)
+                echo "No changes made."
+                ;;
+        esac
+        exit 0
+    fi
 
 # Manage Resilio Sync, a file synchronization utility powered by BitTorrent. Options: status | install | uninstall
 resilio-sync ACTION="":

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cockpit.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-cockpit.just
@@ -7,13 +7,30 @@ cockpit ACTION="":
     source /usr/lib/ujust/ujust.sh
     OPTION="{{ ACTION }}"
 
+    get_status_token() {
+      if systemctl is-enabled --quiet cockpit.service; then
+        echo "enable"
+      else
+        echo "disable"
+      fi
+    }
+
+    get_current_status() {
+      if [[ "$(get_status_token)" == "enable" ]]; then
+        echo "${green}${bold}Enabled${normal}"
+      else
+        echo "${yellow}${bold}Disabled${normal}"
+      fi
+    }
+
     if [ "$OPTION" == "status" ]; then
-      systemctl is-enabled cockpit.service
-      exit $?
+      get_status_token
+      exit 0
     fi
 
     if [ "$OPTION" == "" ]; then
       echo "${bold}Cockpit${normal}"
+      echo "Current status: $(get_current_status)"
       OPTION=$(ugum choose "Enable" "Disable" "Exit without changes")
     fi
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/83-bazzite-audio.just
@@ -5,31 +5,51 @@
 setup-virtual-channels ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-    IMAGE_NAME=$(jq -r '."image-name"' < $IMAGE_INFO)
-    # Set default props, for deck images make sure default output is valves virtual-sink
-    PROPS='node.name      = "playback.game_output"
+    CONFIG_FILE="$HOME/.config/pipewire/pipewire.conf.d/virtual-channels.conf"
+    get_status_token() {
+      if [[ -f "$CONFIG_FILE" ]]; then
+        echo "create"
+      else
+        echo "remove"
+      fi
+    }
+    get_current_status() {
+      if [[ "$(get_status_token)" == "create" ]]; then
+        echo "Enabled"
+      else
+        echo "Disabled"
+      fi
+    }
+    OPTION="{{ ACTION }}"
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust setup-virtual-channels <option>"
+      echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'status' to print the current portal token"
+      echo "  Use 'create' to select Create Virtual Audio Channels"
+      echo "  Use 'remove' to select Remove Virtual Audio Channels"
+      exit 0
+    elif [ "$OPTION" == "status" ]; then
+      get_status_token
+      exit 0
+    elif [ "$OPTION" == "" ]; then
+      echo "${bold}Virtual Audio Channels configuration${normal}"
+      echo "Current status: $(get_current_status)"
+      OPTION=$(ugum choose "Create Virtual Audio Channels" "Remove Virtual Audio Channels" "Exit without changes")
+    fi
+    if [[ "${OPTION,,}" =~ ^create ]]; then
+      IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+      IMAGE_NAME=$(jq -r '."image-name"' < $IMAGE_INFO)
+      # Set default props, for deck images make sure default output is valves virtual-sink
+      PROPS='node.name      = "playback.game_output"
                     audio.position = [ FL FR ]
                     node.passive   = true'
-    if [[ "$IMAGE_NAME" =~ deck ]]; then
+      if [[ "$IMAGE_NAME" =~ deck ]]; then
         PROPS='node.name      = "playback.game_output"
                     audio.position = [ FL FR ]
                     node.passive   = true
                     target.object = "input.virtual-sink"'
-    fi
-    mkdir -p ~/.config/pipewire/pipewire.conf.d
-    OPTION={{ ACTION }}
-    if [ "$OPTION" == "help" ]; then
-      echo "Usage: ujust setup-virtual-channels <option>"
-      echo "  <option>: Specify the quick option to skip the prompt"
-      echo "  Use 'create' to select Create Virtual Audio Channels"
-      echo "  Use 'remove' to select Remove Virtual Audio Channels"
-      exit 0
-    elif [ "$OPTION" == "" ]; then
-      echo "${bold}Virtual Audio Channels configuration${normal}"
-      OPTION=$(Choose "Create Virtual Audio Channels" "Remove Virtual Audio Channels")
-    fi
-    if [[ "${OPTION,,}" =~ ^create ]]; then
+      fi
+      mkdir -p ~/.config/pipewire/pipewire.conf.d
       PLAYBACK_PROPS=$PROPS bash -c 'cat << EOL > ~/.config/pipewire/pipewire.conf.d/virtual-channels.conf
     context.modules = [
         { name = libpipewire-module-loopback
@@ -91,7 +111,7 @@ setup-virtual-channels ACTION="":
       echo "You can also add these channels to OBS audio mixer for separate audio control for yourself and your viewers."
       echo "NOTE: It is recommended to mute the virtual channels so you do not have to listen to them twice if you are not exclusively routing the audio through said channel instead of splitting audio to them."
     elif [[ "${OPTION,,}" =~ ^remove ]]; then
-      rm ~/.config/pipewire/pipewire.conf.d/virtual-channels.conf
+      rm -f "$CONFIG_FILE"
       echo "Virtual audio channels config removed, the channels will be removed next time you login."
     fi
 
@@ -100,24 +120,48 @@ setup-virtual-channels ACTION="":
 setup-virtual-surround ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    mkdir -p ~/.config/pipewire/pipewire.conf.d
-    mkdir -p ~/.config/pipewire/hrtf-sofa
-    OPTION={{ ACTION }}
+    CONFIG_FILE="$HOME/.config/pipewire/pipewire.conf.d/spatializer-7.1.conf"
+    LEGACY_CONFIG_FILE="$HOME/.config/pipewire/pipewire.conf.d/virtual-surround-71.conf"
+    HRTF_FILE="$HOME/.config/pipewire/hrtf-sofa/sadie_d1.sofa"
+    get_status_token() {
+      if [[ -f "$CONFIG_FILE" && -f "$HRTF_FILE" ]]; then
+        echo "enable"
+      else
+        echo "disable"
+      fi
+    }
+    get_current_status() {
+      if [[ "$(get_status_token)" == "enable" ]]; then
+        echo "Enabled"
+      elif [[ -f "$CONFIG_FILE" || -f "$HRTF_FILE" ]]; then
+        echo "Partially Enabled"
+      else
+        echo "Disabled"
+      fi
+    }
+    OPTION="{{ ACTION }}"
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust setup-virtual-surround <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'status' to print the current portal token"
       echo "  Use 'enable' to select Enable Virtual Headphone Surround"
       echo "  Use 'disable' to select Disable Virtual Headphone Surround"
       exit 0
+    elif [ "$OPTION" == "status" ]; then
+      get_status_token
+      exit 0
     elif [ "$OPTION" == "" ]; then
       echo "${bold}Virtual Headphone Surround configuration${normal}"
-      OPTION=$(Choose "Enable Virtual Headphone Surround" "Disable Virtual Headphone Surround")
+      echo "Current status: $(get_current_status)"
+      OPTION=$(ugum choose "Enable Virtual Headphone Surround" "Disable Virtual Headphone Surround" "Exit without changes")
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then
+      mkdir -p ~/.config/pipewire/pipewire.conf.d
+      mkdir -p ~/.config/pipewire/hrtf-sofa
       echo "Downloading Valve's Steam Audio HRTF..."
-      wget -O ~/.config/pipewire/hrtf-sofa/sadie_d1.sofa https://github.com/ValveSoftware/steam-audio/raw/master/core/data/hrtf/sadie_d1.sofa
-      if [ -f ~/.config/pipewire/pipewire.conf.d/virtual-surround-71.conf ]; then
-        mv ~/.config/pipewire/pipewire.conf.d/virtual-surround-71.conf ~/.config/pipewire/virtual-surround-71.conf.bak
+      wget -O "$HRTF_FILE" https://github.com/ValveSoftware/steam-audio/raw/master/core/data/hrtf/sadie_d1.sofa
+      if [ -f "$LEGACY_CONFIG_FILE" ]; then
+        mv "$LEGACY_CONFIG_FILE" ~/.config/pipewire/virtual-surround-71.conf.bak
       fi
       bash -c 'cat << SPATIALIZER > ~/.config/pipewire/pipewire.conf.d/spatializer-7.1.conf
     # Headphone surround sink
@@ -281,14 +325,14 @@ setup-virtual-surround ACTION="":
     ]
     SPATIALIZER'
       echo ""
-      echo "Virtual surround sound has been successfully set up. Reboot your system or restart PipeWire - ${bold}TIP:${normal} ujust restart-pipewire - for changes to take effect. Select 'Virtual Headphone Surround' as the default audio device to enable surround virtualization. ${bold}This setup is incompatible with EasyEffects or JamesDSP;${normal} make sure neither is currently running."
+      echo "Virtual surround sound has been successfully set up. Reboot your system or restart PipeWire for changes to take effect. ${bold}TIP:${normal} Use Bazzite Portal > Troubleshooting > Restart PipeWire or run 'ujust restart-pipewire' in the Terminal. Select 'Virtual Headphone Surround' as the default audio device to enable surround virtualization. ${bold}This setup is incompatible with EasyEffects or JamesDSP;${normal} make sure neither is currently running."
     elif [[ "${OPTION,,}" =~ ^disable ]]; then
-      if [ -f ~/.config/pipewire/pipewire.conf.d/virtual-surround-71.conf ]; then
-        rm ~/.config/pipewire/pipewire.conf.d/virtual-surround-71.conf
+      if [ -f "$LEGACY_CONFIG_FILE" ]; then
+        rm "$LEGACY_CONFIG_FILE"
       fi
-      rm ~/.config/pipewire/pipewire.conf.d/spatializer-7.1.conf
-      rm ~/.config/pipewire/hrtf-sofa/sadie_d1.sofa
-      echo "Virtual surround configuration file and HRTF removed, please reboot or restart PipeWire for changes to take effect - ${bold}TIP:${normal} ujust restart-pipewire."
+      rm -f "$CONFIG_FILE"
+      rm -f "$HRTF_FILE"
+      echo "Virtual surround configuration file and HRTF removed, please reboot or restart PipeWire for changes to take effect. ${bold}TIP:${normal} Use Bazzite Portal > Troubleshooting > Restart PipeWire or run 'ujust restart-pipewire'."
     fi
 
 # Restart PipeWire

--- a/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -1,6 +1,6 @@
 # vim: set ft=make :
 
-# Setup and configure virtualization and vfio
+# Setup and configure virtualization
 [group("virtualization")]
 setup-virtualization ACTION="":
     #!/usr/bin/bash
@@ -14,25 +14,12 @@ setup-virtualization ACTION="":
       echo "${red}${b}WARNING${n}: Virtualization is not properly supported on Steam Deck by Valve"
       echo "Use at your own risk and performance may not be ideal."
     fi
-    if [ "$(systemctl is-enabled libvirtd.service)" == "disabled" ]; then
-      echo "${b}libvirtd${n} service is ${red}disabled${n}!"
-      echo "${green}enabling${n} and starting libvirtd"
-      echo "If virt-manager says libvirtd.sock is not available after a big update, re-run this command."
-      sudo systemctl enable --now libvirtd 2> /dev/null
-      echo "Press ESC if you want to exit and do not need to do anything"
-    fi
     OPTION={{ ACTION }}
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust setup-virtualization <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'virt-on' to select Enable Virtualization"
       echo "  Use 'virt-off' to select Disable Virtualization"
-      echo "  Use 'group' to select Add $USER to libvirt group"
-      echo "  Use 'vfio-on' to select Enable VFIO drivers"
-      echo "  Use 'vfio-off' to select Disable VFIO drivers"
-      echo "  Use 'kvmfr' to select Autocreate Looking-Glass shm"
-      echo "  Use 'usbhp-on' to select Enable SPICE USB hot plugging"
-      echo "  Use 'usbhp-off' to select Disable SPICE USB hot plugging"
       exit 0
     elif [ "$OPTION" == "" ]; then
       echo "${bold}Virtualization Setup${normal}"
@@ -40,18 +27,25 @@ setup-virtualization ACTION="":
       OPTION=$(Choose \
         "Enable Virtualization" \
         "Disable Virtualization" \
-        "Add $USER to libvirt group" \
-        "Enable VFIO drivers" \
-        "Disable VFIO drivers" \
-        "Enable kvmfr module" \
-        "Enable USB hot plugging" \
-        "Disable USB hot plugging" \
       )
     fi
     if [[ "${OPTION,,}" =~ (^enable[[:space:]]virtualization|virt-on) ]]; then
-        if ! rpm -q virt-manager | grep -P "^virt-manager-" 1>/dev/null; then
-          echo "Installing virt-manager..."
-          flatpak install flathub org.virt_manager.virt-manager
+        if [ "$(systemctl is-enabled libvirtd.service)" == "disabled" ]; then
+          echo "${b}libvirtd${n} service is ${red}disabled${n}!"
+          echo "${green}enabling${n} and starting libvirtd"
+          echo "If virt-manager says libvirtd.sock is not available after a big update, re-run this command."
+          sudo systemctl enable --now libvirtd 2> /dev/null
+        fi
+        FLATPAKS_TO_INSTALL=()
+        if ! flatpak info --system org.virt_manager.virt-manager 1>/dev/null 2>&1; then
+          FLATPAKS_TO_INSTALL+=(org.virt_manager.virt-manager)
+        fi
+        if ! flatpak info --system org.virt_manager.virt_manager.Extension.Qemu 1>/dev/null 2>&1; then
+          FLATPAKS_TO_INSTALL+=(org.virt_manager.virt_manager.Extension.Qemu)
+        fi
+        if [ ${#FLATPAKS_TO_INSTALL[@]} -gt 0 ]; then
+          echo "Installing virt-manager and QEMU extension..."
+          flatpak install --system --assumeyes flathub "${FLATPAKS_TO_INSTALL[@]}"
           rpm-ostree kargs \
           --append-if-missing="kvm.ignore_msrs=1" \
           --append-if-missing="kvm.report_ignored_msrs=0"
@@ -62,22 +56,14 @@ setup-virtualization ACTION="":
           sudo chown tss /var/lib/swtpm-localca
           sudo restorecon -rv /var/lib/libvirt
           sudo restorecon -rv /var/log/libvirt
-          echo "Giving qemu access to read ISO files from $HOME"
-          sudo setfacl -m u:qemu:rx $HOME
-          if sudo test ! -f "/etc/libvirt/hooks/qemu"; then
-            echo "Adding libvirt qemu hooks"
-            sudo wget 'https://raw.githubusercontent.com/PassthroughPOST/VFIO-Tools/master/libvirt_hooks/qemu' -O /etc/libvirt/hooks/qemu
-            sudo chmod +x /etc/libvirt/hooks/qemu
-            sudo restorecon -r /etc/libvirt/hooks
-            sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
-            if sudo test ! -d "/etc/libvirt/hooks/qemu.d"; then
-              sudo mkdir /etc/libvirt/hooks/qemu.d
-            fi
-          fi
           sudo systemctl enable bazzite-libvirtd-setup.service \
             && echo "libvirtd will be enabled at next reboot"
           echo 'Please reboot to apply changes'
         fi
+        if ! getent group libvirt 1>/dev/null; then
+          sudo groupadd --system libvirt
+        fi
+        sudo usermod -aG libvirt $USER
     elif [[ "${OPTION,,}" =~ (^disable[[:space:]]virtualization|virt-off) ]]; then
       if [ "$(systemctl is-enabled libvirtd.service)" == "enabled" ]; then
         echo "${red}Disabling${n} libvirtd before removal"
@@ -88,205 +74,14 @@ setup-virtualization ACTION="":
         sudo systemctl disable --now bazzite-libvirtd-setup.service 2> /dev/null
       fi
       echo "Removing virt-manager..."
-      flatpak uninstall org.virt_manager.virt-manager
+      if flatpak info --system org.virt_manager.virt-manager 1>/dev/null 2>&1; then
+        flatpak uninstall --system --assumeyes org.virt_manager.virt-manager
+      fi
+      if flatpak info --system org.virt_manager.virt_manager.Extension.Qemu 1>/dev/null 2>&1; then
+        flatpak uninstall --system --assumeyes org.virt_manager.virt_manager.Extension.Qemu
+      fi
       rpm-ostree kargs \
       --delete-if-present="kvm.ignore_msrs=1" \
       --delete-if-present="kvm.report_ignored_msrs=0"
       echo 'Please reboot to apply changes'
-    elif [[ "${OPTION,,}" =~ (^enable[[:space:]]vfio|vfio-on) ]]; then
-      # Check if we are running on a Steam Deck
-      if /usr/libexec/hwsupport/valve-hardware; then
-        echo "IOMMU is not supported on Steam Deck"
-        exit 0
-      fi
-      echo "Enabling VFIO..."
-      VIRT_TEST=$(rpm-ostree kargs)
-      CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
-      VENDOR_KARG="unset"
-      if [[ ${VIRT_TEST} == *kvm.report_ignored_msrs* ]]; then
-        rpm-ostree initramfs --enable
-        if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
-          VENDOR_KARG="amd_iommu=on"
-        elif [[ ${CPU_VENDOR} == "GenuineIntel" ]]; then
-          VENDOR_KARG="intel_iommu=on"  
-        fi
-        if [[ ${VENDOR_KARG} == "unset" ]]; then
-          echo "Failed to get CPU vendor, exiting..."
-          exit 1
-        else
-          rpm-ostree kargs \
-            --append-if-missing="${VENDOR_KARG}" \
-            --append-if-missing="iommu=pt" \
-            --append-if-missing="rd.driver.pre=vfio-pci" \
-            --append-if-missing="vfio_pci.disable_vga=1"
-          echo "VFIO will be enabled on next boot, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
-          echo "Please understand that since this is such a niche use case, support will be very limited!"
-          echo 'Use the command "ls-iommu -grk" to get iommu information about your GPUs, use the "--help" flag for more options'
-          echo ""
-          echo "${b}Systems with multiple GPUs${n}"
-          echo "Bind your unused/second GPU device ids to the vfio driver by running"
-          echo 'rpm-ostree kargs --append-if-missing="vfio_pci.ids=xxxx:yyyy,xxxx:yyzz"'
-          echo "You will require a $(Urllink "https://www.amazon.com/s?k=hdmi+displayport+dummy+plug" "Dummy HDMI/DisplayPort plug (Ghost Adapter)") or hook the GPU"
-          echo "to a separate monitor input in order to turn the GPU on when starting the VM."
-          echo "NOTE: Your second GPU should be as different as possible from your main GPU and will not be usable by the host after you bind it to the vfio driver!"
-          echo ""
-          echo "${b}Systems with 1 GPU${n}"
-          echo "Once rebooted you can continue setting up whatever scripts and hooks you need"
-          echo "to get Single GPU passthrough working, however ${u}you will be on your own${n}."
-          echo "${b}Do not ask for support for setting up Single GPU Passthrough, we can not help you!${n}"
-        fi
-      fi
-    elif [[ "${OPTION,,}" =~ (^disable[[:space:]]vfio|vfio-off) ]]; then
-      # Check if we are running on a Steam Deck
-      if /usr/libexec/hwsupport/valve-hardware; then
-        echo "IOMMU is not supported on Steam Deck"
-        exit 0
-      fi
-      echo ""
-      echo "Make sure you have ${b}disabled autostart of all VMs using VFIO${n} before continuing!"
-      CONFIRM=$(Choose Cancel Continue)
-      if [ "$CONFIRM" == "Continue" ]; then
-        echo "Disabling VFIO..."
-        VFIO_IDS="$(rpm-ostree kargs | sed -E 's/.+(vfio_pci.ids=.+\s)/\1/' | awk '{ print $1 }' | grep vfio_pci.ids)"
-        VFIO_IDS_KARG=""
-        if [ -n "$VFIO_IDS" ]; then
-          echo "Found VFIO ids in kargs, adding the below line to removal list"
-          echo "$VFIO_IDS"
-          VFIO_IDS_KARG="--delete-if-present=\"$VFIO_IDS\""
-        fi
-        KVMFR_VAL="$(rpm-ostree kargs | sed -E 's/.+(kvmfr.static_size_mb=.+\s)/\1/' | awk '{ print $1 }' | grep kvmfr.static_size_mb)"
-        KVMFR_KARG=""
-        if [ -n "$KVMFR_VAL" ]; then
-          echo "Found KVMFR static_size_mb in kargs, adding the below line to removal list"
-          echo "$KVMFR_VAL"
-          KVMFR_KARG="--delete-if-present=\"$KVMFR_VAL\""
-        fi
-        echo "Removing deprecated dracut modules"
-        sudo rm /etc/dracut.conf.d/vfio.conf
-        sudo rm /etc/modprobe.d/kvmfr.conf
-        rpm-ostree kargs \
-        --delete-if-present="iommu=pt" \
-        --delete-if-present="iommu=on" \
-        --delete-if-present="amd_iommu=on" \
-        --delete-if-present="intel_iommu=on" \
-        --delete-if-present="rd.driver.pre=vfio-pci" \
-        --delete-if-present="vfio_pci.disable_vga=1" \
-        --delete-if-present="vfio_pci.disable_vga=0" \
-        $VFIO_IDS_KARG \
-        $KVMFR_KARG
-      fi
-    elif [[ "${OPTION,,}" =~ kvmfr ]]; then
-      # Check if we are running on a Steam Deck
-      if /usr/libexec/hwsupport/valve-hardware; then
-        echo "IOMMU is not supported on Steam Deck"
-        exit 0
-      fi
-      echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "This module") along with $(Urllink "https://looking-glass.io" "Looking Glass") is very experimental and not recommended for production use!"
-      echo "The ublue team packages the kvmfr module only because it has to be supplied with the system image while using an atomic desktop."
-      echo "If you do plan to use Looking Glass, please $(Urllink "https://docs.bazzite.gg/Advanced/looking-glass/" "follow the guide here") on how to compile it for your system."
-      echo "To use the kvmfr module after enabling it, just add and edit the xml for libvirt from the documentation in the first link."
-      echo "Since we package the kvmfr module please open kvmfr related issues you have on Bazzite"
-      echo "in the $(Urllink "https://discord.bazzite.gg/" "Bazzite Discord") or the $(Urllink "https://github.com/ublue-os/bazzite/issues" "Bazzite Github issue tracker")."
-      echo "~ @HikariKnight"
-      CONFIRM=$(Choose Ok Cancel)
-      if [ "$CONFIRM" == "Cancel" ]; then
-        exit 0
-      fi
-      echo ""
-      echo "Setting up kvmfr module so it loads next boot"
-      if [ -f "/etc/modprobe.d/kvmfr.conf" ]; then
-        echo "Re-creating dummy kvmfr modprobe file"
-        sudo rm /etc/modprobe.d/kvmfr.conf
-      fi
-      sudo bash -c 'cat << KVMFR_MODPROBE > /etc/modprobe.d/kvmfr.conf
-    # This is a dummy file and changing it does nothing
-    # If you want to change the kvmfr static_size_mb
-    # Run "rpm-ostree kargs --replace=kvmfr.static_size_mb=oldvalue=newvalue"
-    # Default value set by us is 128 which is enough for 4k SDR
-    # Find the current value by running "rpm-ostree kargs"
-    KVMFR_MODPROBE'
-      rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128" --append-if-missing="split_lock_detect=off"
-      if [ -f "/etc/udev/rules.d/70-kvmfr.rules" ]; then
-        echo "Re-creating kvmfr udev rules"
-        sudo rm /etc/udev/rules.d/70-kvmfr.rules
-      fi
-      echo "Adding udev rule for /dev/kvmfr0"
-      sudo bash -c 'cat << KVMFR_UDEV > /etc/udev/rules.d/70-kvmfr.rules
-    SUBSYSTEM=="kvmfr", TAG+="uaccess", GROUP="qemu", MODE="0660"
-    KVMFR_UDEV'
-      echo "Adding /dev/kvmfr0 to qemu cgroup_device_acl"
-      sudo perl -0777 -pi -e 's/
-    #cgroup_device_acl = \[
-    #    "\/dev\/null", "\/dev\/full", "\/dev\/zero",
-    #    "\/dev\/random", "\/dev\/urandom",
-    #    "\/dev\/ptmx", "\/dev\/kvm",
-    #    "\/dev\/userfaultfd"
-    #\]
-    /
-    cgroup_device_acl = \[
-        "\/dev\/null", "\/dev\/full", "\/dev\/zero",
-        "\/dev\/random", "\/dev\/urandom",
-        "\/dev\/ptmx", "\/dev\/kvm",
-        "\/dev\/userfaultfd", "\/dev\/kvmfr0"
-    \]
-    /' /etc/libvirt/qemu.conf
-      echo "Adding SELinux context record for /dev/kvmfr0"
-      sudo semanage fcontext -a -t svirt_tmpfs_t /dev/kvmfr0
-      echo "Adding SELinux access rules for /dev/kvmfr0"
-      if [ ! -d "$HOME/.config/selinux_te/mod" ]; then
-        mkdir -p "$HOME/.config/selinux_te/mod"
-      fi
-      if [ ! -d "$HOME/.config/selinux_te/pp" ]; then
-        mkdir -p "$HOME/.config/selinux_te/pp"
-      fi
-      if [ -f "$HOME/.config/selinux_te/kvmfr.te" ]; then
-        echo "Re-creating kvmfr selinux type enforcement rules"
-        rm $HOME/.config/selinux_te/kvmfr.te
-      fi
-      bash -c "cat << KVMFR_SELINUX > $HOME/.config/selinux_te/kvmfr.te
-    module kvmfr 1.0;
-
-    require {
-        type device_t;
-        type svirt_t;
-        class chr_file { open read write map };
-    }
-
-    #============= svirt_t ==============
-    allow svirt_t device_t:chr_file { open read write map };
-    KVMFR_SELINUX"
-      echo "This is the type enforcement we wrote for SELinux and you can find it in $HOME/.config/selinux_te/kvmfr.te"
-      echo "#======= start of kvmfr.te ======="
-      cat "$HOME/.config/selinux_te/kvmfr.te"
-      echo "#======== end of kvmfr.te ========"
-      checkmodule -M -m -o "$HOME/.config/selinux_te/mod/kvmfr.mod" "$HOME/.config/selinux_te/kvmfr.te"
-      semodule_package -o "$HOME/.config/selinux_te/pp/kvmfr.pp" -m "$HOME/.config/selinux_te/mod/kvmfr.mod"
-      sudo semodule -i "$HOME/.config/selinux_te/pp/kvmfr.pp"
-      echo "Loading kvmfr module so you do not have to reboot to use it the first time"
-      sudo modprobe kvmfr static_size_mb=128
-      sudo chown $USER:qemu /dev/kvmfr0
-      echo ""
-      echo "Kvmfr0 $(Urllink "https://looking-glass.io/docs/B7-rc1/install_libvirt/#determining-memory" "static size is set to 128mb by default")"
-      echo "this will work with up to 4K SDR resolutiion, as most dummy plugs go up to 4K"
-      echo "some games will try use the adapters max resolution on first boot and cause issues if the value is too low."
-      echo "Most ghost display adapters max out at 4k, hence the default value of 128mb."
-      echo ""
-      echo "If you need to change it to a different value"
-      echo "you can do that by running \"rpm-ostree kargs --replace=kvmfr.static_size_mb=128=newvalue\""
-      echo "You can check the current kernel arguments with \"rpm-ostree kargs\""
-      echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "Please read official documentation for kvmfr for how to use it")"
-      echo "${b}NOTE: You can start using kvmfr right now without rebooting if you already rebooted after enabling VFIO.${n}"
-      CONFIRM=$(Choose OK)
-    elif [[ "${OPTION,,}" =~ (^enable[[:space:]]usb|usbhp-on) ]]; then
-      echo "Adding udev rule for USB devices"
-      sudo bash -c 'cat << USBHP_UDEV > /etc/udev/rules.d/72-usbhp.rules
-    ACTION=="add" SUBSYSTEM=="usb", TAG+="uaccess"
-    USBHP_UDEV'
-    elif [[ "${OPTION,,}" =~ (^disable[[:space:]]usb|usbhp-off) ]]; then
-      sudo bash -c 'rm /etc/udev/rules.d/72-usbhp.rules'
-    elif [[ "${OPTION,,}" =~ group ]]; then
-      if ! grep -q "^libvirt" /etc/group; then
-        grep '^libvirt' /usr/lib/group | sudo tee -a /etc/group > /dev/null
-      fi
-      sudo usermod -aG libvirt $USER
     fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -1,7 +1,68 @@
 # vim: set ft=make :
 
-# Re-enable input remapper feature on non-desktop images
-restore-input-remapper:
-    systemctl enable --now input-remapper.service && \
-    cp /usr/share/applications/input-remapper-gtk.desktop ~/.local/share/applications/input-remapper-gtk.desktop && \
-    sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop
+# Manage input remapper feature on non-desktop images. Options: status | enable | disable
+restore-input-remapper ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    DESKTOP_FILE="$HOME/.local/share/applications/input-remapper-gtk.desktop"
+    get_status_token() {
+        if systemctl is-enabled --quiet input-remapper.service && [[ -f "$DESKTOP_FILE" ]]; then
+            echo "enable"
+        else
+            echo "disable"
+        fi
+    }
+    get_current_status() {
+        if [[ "$(get_status_token)" == "enable" ]]; then
+            echo "Enabled"
+        else
+            echo "Disabled"
+        fi
+    }
+    enable_input_remapper() {
+        systemctl enable --now input-remapper.service
+        mkdir -p "$HOME/.local/share/applications"
+        cp /usr/share/applications/input-remapper-gtk.desktop "$DESKTOP_FILE"
+        sed -i '/NoDisplay=true/d' "$DESKTOP_FILE"
+        echo "Input Remapper has been enabled."
+    }
+    disable_input_remapper() {
+        systemctl disable --now input-remapper.service
+        rm -f "$DESKTOP_FILE"
+        echo "Input Remapper has been disabled."
+    }
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+        echo "Usage: ujust restore-input-remapper <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'status' to print the current portal token"
+        echo "  Use 'enable' to enable Input Remapper"
+        echo "  Use 'disable' to disable Input Remapper"
+        exit 0
+    elif [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit 0
+    elif [[ "$OPTION" == "enable" ]]; then
+        enable_input_remapper
+        exit 0
+    elif [[ "$OPTION" == "disable" ]]; then
+        disable_input_remapper
+        exit 0
+    elif [[ -z "$OPTION" ]]; then
+        current_status=$(get_current_status)
+        echo "${bold}Input Remapper${normal}"
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Enable" "Disable" "Exit without changes")
+        case "$OPTION" in
+            "Enable")
+                enable_input_remapper
+                ;;
+            "Disable")
+                disable_input_remapper
+                ;;
+            *)
+                echo "No changes made."
+                ;;
+        esac
+        exit 0
+    fi

--- a/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/87-bazzite-framegen.just
@@ -5,41 +5,48 @@ get-lsfg ACTION="prompt":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
 
-    function check_lsfg_installed() {
+    function get_current_status() {
         # Check new installation location
         if [[ -f "/usr/local/lib/liblsfg-vk.so" ]] && [[ -f "/usr/local/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json" ]]; then
-            echo "${green}${bold}lsfg-vk is installed and ready to use.${normal}"
+            echo "${green}${bold}Installed${normal}"
         # Check legacy installation location
         elif [[ -f "$HOME/.local/lib/liblsfg-vk.so" ]] && [[ -f "$HOME/.local/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json" ]]; then
-            echo "${yellow}${bold}lsfg-vk is installed (legacy location) - consider reinstalling for latest version.${normal}"
+            echo "${yellow}${bold}Installed (legacy location)${normal}"
         else
-            echo "${red}${bold}lsfg-vk is not installed.${normal}"
+            echo "${red}${bold}Not Installed${normal}"
+        fi
+    }
+
+    function get_status_token() {
+        if [[ -f "/usr/local/lib/liblsfg-vk.so" ]] && [[ -f "/usr/local/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json" ]]; then
+            echo "install"
+        elif [[ -f "$HOME/.local/lib/liblsfg-vk.so" ]] && [[ -f "$HOME/.local/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json" ]]; then
+            echo "install"
+        else
+            echo "uninstall"
         fi
     }
 
     OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
-        echo ""
-        echo "Current Status:"
-        check_lsfg_installed
-        echo ""
+        current_status=$(get_current_status)
         echo "${bold}lsfg-vk${normal} enables lossless scaling functionality for supported games."
-        echo ""
-        echo "Below you can install or remove ${bold}lsfg-vk${normal} directly."
-        echo ""
-        echo "What would you like to do with lsfg-vk?"
-        echo ""
-        OPTION=$(ugum choose "Install lsfg-vk directly" "Install Decky Plugin" "Uninstall lsfg-vk" "Exit without changes")
+        echo "Below you can install or remove ${bold}lsfg-vk${normal}."
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Install lsfg-vk" "Uninstall lsfg-vk" "Exit without changes")
     elif [ "$OPTION" == "help" ]; then
         echo "Usage: just get-lsfg <option>"
         echo "  <option>: Specify an action - 'install' or 'uninstall'"
-        echo "  Use 'install' to install lsfg-vk directly."
+        echo "  Use 'install' to install lsfg-vk."
         echo "  Use 'uninstall' to remove lsfg-vk."
+        exit 0
+    elif [ "$OPTION" == "status" ]; then
+        get_status_token
         exit 0
     fi
 
-    if [ "${OPTION,,}" == "install" ] || [ "${OPTION,,}" == "install lsfg-vk directly" ]; then
-        echo "Installing lsfg-vk directly..."
+    if [ "${OPTION,,}" == "install" ] || [ "${OPTION,,}" == "install lsfg-vk" ]; then
+        echo "Installing lsfg-vk..."
 
         # Get the latest release download URL
         API_URL="https://api.github.com/repos/PancakeTAS/lsfg-vk/releases/latest"
@@ -143,9 +150,6 @@ get-lsfg ACTION="prompt":
 
         echo "lsfg-vk installed successfully!"
         echo "The lsfg-vk UI should now be available in your applications menu and on your desktop."
-    elif [ "${OPTION,,}" == "install decky plugin" ] || [ "${OPTION,,}" == "install-decky-plugin" ]; then
-        echo "Installing Decky LSFG plugin..."
-        ujust get-decky-lossless-scaling install
     elif [ "${OPTION,,}" == "uninstall" ] || [ "${OPTION,,}" == "uninstall lsfg-vk" ]; then
         echo "Uninstalling lsfg-vk..."
 

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -263,6 +263,18 @@ screens:
           - id: "remove"
             label: "Remove"
             script: "ujust add-user-to-input-group remove"
+      - id: "restore-input-remapper"
+        title: "Input Remapper"
+        description: "Manage Input Remapper and make its launcher visible on non-desktop images."
+        default: false
+        status_script: "ujust restore-input-remapper status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: 'ujust restore-input-remapper enable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable"
+            script: 'ujust restore-input-remapper disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "password-asterisks"
         title: "Visible Password Asterisks"
         description: "Show or hide password asterisks in sudo prompts."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -803,6 +803,11 @@ screens:
         description: "Collects system information and logs, then gives you links to share with support for troubleshooting."
         default: false
         script: 'ujust get-logs; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "bazzite-discord"
+        title: "Bazzite Support Discord Server"
+        description: "Opens Discord into the Bazzite Support Channel. PLEASE BE SURE TO PASTE YOUR TROUBLESHOOTING LOGS!"
+        default: false
+        script: "xdg-open https://discord.gg/JQq48bYzrc"
       - id: "benchmark"
         title: "Run System Benchmark"
         description: "Runs a one-minute CPU benchmark."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -274,6 +274,24 @@ screens:
         description: "Configure beesd deduplication for BTRFS filesystems."
         default: false
         script: 'ujust configure-beesd; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "snapper"
+        title: "Snapshots"
+        description: "Enable or disable Snapper snapshots for /var/home."
+        default: false
+        status_script: "ujust configure-snapshots status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: "ujust configure-snapshots enable"
+          - id: "disable"
+            label: "Disable"
+            script: "ujust configure-snapshots disable"
+          - id: "wipe"
+            label: "Wipe"
+            script: "ujust configure-snapshots wipe"
+          - id: "btrfs-assistant"
+            label: "Open Btrfs Assistant"
+            script: "setsid -f gtk-launch btrfs-assistant.desktop >/dev/null 2>&1"
       - id: "automounting"
         title: "Automounting"
         description: "Enable or disable automounting of labeled BTRFS/EXT4 partitions under /run/media/system."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -713,6 +713,11 @@ screens:
         description: "Rollback to the previous Bazzite deployment"
         default: false
         script: "brh rollback -y && reboot"
+      - id: "verify-image"
+        title: "Verify System Image"
+        description: "Detects if you are on an unverified official image and rebases you to the signed version."
+        default: false
+        script: "ujust verify-image"
       - id: "reset-bazzite"
         title: "Reset Bazzite"
         description: "Reset Bazzite layering to Default (Only resets layers NOT user data)" 

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -347,6 +347,30 @@ screens:
         description: "Adds a script in Steam to boot Windows which is useful for dual-boot setups"
         default: false
         script: "ujust setup-boot-windows-steam"
+      - id: "virtual-audio-channels"
+        title: "Virtual Audio Channels"
+        description: "Create or remove PipeWire virtual sinks for separate Game, Voice, Browser, and Music audio routing."
+        default: false
+        status_script: "ujust setup-virtual-channels status"
+        options:
+          - id: "create"
+            label: "Enable"
+            script: 'ujust setup-virtual-channels create; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "remove"
+            label: "Remove"
+            script: 'ujust setup-virtual-channels remove; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "virtual-headphone-surround"
+        title: "Virtual Headphone Surround"
+        description: "Enable or disable a PipeWire virtual 7.1 headphone surround sink."
+        default: false
+        status_script: "ujust setup-virtual-surround status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: 'ujust setup-virtual-surround enable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable"
+            script: 'ujust setup-virtual-surround disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "configure-beesd"
         title: "BTRFS Deduplication"
         description: "Configure beesd deduplication for BTRFS filesystems."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -639,3 +639,8 @@ screens:
         description: "Kills all processes related to wine and proton."
         default: false
         script: "ujust fix-proton-hang"
+      - id: "fix-reset-steam"
+        title: "Reset Steam Installation"
+        description: "Resets the Steam installation by deleting Steams local files. Does not delete game or save files!"
+        default: false
+        script: "ujust fix-reset-steam"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -442,11 +442,11 @@ screens:
   - title: "Game Fixes"
     description: "Fixes for specific games"
     actions:
-      - id: "geforce-now"
-        title: "GeForce Now"
-        description: "Cloud gaming service"
+      - id: "fix-gmod"
+        title: "Garry's Mod Patch Tool"
+        description: "Patch Garry's Mod's 64-bit beta to work properly on Linux."
         default: false
-        script: "ujust get-media-app \"GeForce Now\""
+        script: "ujust fix-gmod"
   - title: "Media Apps"
     description: "Entertainment and streaming services"
     actions:

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -382,6 +382,18 @@ screens:
           - id: "virt-off"
             label: "Disable"
             script: 'ujust setup-virtualization virt-off; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "save-panics"
+        title: "Save Kernel Panics"
+        description: "Enable or disable ramoops so kernel panic details can be recovered after reboot."
+        default: false
+        status_script: "ujust toggle-save-panics status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: 'ujust toggle-save-panics enable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable"
+            script: 'ujust toggle-save-panics disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "configure-beesd"
         title: "BTRFS Deduplication"
         description: "Configure beesd deduplication for BTRFS filesystems."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -371,6 +371,18 @@ screens:
           - id: "disable"
             label: "Disable"
             script: 'ujust setup-virtual-surround disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "bluetooth-headset-mic"
+        title: "Bluetooth Headset Audio Fix"
+        description: "Prevent Bluetooth devices from switching to low-quality headset mode by disabling their mic profile."
+        default: false
+        status_script: "ujust toggle-bt-mic status"
+        options:
+          - id: "enable"
+            label: "Enable Fix"
+            script: 'ujust toggle-bt-mic enable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable Fix"
+            script: 'ujust toggle-bt-mic disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "virtualization"
         title: "Virtualization"
         description: "Install or remove virt-manager and configure host virtualization support."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -371,6 +371,17 @@ screens:
           - id: "disable"
             label: "Disable"
             script: 'ujust setup-virtual-surround disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "virtualization"
+        title: "Virtualization"
+        description: "Install or remove virt-manager and configure host virtualization support."
+        default: false
+        options:
+          - id: "virt-on"
+            label: "Enable"
+            script: 'ujust setup-virtualization virt-on; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "virt-off"
+            label: "Disable"
+            script: 'ujust setup-virtualization virt-off; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "configure-beesd"
         title: "BTRFS Deduplication"
         description: "Configure beesd deduplication for BTRFS filesystems."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -170,6 +170,24 @@ screens:
           - id: "uninstall"
             label: "Uninstall"
             script: 'ujust install-displaylink uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "openrazer"
+        title: "OpenRazer"
+        description: "Install OpenRazer support for Razer gaming hardware."
+        default: false
+        status_script: "ujust install-openrazer status"
+        options:
+          - id: "install-razer-genie"
+            label: "Install with Razer Genie"
+            script: 'ujust install-openrazer install-razer-genie; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "install-polychromatic"
+            label: "Install with Polychromatic"
+            script: 'ujust install-openrazer install-polychromatic; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "install"
+            label: "Install Without Frontend"
+            script: 'ujust install-openrazer install; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "uninstall"
+            label: "Uninstall"
+            script: 'ujust install-openrazer uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "openrgb"
         title: "OpenRGB"
         description: "Open source RGB lighting control that doesn't depend on manufacturer software"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -722,11 +722,6 @@ screens:
   - title: "Brew"
     description: "Brew Taps and Casks"
     actions:
-      - id: "ublue-tap"
-        title: "Add Universal Blue tap"
-        description: "Adds Universal Blue's Brew tap"
-        default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap'
       - id: "visual-studio-code-linux"
         title: "Install Visual Studio Code"
         description: "Installs Visual Studio Code editor"
@@ -752,6 +747,11 @@ screens:
         description: "Installs VSCodium editor"
         default: false
         script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask vscodium-linux'
+      - id: "android-platform-tools"
+        title: "Install Android Platform Tools"
+        description: "Installs Android Platform Tools"
+        default: false
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install --cask android-platform-tools'
   - title: "Manage PC"
     description: "System updates and configuration"
     actions:

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -54,6 +54,18 @@ screens:
           - id: "uninstall"
             label: "Uninstall"
             script: "ujust get-decky-lossless-scaling uninstall"
+      - id: "lsfg-vk"
+        title: "Lossless Scaling Vulkan Layer"
+        description: "Install the lsfg-vk Vulkan layer for Lossless Scaling compatibility in Linux."
+        default: false
+        status_script: "ujust get-lsfg status"
+        options:
+          - id: "install"
+            label: "Install"
+            script: 'ujust get-lsfg install; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "uninstall"
+            label: "Uninstall"
+            script: 'ujust get-lsfg uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "emudeck"
         title: "EmuDeck"
         description: "A utility for installing and configuring emulators on the Steam Deck"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -634,3 +634,8 @@ screens:
         description: "Runs a one-minute CPU benchmark."
         default: false
         script: 'ujust benchmark; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "fix-proton-hang"
+        title: "Kill Wine/Proton Processes"
+        description: "Kills all processes related to wine and proton."
+        default: false
+        script: "ujust fix-proton-hang"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -198,7 +198,7 @@ screens:
             script: "ujust password-feedback off"
       - id: "bazzite-cli"
         title: "Bazzite CLI"
-        description: "Enable or disable the Bazzite CLI shell enhancements."
+        description: "Enable a Bluefin-style CLI experience."
         default: false
         options:
           - id: "enable"
@@ -582,3 +582,8 @@ screens:
         description: "Collects system information and logs, then gives you links to share with support for troubleshooting."
         default: false
         script: 'ujust get-logs; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "benchmark"
+        title: "Run System Benchmark"
+        description: "Runs a one-minute CPU benchmark."
+        default: false
+        script: 'ujust benchmark; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -383,6 +383,33 @@ screens:
           - id: "disable"
             label: "Disable Fix"
             script: 'ujust toggle-bt-mic disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "intel-i915-sleep-fix"
+        title: "Intel i915 Sleep Fix"
+        description: "Manage the i915.enable_dc power-saving setting for older Intel GPUs with suspend issues."
+        default: false
+        status_script: "ujust toggle-i915-sleep-fix status"
+        options:
+          - id: "auto"
+            label: "Set to Auto (i915.enable_dc=-1)"
+            script: 'ujust toggle-i915-sleep-fix auto; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable Power Saving (i915.enable_dc=0)"
+            script: 'ujust toggle-i915-sleep-fix disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "level-1"
+            label: "Set to Level 1 (i915.enable_dc=1)"
+            script: 'ujust toggle-i915-sleep-fix level-1; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "level-2"
+            label: "Set to Level 2 (i915.enable_dc=2)"
+            script: 'ujust toggle-i915-sleep-fix level-2; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "level-3"
+            label: "Set to Level 3 (i915.enable_dc=3)"
+            script: 'ujust toggle-i915-sleep-fix level-3; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "level-4"
+            label: "Set to Level 4 (i915.enable_dc=4)"
+            script: 'ujust toggle-i915-sleep-fix level-4; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "unset"
+            label: "Unset Parameter"
+            script: 'ujust toggle-i915-sleep-fix unset; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "virtualization"
         title: "Virtualization"
         description: "Install or remove virt-manager and configure host virtualization support."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -66,6 +66,18 @@ screens:
           - id: "uninstall"
             label: "Uninstall"
             script: 'ujust get-lsfg uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "boxtron"
+        title: "Boxtron"
+        description: "Installs Boxtron on a Fedora distrobox and exports it."
+        default: false
+        status_script: "ujust install-boxtron status"
+        options:
+          - id: "install"
+            label: "Install"
+            script: 'ujust install-boxtron install; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "uninstall"
+            label: "Uninstall"
+            script: 'ujust install-boxtron uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "emudeck"
         title: "EmuDeck"
         description: "A utility for installing and configuring emulators on the Steam Deck"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -90,6 +90,18 @@ screens:
           - id: "portal"
             label: "Open Portal"
             script: "ujust setup-sunshine portal"
+      - id: "cockpit"
+        title: "Cockpit"
+        description: "Enable or disable the Cockpit web interface for system management."
+        default: false
+        status_script: "ujust cockpit status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: "ujust cockpit enable"
+          - id: "disable"
+            label: "Disable"
+            script: "ujust cockpit disable"
       - id: "waydroid"
         title: "Waydroid"
         description: "Android app compatibility layer for Linux"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -652,6 +652,11 @@ screens:
         description: "Reset Bazzite layering to Default (Only resets layers NOT user data)" 
         default: false
         script: "rpm-ostree reset"
+      - id: "cancel-pending-deployment"
+        title: "Cancel Pending Deployment"
+        description: "Remove a pending rpm-ostree deployment that you do not want to boot into."
+        default: false
+        script: 'rpm-ostree cleanup -p; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "Reboot to UEFI"
         title: "Reboot to UEFI"
         description: "Reboot into the UEFI settings menu, useful for changing boot order or other firmware settings."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -705,6 +705,11 @@ screens:
         description: "Runs a one-minute CPU benchmark."
         default: false
         script: 'ujust benchmark; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "restart-pipewire"
+        title: "Restart PipeWire"
+        description: "Restart the user PipeWire audio service."
+        default: false
+        script: 'ujust restart-pipewire; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "fix-proton-hang"
         title: "Kill Wine/Proton Processes"
         description: "Kills all processes related to wine and proton."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -1,20 +1,8 @@
 title: Bazzite Portal
-screens:        
-  - title: "Setting up Bazzite"
+screens:
+  - title: "App Install"
     description: "Core system components and utilities"
     actions:
-      - id: "iwd"
-        title: "iwd"
-        description: "Enable or disable iwd as the Wi-Fi backend instead of wpa_supplicant."
-        default: false
-        status_script: "ujust iwd status"
-        options:
-          - id: "enable"
-            label: "Enable"
-            script: "ujust iwd enable"
-          - id: "disable"
-            label: "Disable"
-            script: "ujust iwd disable"
       - id: "decky-loader"
         title: "Decky Loader"
         description: "A plugin loader for the Steam Deck"
@@ -146,9 +134,45 @@ screens:
           - id: "uninstall"
             label: "Uninstall"
             script: "ujust resilio-sync uninstall"
-  - title: "Customizations and Tweaks"
+      - id: "tailscale"
+        title: "Tailscale"
+        description: "Enable or disable the Tailscale service for mesh VPN support."
+        default: false
+        status_script: "ujust tailscale status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: "ujust tailscale enable"
+          - id: "disable"
+            label: "Disable"
+            script: "ujust tailscale disable"
+      - id: "steamcmd"
+        title: "SteamCMD"
+        description: "Command-line version of the Steam client for dedicated servers and game downloads"
+        default: false
+        status_script: "ujust get-steamcmd status"
+        options:
+          - id: "install"
+            label: "Install"
+            script: "ujust get-steamcmd install"
+          - id: "uninstall"
+            label: "Uninstall"
+            script: "ujust get-steamcmd uninstall"
+  - title: "System Fixes"
     description: "System configurations and enhancements"
     actions:
+      - id: "iwd"
+        title: "iwd"
+        description: "Enable or disable iwd as the Wi-Fi backend instead of wpa_supplicant."
+        default: false
+        status_script: "ujust iwd status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: "ujust iwd enable"
+          - id: "disable"
+            label: "Disable"
+            script: "ujust iwd disable"
       - id: "add-input-group"
         title: "Add input group to current user"
         description: "Adds the input group to your current user. Required by certain controller drivers."
@@ -312,30 +336,6 @@ screens:
           - id: "disable"
             label: "Disable"
             script: "ujust ssh disable"
-      - id: "tailscale"
-        title: "Tailscale"
-        description: "Enable or disable the Tailscale service for mesh VPN support."
-        default: false
-        status_script: "ujust tailscale status"
-        options:
-          - id: "enable"
-            label: "Enable"
-            script: "ujust tailscale enable"
-          - id: "disable"
-            label: "Disable"
-            script: "ujust tailscale disable"
-      - id: "steamcmd"
-        title: "SteamCMD"
-        description: "Command-line version of the Steam client for dedicated servers and game downloads"
-        default: false
-        status_script: "ujust get-steamcmd status"
-        options:
-          - id: "install"
-            label: "Install"
-            script: "ujust get-steamcmd install"
-          - id: "uninstall"
-            label: "Uninstall"
-            script: "ujust get-steamcmd uninstall"
       - id: "global-fsr4"
         title: "Global FSR4 Upgrade (RDNA4)"
         description: "Enable or disable the global Proton FSR4 upgrade on RDNA4 GPUs; upgrades FSR 3.1+ to FSR 4 on Proton 10 or GE 10-25 or later."
@@ -381,7 +381,10 @@ screens:
           - id: "disable"
             label: "Disable"
             script: "ujust reisub disable"
-  - title: "Media Applications"
+  - title: "Game Fixes"
+    description: "Fixes for specific games"
+    actions:
+  - title: "Media Apps"
     description: "Entertainment and streaming services"
     actions:
       - id: "xbox-cloud-gaming"
@@ -522,7 +525,7 @@ screens:
         description: "Installs VSCodium editor"
         default: false
         script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask vscodium-linux'
-  - title: "System Management"
+  - title: "Manage PC"
     description: "System updates and configuration"
     actions:
       - id: "update-bazzite"
@@ -530,39 +533,36 @@ screens:
         description: "Updates Bazzite, Flatpaks, firmware, and more"
         default: false
         script: "ujust update"
-        
       - id: "rebase-bazzite-stable"
         title: "Rebase Bazzite (stable)"
         description: "Rebase Bazzite to the stable track"
         default: false
         script: "brh rebase stable -y && reboot"
-
       - id: "rebase-bazzite-testing"
         title: "Rebase Bazzite (testing)"
         description: "Rebase Bazzite to the testing track"
         default: false
         script: "brh rebase testing -y && reboot"
-
       - id: "rollback-bazzite"
         title: "Rollback Bazzite"
         description: "Rollback to the previous Bazzite deployment"
         default: false
         script: "brh rollback -y && reboot"
-
       - id: "reset-bazzite"
         title: "Reset Bazzite"
         description: "Reset Bazzite layering to Default (Only resets layers NOT user data)" 
         default: false
         script: "rpm-ostree reset"
-
-      - id: "get-logs"
-        title: "Collect Troubleshooting Logs"
-        description: "Collects system information and logs, then gives you links to share with support for troubleshooting."
-        default: false
-        script: 'ujust get-logs; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
-      
       - id: "Reboot to UEFI"
         title: "Reboot to UEFI"
         description: "Reboot into the UEFI settings menu, useful for changing boot order or other firmware settings."
         default: false
         script: "systemctl reboot --firmware-setup"
+  - title: "Troubleshooting"
+    description: "Tools and utilities for diagnosing and fixing issues"
+    actions:
+      - id: "get-logs"
+        title: "Collect Troubleshooting Logs"
+        description: "Collects system information and logs, then gives you links to share with support for troubleshooting."
+        default: false
+        script: 'ujust get-logs; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -158,6 +158,18 @@ screens:
           - id: "uninstall"
             label: "Uninstall"
             script: 'ujust install-coolercontrol uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "displaylink"
+        title: "DisplayLink"
+        description: "Install DisplayLink support for laptop docks and USB display adapters."
+        default: false
+        status_script: "ujust install-displaylink status"
+        options:
+          - id: "install"
+            label: "Install"
+            script: 'ujust install-displaylink install; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "uninstall"
+            label: "Uninstall"
+            script: 'ujust install-displaylink uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "openrgb"
         title: "OpenRGB"
         description: "Open source RGB lighting control that doesn't depend on manufacturer software"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -196,6 +196,17 @@ screens:
           - id: "off"
             label: "Hide Password Asterisks"
             script: "ujust password-feedback off"
+      - id: "bazzite-cli"
+        title: "Bazzite CLI"
+        description: "Enable or disable the Bazzite CLI shell enhancements."
+        default: false
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && ujust bazzite-cli enable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable"
+            script: 'ujust bazzite-cli disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "hide-grub"
         title: "GRUB Menu Visibility"
         description: "Choose when the GRUB menu appears at boot."
@@ -384,6 +395,11 @@ screens:
   - title: "Game Fixes"
     description: "Fixes for specific games"
     actions:
+      - id: "geforce-now"
+        title: "GeForce Now"
+        description: "Cloud gaming service"
+        default: false
+        script: "ujust get-media-app \"GeForce Now\""
   - title: "Media Apps"
     description: "Entertainment and streaming services"
     actions:

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -146,6 +146,18 @@ screens:
           - id: "helper"
             label: "Install Helper"
             script: "ujust configure-waydroid helper"
+      - id: "coolercontrol"
+        title: "CoolerControl"
+        description: "View sensors and create fan and pump profiles from available temperature sensors."
+        default: false
+        status_script: "ujust install-coolercontrol status"
+        options:
+          - id: "install"
+            label: "Install"
+            script: 'ujust install-coolercontrol install; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "uninstall"
+            label: "Uninstall"
+            script: 'ujust install-coolercontrol uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "openrgb"
         title: "OpenRGB"
         description: "Open source RGB lighting control that doesn't depend on manufacturer software"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -269,6 +269,11 @@ screens:
         description: "Adds a script in Steam to boot Windows which is useful for dual-boot setups"
         default: false
         script: "ujust setup-boot-windows-steam"
+      - id: "configure-beesd"
+        title: "BTRFS Deduplication"
+        description: "Configure beesd deduplication for BTRFS filesystems."
+        default: false
+        script: 'ujust configure-beesd; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "automounting"
         title: "Automounting"
         description: "Enable or disable automounting of labeled BTRFS/EXT4 partitions under /run/media/system."

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -274,6 +274,18 @@ screens:
         description: "Configure beesd deduplication for BTRFS filesystems."
         default: false
         script: 'ujust configure-beesd; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "watchdog"
+        title: "Watchdog"
+        description: "Enable or disable the hardware watchdog recovery mechanism."
+        default: false
+        status_script: "ujust configure-watchdog status"
+        options:
+          - id: "enable"
+            label: "Enable"
+            script: 'ujust configure-watchdog enable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+          - id: "disable"
+            label: "Disable"
+            script: 'ujust configure-watchdog disable; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
       - id: "snapper"
         title: "Snapshots"
         description: "Enable or disable Snapper snapshots for /var/home."


### PR DESCRIPTION
With this PR I am intergrating the rest of the missing ujusts that were TUI only by adding them to the portal and intergrating actions and ugm TUI wherever was missing and possible.

Full list: 
bazzite-cli
configure-snapshots	
configure-watchdog	
toggle-save-panics	
toggle-bt-mic	
toggle-i915-sleep-fix	
install-coolercontrol	
install-displaylink	
install-openrazer	
install-boxtron	
cockpit
setup-virtual-channels	
setup-virtual-surround	
setup-virtualization	
restore-input-remapper
get-lsfg	
benchmark
configure-beesd
fix-gmod
fix-proton-hang
fix-reset-steam
restart-pipewire
verify-image

Another change is that I reordered the portal tabs and also cleaned up some names then added a new Troubleshooting tab that has a button that directs users to the Bazzite Discord bazzite-help forum channel. 

