### PR TITLE
fix: enable wakeup for Steam Controller puck

### DIFF
--- a/system_files/deck/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
+++ b/system_files/deck/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
@@ -1,0 +1,3 @@
+# Enable wake from sleep for the Steam Controller Puck.
+# Source: https://www.reddit.com/r/SteamController/s/7ZEteNW6dm
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="28de", ATTR{idProduct}=="1304", TEST=="power/wakeup", ATTR{power/wakeup}="enabled"

--- a/system_files/desktop/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
+++ b/system_files/desktop/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
@@ -1,0 +1,3 @@
+# Enable wake from sleep for the Steam Controller Puck.
+# Source: https://www.reddit.com/r/SteamController/s/7ZEteNW6dm
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="28de", ATTR{idProduct}=="1304", TEST=="power/wakeup", ATTR{power/wakeup}="enabled"


### PR DESCRIPTION
Adds a udev rule to enable wakeup for the Steam Controller Puck.

Tested on -deck gnome variant with Steam controller 2 I just got today. Puck would not wake from s3 no matter in gamescope session nor desktop from controller steam button press but after add and reload of this udev rule, it works like a charm. 

Source: https://www.reddit.com/r/SteamController/s/7ZEteNW6dm