### PR TITLE
chore(ci): replace retry action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -493,7 +493,7 @@ jobs:
           ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
           OUTPUT_IMAGE: ${{ steps.base.outputs.output_image }}
           VERSION: ${{ steps.relabel.outputs.version }}
-          MAX_RETRIES: 3
+          MAX_RETRIES: 5
           WAIT_SECONDS: 15
         run: |
           set -x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -479,44 +479,32 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      # Push the image to GHCR (Image Registry)
-      - name: Push to GHCR
-        id: push
-        if: github.event_name != 'pull_request'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        env:
-          ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
-          OUTPUT_IMAGE: ${{ steps.base.outputs.output_image }}
-          RECHUNK_REF: ${{ steps.rechunk.outputs.ref }}
-          VERSION: ${{ steps.relabel.outputs.version }}
-        with:
-          max_attempts: 3
-          retry_wait_seconds: 15
-          timeout_minutes: 10
-          command: |
-            log_sum() { echo "$1" >> $GITHUB_STEP_SUMMARY; }
-            log_sum '# Push to GHCR result'
-            log_sum '```'
-
-            dest_image="${OUTPUT_IMAGE}:${VERSION}"
-            sudo skopeo copy ${RECHUNK_REF} docker://$dest_image
-            log_sum "$dest_image"
-
-            for tag in ${ALIAS_TAGS}; do
-              dest_image="${OUTPUT_IMAGE}:$tag"
-              sudo skopeo copy ${RECHUNK_REF} docker://$dest_image
-              log_sum "$dest_image"
-            done
-            log_sum '```'
-
-            digest=$(sudo skopeo inspect --format '{{.Digest}}' docker://${OUTPUT_IMAGE}:${VERSION})
-            echo "digest=${digest}" >> $GITHUB_OUTPUT
-
       - name: Install Cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: "v2.6.1"
+
+      # Push the image to GHCR (Image Registry)
+      - name: Push to GHCR
+        id: push
+        if: github.event_name != 'pull_request'
+        env:
+          ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
+          OUTPUT_IMAGE: ${{ steps.base.outputs.output_image }}
+          VERSION: ${{ steps.relabel.outputs.version }}
+          MAX_RETRIES: 3
+          WAIT_SECONDS: 15
+        run: |
+          set -x
+
+          for tag in ${VERSION} ${ALIAS_TAGS}; do
+            for i in $(seq "${MAX_RETRIES}"); do
+              sudo podman push --digestfile=/tmp/digestfile "localhost/chunked-img" "${OUTPUT_IMAGE}:$tag" && break || sleep $((${WAIT_SECONDS} * i));
+            done
+          done
+
+          echo "digest=$(< /tmp/digestfile)" >> $GITHUB_OUTPUT
 
       - name: Sign container image
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -498,11 +498,18 @@ jobs:
         run: |
           set -x
 
+          log_sum() { echo "$1" >> $GITHUB_STEP_SUMMARY; }
+          log_sum '# Push to GHCR result'
+          log_sum '```'
+
           for tag in ${VERSION} ${ALIAS_TAGS}; do
             for i in $(seq "${MAX_RETRIES}"); do
-              sudo podman push --digestfile=/tmp/digestfile "localhost/chunked-img" "${OUTPUT_IMAGE}:$tag" && break || sleep $((${WAIT_SECONDS} * i));
+              sudo podman push --digestfile=/tmp/digestfile "localhost/chunked-img" "${OUTPUT_IMAGE}:$tag" && \
+                log_sum "${OUTPUT_IMAGE}:$tag" && break || sleep $((${WAIT_SECONDS} * i));
             done
           done
+
+          log_sum '```'
 
           echo "digest=$(< /tmp/digestfile)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Retry action doesn't work as intended[1] and skopeo can't extract[2] digest[3] key[4] so replacing the whole step entirely and bringing the code @tulilirockz was using for Zirconium for several months now, slightly adjusted for our needs.

Also moving Cosign install step before the actual image push so users wouldn't end up with unsigned image

[1]: https://github.com/ublue-os/bazzite/actions/runs/25670171643/job/75353034807
[2]: https://github.com/ublue-os/bazzite/actions/runs/25681930815/job/75395592341
[3]: https://github.com/ublue-os/bazzite/actions/runs/25681937840/job/75395492760
[4]: https://github.com/ublue-os/bazzite/actions/runs/25681937840/job/75395492782