### PR TITLE
feat(smb): install mount manager

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -289,6 +289,7 @@ RUN --mount=type=cache,dst=/var/cache \
         wlr-randr \
         gmodpatchtool \
         bazzite-portal \
+        smb-mount-manager \
         ls-iommu && \
     ln -s /dev/null /etc/NetworkManager/dispatcher.d/04-iscsi && \
     systemctl mask iscsi && \


### PR DESCRIPTION
This PR adds smb mount manager to Bazzite so our users will have a better more stable experience adding their shares to the system as both KIO and GIO provide an unstable experience when it comes to SMB shares. 

Mount manager is under my git now and not under ublues org. So it can be treated as a preinstalled app exactly like protonplus for example.

EDIT: PR changed to draft and will be converted to brew if accepted.