### PR TITLE
chore: remove toolbox for gnome

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -195,6 +195,9 @@ RUN --mount=type=cache,dst=/var/cache \
         firefox \
         firefox-langpacks \
         htop && \
+    if grep -q "silverblue" <<< "${BASE_IMAGE_NAME}"; then \
+        dnf5 -y remove toolbox \
+    ; fi && \
     /ctx/cleanup
 
 # Install new packages


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Toolbox was added back for KDE in #4731 so Konsole can see Distrobox containers but this workaround is not needed for Ptyxis