### PR TITLE
feat: add selectable CEC modes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -36,6 +36,8 @@ ARG NVIDIA_BASE="${NVIDIA_BASE:-bazzite}"
 ARG KERNEL_FLAVOR="${KERNEL_FLAVOR:-ogc}"
 ARG KERNEL_VERSION="${KERNEL_VERSION:-6.19.14-ogc5.1.fc44.x86_64}"
 ARG NVIDIA_FLAVOR="${NVIDIA_FLAVOR:-nvidia-open}"
+ARG LINUX_CEC_REF="218fd8194fbf2641b1646ed44d69ef76eb6c57fd"
+ARG INPUTATTACH_CEC_UNITS_REF="cbd910971a6712a7aa6c5e7f5714fd0a4bffc417"
 
 FROM ghcr.io/ublue-os/akmods:${KERNEL_FLAVOR}-${FEDORA_VERSION}-${KERNEL_VERSION} AS akmods
 FROM ghcr.io/ublue-os/akmods-extra:${KERNEL_FLAVOR}-${FEDORA_VERSION}-${KERNEL_VERSION} AS akmods-extra
@@ -43,6 +45,44 @@ FROM ghcr.io/ublue-os/akmods-${NVIDIA_FLAVOR}:${KERNEL_FLAVOR}-${FEDORA_VERSION}
 
 FROM scratch AS ctx
 COPY build_files /
+
+FROM quay.io/fedora/fedora:${FEDORA_VERSION} AS linux-cec-builder
+ARG LINUX_CEC_REF
+RUN dnf5 -y install \
+        cargo \
+        dbus-devel \
+        git \
+        make \
+        pkgconf-pkg-config \
+        rust \
+        systemd-devel \
+        systemd-rpm-macros && \
+    git clone https://gitlab.steamos.cloud/holo/linux-cec.git /tmp/linux-cec && \
+    cd /tmp/linux-cec && \
+    git checkout "${LINUX_CEC_REF}" && \
+    make && \
+    make DESTDIR=/out PREFIX=/usr \
+        UDEV_RULES_DIR=/usr/lib/udev/rules.d \
+        SYSTEMD_USER_UNIT_DIR=/usr/lib/systemd/user \
+        DBUS_INTERFACES_DIR=/usr/share/dbus-1/interfaces \
+        DBUS_SESSION_BUS_SERVICES_DIR=/usr/share/dbus-1/services \
+        install && \
+    rm -rf /tmp/linux-cec /var/cache/dnf /var/log/dnf*
+
+FROM quay.io/fedora/fedora:${FEDORA_VERSION} AS inputattach-cec-units-builder
+ARG INPUTATTACH_CEC_UNITS_REF
+RUN dnf5 -y install \
+        git \
+        make \
+        pkgconf-pkg-config && \
+    git clone https://gitlab.steamos.cloud/holo/inputattach-cec-units.git /tmp/inputattach-cec-units && \
+    cd /tmp/inputattach-cec-units && \
+    git checkout "${INPUTATTACH_CEC_UNITS_REF}" && \
+    make DESTDIR=/out PREFIX=/usr \
+        UDEV_RULES_DIR=/usr/lib/udev/rules.d \
+        SYSTEMD_SYSTEM_UNIT_DIR=/usr/lib/systemd/system \
+        install && \
+    rm -rf /tmp/inputattach-cec-units /var/cache/dnf /var/log/dnf*
 
 ################
 # DESKTOP BUILDS
@@ -60,6 +100,8 @@ ARG VERSION_TAG="${VERSION_TAG}"
 ARG VERSION_PRETTY="${VERSION_PRETTY}"
 
 COPY system_files/desktop/shared/ system_files/desktop/${BASE_IMAGE_NAME}/ /
+COPY --from=linux-cec-builder /out/ /
+COPY --from=inputattach-cec-units-builder /out/ /
 RUN find /usr/share/ublue-os/docs -type f -exec setfattr -n user.component -v "ublue-docs" {} +
 
 # Install needed firmware blobs
@@ -255,6 +297,7 @@ RUN --mount=type=cache,dst=/var/cache \
         xdotool \
         wmctrl \
         libcec \
