### PR TITLE
chore(just): add rog-control-center rpm to ujust asus

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -305,7 +305,7 @@ asus ACTION="":
             echo "{{ BOLD }}{{ GREEN }}Installed{{ NORMAL }}"
         elif brew_package asusctl-linux || brew_package rog-control-center-linux; then
             echo "{{ BOLD }}{{ YELLOW }}Partially Installed{{ NORMAL }}"
-        elif layered_package asusctl || layered_package asusctl-rog-gui; then
+        elif layered_package asusctl || layered_package asusctl-rog-gui || layered_package rog-control-center; then
             echo "{{ YELLOW }}Installed (layered){{ NORMAL }}"
         else
             echo "{{ RED }}Not Installed{{ NORMAL }}"
@@ -314,7 +314,7 @@ asus ACTION="":
 
     install_asus_tools() {
         layered_packages=()
-        for pkg in asusctl asusctl-rog-gui; do
+        for pkg in asusctl asusctl-rog-gui rog-control-center; do
             if layered_package "$pkg"; then
                 layered_packages+=("$pkg")
             fi
@@ -376,7 +376,7 @@ asus ACTION="":
             fi
         done
 
-        for pkg in asusctl asusctl-rog-gui; do
+        for pkg in asusctl asusctl-rog-gui rog-control-center; do
             if layered_package "$pkg"; then
                 layered_packages+=("$pkg")
             fi


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Apparently there was another RPM package just for ROG Control Center which I somehow missed while researching it. Now it should contain everything

Note: it's needed to get rid of those layers and replace them with Brew casks