### PR TITLE
fix(bazaar): update Jellyfin Desktop link

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
@@ -192,7 +192,7 @@ rows:
           - com.spotify.Client
           - com.mastermindzh.tidal-hifi
           - org.videolan.VLC
-          - com.github.iwalton3.jellyfin-media-player
+          - org.jellyfin.JellyfinDesktop
           - tv.plex.PlexDesktop
           - com.plexamp.Plexamp
           - rocks.shy.VacuumTube


### PR DESCRIPTION
Jellyfin Media Player was renamed to Jellyfin Desktop for its v2.0 update. The flatpak identifier was updated as well, breaking our entry in Bazaar under `Curated > Music & Media`. This commit updates the entry to point to the new identifier.