+        linuxconsoletools \
         v4l-utils \
         yad \
         f3 \

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -78,28 +78,6 @@ enable-ryzenadj-max-performance:
     sudo systemctl enable max-perf-boot.service
     echo 'Installation complete. Reboot to take effect'
 
-alias toggle-password-feedback := password-feedback
-
-# Manage password prompt feedback in terminal, where sudo password prompts will display asterisks when enabled
-password-feedback ACTION="":
-    #!/usr/bin/bash
-    PWFEEDBACK_FILE="/etc/sudoers.d/enable-pwfeedback"
-    OPTION={{ ACTION }}
-
-    if [ "$OPTION" = "on" ]; then
-      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
-      echo "enabled, restart terminal to see changes"
-    elif [ "$OPTION" = "off" ]; then
-      sudo rm -f $PWFEEDBACK_FILE
-      echo "disabled pwfeedback. restart your terminal to see changes"
-    elif sudo test -f $PWFEEDBACK_FILE; then
-      sudo rm -f $PWFEEDBACK_FILE
-      echo "disabled pwfeedback. restart your terminal to see changes"
-    else
-      echo 'Defaults pwfeedback' | sudo tee $PWFEEDBACK_FILE
-      echo "enabled, restart terminal to see changes"
-    fi
-
 # disables ryzenadj --max-performance on AC power
 disable-ryzenadj-max-performance:
     #/bin/bash

--- a/system_files/desktop/shared/etc/default/cec-control
+++ b/system_files/desktop/shared/etc/default/cec-control
@@ -1,3 +1,4 @@
+CEC_MODE=dgpu
 CEC_TVID=0
 CEC_WAKE=true
 CEC_SETSOURCE=true

--- a/system_files/desktop/shared/usr/bin/cec-control
+++ b/system_files/desktop/shared/usr/bin/cec-control
@@ -1,0 +1,100 @@
+#!/usr/bin/bash
+ACTION="$1"
+
+source /etc/default/cec-control
+
+# Only the dGPU/external-adapter mode should use this legacy script. Native
+# mode is handled by cecd/SteamOS Manager and must not race this script.
+CEC_MODE=${CEC_MODE:-dgpu}
+if [[ "$CEC_MODE" == "native" || "$CEC_MODE" == "cecd" ]]; then
+    exit 0
+fi
+
+# OVERRIDE WITH DEFAULTS IF NOT SET
+CEC_TVID=${CEC_TVID:-0}
+CEC_WAKE=${CEC_WAKE:-true}
+CEC_SETSOURCE=${CEC_SETSOURCE:-true}
+CEC_ONPOWEROFF_STANDBY=${CEC_ONPOWEROFF_STANDBY:-true}
+CEC_ONSLEEP_STANDBY=${CEC_ONSLEEP_STANDBY:-false}
+CEC_OSD_NAME=${CEC_OSD_NAME:-$(hostname)}
+
+# Auto-detect which CEC backend to use
+# If /dev/cec* exists -> kernel CEC (GPU native) -> use cec-ctl
+# If no /dev/cec* -> Pulse-Eight USB adapter -> use libcec
+USE_KERNEL_CEC=false
+CEC_DEVICE=""
+
+# Check for kernel CEC devices
+for cec_dev in /dev/cec*; do
+    if [[ -e "$cec_dev" ]]; then
+        USE_KERNEL_CEC=true
+        CEC_DEVICE="$cec_dev"
+        break
+    fi
+done
+
+args=()
+args+=( "--single-command" )
+args+=( "--log-level 1" )
+args+=( "--osd-name $CEC_OSD_NAME" )
+
+# Conditionally apply a port number override if one is set
+[[ -n "$CEC_PORT_NUMBER" ]] && args+=( "--port $CEC_PORT_NUMBER" )
+
+# Helper functions to send activate and standby messages to the CEC bus
+# We loop through TVIDs to cover cases where you might have multiple devices
+# to control (eg: a TV, an audio system, and some sort of tuner device)
+function perform_standby {
+    if [ "$USE_KERNEL_CEC" = true ]; then
+        # Kernel CEC path
+        cec-ctl -d "$CEC_DEVICE" --playback 2>/dev/null || true
+        
+        for id in $CEC_TVID; do
+            cec-ctl -d "$CEC_DEVICE" --to "$id" --standby 2>/dev/null || \
+                echo "Warning: Failed to send standby to CEC device $id" >&2
+        done
+    else
+        # libcec path
+        for id in $CEC_TVID; do
+            echo "standby $id" | cec-client ${args[@]}
+        done
+    fi
+}
+
+function perform_activate {
+    if [ "$USE_KERNEL_CEC" = true ]; then
+        # Kernel CEC path
+        cec-ctl -d "$CEC_DEVICE" --playback 2>/dev/null || true
+        
+        for id in $CEC_TVID; do
+            cec-ctl -d "$CEC_DEVICE" --to "$id" --image-view-on 2>/dev/null || \
+                echo "Warning: Failed to send image-view-on to CEC device $id" >&2
+        done
+        
+        if [ "$CEC_SETSOURCE" = true ]; then
+            # Get our physical address if we are setting source
+            local phys_addr=$(cec-ctl -d "$CEC_DEVICE" 2>/dev/null | grep "Physical Address" | awk '{print $4}')
+            if [[ -n "$phys_addr" ]]; then
+                cec-ctl -d "$CEC_DEVICE" -s --active-source phys-addr="$phys_addr" 2>/dev/null || true
+            fi
+        fi
+    else
+        # libcec path
+        for id in $CEC_TVID; do
+            echo "on $id" | cec-client ${args[@]}
+        done
+
+        if [ "$CEC_SETSOURCE" = true ]; then
+            echo "as" | cec-client ${args[@]}
+        fi
+    fi
+}
+
+# Run specified actions
+if [ "${ACTION}" = "onboot" ] && [ "$CEC_WAKE" = true ]; then
+    perform_activate
+elif [ "${ACTION}" = "onpoweroff" ] && [ "$CEC_ONPOWEROFF_STANDBY" = true ]; then
+    perform_standby
+elif [ "${ACTION}" = "onsleep" ] && [ "$CEC_ONSLEEP_STANDBY" = true ]; then
+    perform_standby
+fi

