### PR TITLE
chore(plasmalogin): remove deprecated plasmalogin workaround

### DIFF
--- a/system_files/desktop/kinoite/usr/lib/systemd/system/plasmalogin.service.d/override.conf
+++ b/system_files/desktop/kinoite/usr/lib/systemd/system/plasmalogin.service.d/override.conf
@@ -1,4 +1,0 @@
-# DELETEME: Whenever this fix makes it to fedora.
-# See https://invent.kde.org/plasma/plasma-login-manager/-/commit/a8c752fe28c36fa7d3b95461a7b24ce2d9de7f69
-[Service]
-ExecStartPre=-udevadm settle --timeout=10


### PR DESCRIPTION
Fix for https://github.com/ublue-os/bazzite/issues/4763 now included in upstream Fedora version.