### PR TITLE
fix(gnome): prevent injection in Add to Steam Nautilus extension

### DIFF
--- a/spec_files/steamdeck-gnome-presets/steamos-add-to-steam.py
+++ b/spec_files/steamdeck-gnome-presets/steamos-add-to-steam.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from urllib.parse import unquote
 from gi.repository import Nautilus, GObject
 from typing import List
@@ -15,7 +16,7 @@ class AddToSteamExtension(GObject.GObject, Nautilus.MenuProvider):
     def _add_to_steam(self, file: Nautilus.FileInfo) -> None:
         filename = unquote(file.get_uri()[7:])
 
-        os.popen(f'/usr/bin/steamos-add-to-steam "{filename}"')
+        subprocess.Popen(['/usr/bin/steamos-add-to-steam', filename])
 
     def menu_activate_cb(
         self,


### PR DESCRIPTION
Replace os.popen() with subprocess.Popen() using an argument list to avoid shell interpretation of filenames containing metacharacters.

os.popen() invokes /bin/sh -c, which interprets shell metacharacters in the filename (quotes, semicolons, backticks, dollar signs). Using subprocess.Popen with a list passes the filename as a single argument directly to execvp, with no shell involved. The context menu label "Add to Steam" implies a benign categorization action, not an operation that could execute arbitrary commands. 