--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onboot.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onboot.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run CEC actions on boot
+After=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/cec-control onboot
+
+[Install]
+WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target

--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onpoweroff.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onpoweroff.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run CEC actions for poweroff
+DefaultDependencies=no
+Before=systemd-poweroff.service poweroff.target
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/cec-control onpoweroff
+
+[Install]
+WantedBy=poweroff.target

--- a/system_files/desktop/shared/usr/lib/systemd/system/cec-onsleep.service
+++ b/system_files/desktop/shared/usr/lib/systemd/system/cec-onsleep.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run CEC actions for sleep
+DefaultDependencies=no
+Before=systemd-suspend.service systemd-hibernate.service systemd-hybrid-sleep.service systemd-suspend-then-hibernate.service sleep.target
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/cec-control onsleep
+
+[Install]
+WantedBy=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target

--- a/system_files/desktop/shared/usr/lib/udev/rules.d/99-cec-bluetooth.rules
+++ b/system_files/desktop/shared/usr/lib/udev/rules.d/99-cec-bluetooth.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="bluetooth", RUN+="/usr/bin/cec-control onboot"

--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -605,6 +605,159 @@ steam-icons ACTION="":
       ;;
     esac
 
+alias cec-backend := cec-mode
+
+# Select the HDMI-CEC implementation. dGPU mode keeps the libcec/cec-ctl event services for external adapters. Native mode uses Valve's cecd backend for devices with native kernel CEC.
+cec-mode ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+
+    CONFIG_FILE="/etc/default/cec-control"
+    CECD_NATIVE_CONFIG="$HOME/.config/cecd/config.d/98-bazzite-cec-mode.toml"
+    DGPU_UNITS=(cec-onboot.service cec-onsleep.service cec-onpoweroff.service)
+    NATIVE_UNITS=(cecd.service steamos-manager-configure-cecd.service)
+    INPUTATTACH_UNITS=(pulse8-cec-inputattach@.service rainshadow-cec-inputattach@.service)
+
+    set_cec_mode() {
+      local mode="$1"
+      if [[ -f "$CONFIG_FILE" ]] && grep -q '^CEC_MODE=' "$CONFIG_FILE"; then
+        sudo sed -i "s/^CEC_MODE=.*/CEC_MODE=$mode/" "$CONFIG_FILE"
+      else
+        echo "CEC_MODE=$mode" | sudo tee -a "$CONFIG_FILE" > /dev/null
+      fi
+    }
+
+    write_cecd_native_config() {
+      mkdir -p "$(dirname "$CECD_NATIVE_CONFIG")"
+      printf '%s\n' \
+        '# Bazzite CEC Native mode defaults.' \
+        '# SteamOS Manager writes wake_tv/uinput state to 99-steamos-manager.toml.' \
+        '# Keep suspend_tv here because SteamOS Manager does not currently expose it.' \
+        'logical_address = "playback"' \
+        'suspend_tv = true' \
+        'allow_standby = false' \
+        > "$CECD_NATIVE_CONFIG"
+    }
+
+    remove_cecd_native_config() {
+      rm -f "$CECD_NATIVE_CONFIG"
+    }
+
+    has_user_unit() {
+      systemctl --user list-unit-files "$1" --no-legend 2>/dev/null | grep -q "^$1"
+    }
+
+    is_enabled() {
+      systemctl is-enabled "$1" >/dev/null 2>&1
+    }
+
+    user_is_enabled() {
+      systemctl --user is-enabled "$1" >/dev/null 2>&1
+    }
+
+    get_status_token() {
+      if user_is_enabled cecd.service; then
+        echo "native"
+      elif is_enabled cec-onboot.service || is_enabled cec-onsleep.service || is_enabled cec-onpoweroff.service; then
+        echo "dgpu"
+      else
+        echo "disabled"
+      fi
+    }
+
+    print_status() {
+      case "$(get_status_token)" in
+        native)
+          echo "Native"
+          ;;
+        dgpu)
+          echo "dGPU"
+          ;;
+        *)
+          echo "Disabled"
+          ;;
+      esac
+    }
+
+    enable_dgpu_mode() {
+      sudo -v || exit 1
+      echo "Switching HDMI-CEC to dGPU mode..."
+      systemctl --user disable --now "${NATIVE_UNITS[@]}" >/dev/null 2>&1 || true
+      sudo systemctl stop 'pulse8-cec-inputattach@*.service' 'rainshadow-cec-inputattach@*.service' >/dev/null 2>&1 || true
+      sudo systemctl mask "${INPUTATTACH_UNITS[@]}" >/dev/null 2>&1 || true
+      remove_cecd_native_config
+      set_cec_mode dgpu
+      sudo systemctl unmask "${DGPU_UNITS[@]}" >/dev/null 2>&1 || true
+      sudo systemctl daemon-reload
+      sudo systemctl enable "${DGPU_UNITS[@]}"
+      sudo systemctl start cec-onboot.service || true
+      echo -e "HDMI-CEC is now using ${green}${bold}dGPU mode${normal}."
+      echo "This uses /usr/bin/cec-control with libcec or cec-ctl for external/dGPU CEC adapters."
+    }
+
+    enable_native_mode() {
+      if ! command -v cecd >/dev/null 2>&1; then
+        echo -e "${red}${bold}Error:${normal} /usr/bin/cecd was not found."
+        echo "Native mode requires Valve's linux-cec/cecd binary package. Leaving the current CEC mode unchanged."
+        exit 1
+      fi
+      if ! has_user_unit cecd.service; then
+        echo -e "${red}${bold}Error:${normal} cecd.service was not found."
+        echo "Native mode requires the cecd user service. Leaving the current CEC mode unchanged."
+        exit 1
+      fi
+
+      sudo -v || exit 1
+      echo "Switching HDMI-CEC to Native mode..."
+      write_cecd_native_config
+      set_cec_mode native
+      sudo systemctl disable --now "${DGPU_UNITS[@]}" >/dev/null 2>&1 || true
+      sudo systemctl mask "${DGPU_UNITS[@]}" >/dev/null 2>&1 || true
+      sudo systemctl unmask "${INPUTATTACH_UNITS[@]}" >/dev/null 2>&1 || true
+      sudo udevadm control --reload-rules >/dev/null 2>&1 || true
+      sudo udevadm trigger --subsystem-match=tty --action=add >/dev/null 2>&1 || true
+      systemctl --user daemon-reload
+      systemctl --user enable steamos-manager-configure-cecd.service >/dev/null 2>&1 || true
+      systemctl --user enable cecd.service
+      systemctl --user start --no-block cecd.service
+      timeout 15 steamosctl set-hdmi-cec-state control-and-wake >/dev/null 2>&1 || true
+      echo -e "HDMI-CEC is now using ${green}${bold}Native mode${normal}."
+      echo "This uses Valve's linux-cec/cecd backend for native kernel CEC devices."
+    }
+
+    OPTION="{{ ACTION }}"
+
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust cec-mode <option>"
+      echo "  status   Print dgpu, native, or disabled"
+      echo "  dgpu     Use restored cec-control services for dGPU/external CEC adapters"
+      echo "  native   Use Valve linux-cec/cecd through SteamOS Manager"
+      exit 0
+    elif [ "$OPTION" == "status" ]; then
+      get_status_token
+      exit $?
+    elif [ -z "$OPTION" ]; then
+      echo -e "${bold}CEC Mode:${normal} $(print_status)"
+      echo ""
+      echo "dGPU mode uses the restored cec-control services for external adapters and dGPU paths."
+      echo "Native mode uses Valve's linux-cec/cecd backend through SteamOS Manager."
+      echo "Only one mode should be active at a time."
+      echo ""
+      OPTION=$(ugum choose "dGPU" "Native" "Exit without saving")
+    fi
+
+    case "$OPTION" in
+      dGPU|dgpu|legacy|Legacy)
+        enable_dgpu_mode
+        ;;
+      Native|native|cecd|CECD)
+        enable_native_mode
+        ;;
+      "Exit without saving"|*)
+        echo "No changes made."
+        ;;
+    esac
+
 alias toggle-cec-sleep := cec-sleep
 
 # Manage CEC_ONSLEEP_STANDBY - Controls whether TV goes to standby when system sleeps. Options: status | enable | disable
