### PR TITLE
chore: move from altlinux tuner to refine

### DIFF
--- a/installer/gnome_flatpaks/flatpaks
+++ b/installer/gnome_flatpaks/flatpaks
@@ -20,7 +20,7 @@ app/org.gnome.baobab/x86_64/stable
 app/org.gnome.clocks/x86_64/stable
 app/org.gnome.font-viewer/x86_64/stable
 app/org.gnome.Showtime/x86_64/stable
-app/org.altlinux.Tuner/x86_64/stable
+app/page.tesk.Refine/x86_64/stable
 app/com.github.Matoking.protontricks/x86_64/stable
 runtime/com.obsproject.Studio.Plugin.OBSVkCapture/x86_64/stable
 runtime/com.obsproject.Studio.Plugin.Gstreamer/x86_64/stable


### PR DESCRIPTION
Refine is maintained by a GNOME developer, it should also be more up to date than Alt, and its _not_ the fork. I don't really see why to go with Alt Tuner here really

