### PR TITLE
fix: align Steam wake rule with Valve upstream

### DIFF
--- a/system_files/deck/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
+++ b/system_files/deck/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
@@ -1,3 +1,3 @@
-# Enable wake from sleep for the Steam Controller Puck.
+# Enable wake from sleep for Valve hardware.
 # Source: https://www.reddit.com/r/SteamController/s/7ZEteNW6dm
-ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="28de", ATTR{idProduct}=="1304", TEST=="power/wakeup", ATTR{power/wakeup}="enabled"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTR{power/wakeup}="enabled"

--- a/system_files/desktop/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
+++ b/system_files/desktop/shared/usr/lib/udev/rules.d/99-steamcontroller-wakeup.rules
@@ -1,3 +1,3 @@
-# Enable wake from sleep for the Steam Controller Puck.
+# Enable wake from sleep for Valve hardware.
 # Source: https://www.reddit.com/r/SteamController/s/7ZEteNW6dm
-ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="28de", ATTR{idProduct}=="1304", TEST=="power/wakeup", ATTR{power/wakeup}="enabled"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTR{power/wakeup}="enabled"


### PR DESCRIPTION
Fixes #4873.

Matches Valve's upstream wake rule, and scopes for not just puck. Controller on usb, Bluetooth, 2015 Steam controller dongle. 

There are a lot more rules here but wanted to keep change focused on the known hardware

https://github.com/ValveSoftware/steam-devices