@@ -612,9 +765,45 @@ cec-sleep ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     CONFIG_FILE="/etc/default/cec-control"
+    CECD_NATIVE_CONFIG="$HOME/.config/cecd/config.d/98-bazzite-cec-mode.toml"
+
+    get_cec_mode() {
+      grep '^CEC_MODE=' "$CONFIG_FILE" 2>/dev/null | cut -d= -f2
+    }
+
+    get_native_suspend_tv() {
+      local current_value="false"
+      if grep -q '^suspend_tv[[:space:]]*=' "$CECD_NATIVE_CONFIG" 2>/dev/null; then
+        current_value=$(grep '^suspend_tv[[:space:]]*=' "$CECD_NATIVE_CONFIG" | tail -n1 | cut -d= -f2 | tr -d '[:space:]')
+      fi
+      echo "$current_value"
+    }
+
+    set_native_suspend_tv() {
+      local value="$1"
+      mkdir -p "$(dirname "$CECD_NATIVE_CONFIG")"
+      if [[ ! -f "$CECD_NATIVE_CONFIG" ]]; then
+        printf '%s\n' \
+          '# Bazzite CEC Native mode defaults.' \
+          '# SteamOS Manager writes wake_tv/uinput state to 99-steamos-manager.toml.' \
+          '# Keep suspend_tv here because SteamOS Manager does not currently expose it.' \
+          'logical_address = "playback"' \
+          'allow_standby = false' \
+          > "$CECD_NATIVE_CONFIG"
+      fi
+      if grep -q '^suspend_tv[[:space:]]*=' "$CECD_NATIVE_CONFIG"; then
+        sed -i "s/^suspend_tv[[:space:]]*=.*/suspend_tv = $value/" "$CECD_NATIVE_CONFIG"
+      else
+        echo "suspend_tv = $value" >> "$CECD_NATIVE_CONFIG"
+      fi
+      systemctl --user kill -s HUP cecd.service >/dev/null 2>&1 || true
+    }
+
     get_status_token() {
       local current_value="false"
-      if grep -q '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE" 2>/dev/null; then
+      if [[ "$(get_cec_mode)" == "native" ]]; then
+        current_value=$(get_native_suspend_tv)
+      elif grep -q '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE" 2>/dev/null; then
         current_value=$(grep '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE" | cut -d= -f2)
       fi
       if [[ "$current_value" == "true" ]]; then
@@ -661,7 +850,9 @@ cec-sleep ACTION="":
     case "$OPTION" in
       Enable|enable)
         echo "Enabling CEC on-sleep standby..."
-        if grep -q '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE"; then
+        if [[ "$(get_cec_mode)" == "native" ]]; then
+          set_native_suspend_tv true
+        elif grep -q '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE"; then
           sudo sed -i 's/^CEC_ONSLEEP_STANDBY=.*/CEC_ONSLEEP_STANDBY=true/' "$CONFIG_FILE"
         else
           echo 'CEC_ONSLEEP_STANDBY=true' | sudo tee -a "$CONFIG_FILE" > /dev/null
@@ -670,7 +861,9 @@ cec-sleep ACTION="":
         ;;
       Disable|disable)
         echo "Disabling CEC on-sleep standby..."
