### PR TITLE
chore(distrobox): remove bluefin-cli and arch-amdgpupro

### DIFF
--- a/system_files/desktop/shared/etc/distrobox/distrobox.ini
+++ b/system_files/desktop/shared/etc/distrobox/distrobox.ini
@@ -7,14 +7,6 @@
 image=ghcr.io/ublue-os/arch-toolbox:latest
 pull=true
 
-[arch-amdgpupro]
-image=ghcr.io/ublue-os/arch-toolbox-amdgpupro:latest
-pull=true
-
-[bluefin-cli]
-image=ghcr.io/ublue-os/bluefin-cli
-pull=true
-
 [debian]
 image=quay.io/toolbx-images/debian-toolbox:unstable
 pull=true

--- a/system_files/nvidia/shared/etc/distrobox/distrobox.ini
+++ b/system_files/nvidia/shared/etc/distrobox/distrobox.ini
@@ -8,11 +8,6 @@ image=ghcr.io/ublue-os/arch-toolbox:latest
 nvidia=true
 pull=true
 
-[bluefin-cli]
-image=ghcr.io/ublue-os/bluefin-cli
-nvidia=true
-pull=true
-
 [debian]
 image=quay.io/toolbx-images/debian-toolbox:unstable
 nvidia=true


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Both are no longer maintained.

Arch AMDGPU PRO: https://github.com/ublue-os/toolboxes/pull/545

Bluefin-CLI: https://github.com/ublue-os/toolboxes/pull/546