### PR TITLE
chore(topgrade): enable firmware updating

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/topgrade.toml
+++ b/system_files/desktop/shared/usr/share/ublue-os/topgrade.toml
@@ -10,3 +10,6 @@ no_retry = false
 
 [linux]
 rpm_ostree = true
+
+[firmware]
+upgrade = true


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
I've noticed that apparently after updating Topgrade to the latest it now started to check for firmware update but not actually apply them which kinda defeats the purpose of manual updating, this should do the trick. But to be honest I never payed attention to it if it ever did, feel free to close PR if that's not needed