-        if grep -q '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE"; then
+        if [[ "$(get_cec_mode)" == "native" ]]; then
+          set_native_suspend_tv false
+        elif grep -q '^CEC_ONSLEEP_STANDBY=' "$CONFIG_FILE"; then
           sudo sed -i 's/^CEC_ONSLEEP_STANDBY=.*/CEC_ONSLEEP_STANDBY=false/' "$CONFIG_FILE"
         else
           echo 'CEC_ONSLEEP_STANDBY=false' | sudo tee -a "$CONFIG_FILE" > /dev/null

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -531,6 +531,18 @@ screens:
           - id: "force-enable"
             label: "Force Enable"
             script: "ujust wol force-enable"
+      - id: "cec-mode"
+        title: "CEC Mode"
+        description: "Choose the HDMI-CEC backend. dGPU mode works better for home theater PCs, while Native mode works better for handhelds."
+        default: false
+        status_script: "ujust cec-mode status"
+        options:
+          - id: "dgpu"
+            label: "dGPU"
+            script: "ujust cec-mode dgpu"
+          - id: "native"
+            label: "Native"
+            script: "ujust cec-mode native"
       - id: "cec-sleep-standby"
         title: "CEC Sleep Standby"
         description: "Put TV to standby when system sleeps via HDMI-CEC. Requires a CEC-compatible Device, or Pulse 8 HDMI-CEC adapter."


### PR DESCRIPTION
This keeps the old CEC control path available instead of making SteamOS Manager and cecd the only option.

added a `ujust cec-mode` switch with dGPU and Native modes. dGPU mode enables the “legacy” `cec-control` services for the libcec and cec-ctl path known to work pretty well on HTPCs with things like pulse8 and ugreen adaptors to work around dGPUs not having cec pin 13 wired up. Native mode masks those services and uses Valve's linux-cec/cecd path instead (in my tests with ugreen adaptors and pulse8 adaptor on two diff TVs gives very inconsistent results vs legacy).

Native mode now builds linux-cec from Valve's upstream GitLab repo and includes the inputattach CEC units plus linuxconsoletools so Pulse-Eight style adapters can be attached to the kernel CEC subsystem.

I tested this on a Bazzite Deck GNOME image with a both adapters. cecd starts, sees `/dev/cec0`, and DBus works. Direct native wake and standby calls can work, but the automatic suspend/resume behavior is still not as reliable as the legacy path, seems like they work once per session then refuse to work on subsequent wakes, and sometimes suspend will change to a random HDMI input rather than sleep the TV, so either upstream needs patching or we need to revise our stack. 

That lines up with keeping dGPU mode as a fallback while cecd coverage matures imo, rather than leave this feature broken for an unknown time

also rm a dupe recipe that shared and deck have to fix ujust errors