### PR TITLE
fix(deck): tear down graphical session before launching GNOME oneshot

### DIFF
--- a/system_files/deck/silverblue/usr/bin/gnome-session-oneshot
+++ b/system_files/deck/silverblue/usr/bin/gnome-session-oneshot
@@ -6,6 +6,10 @@ die() { echo >&2 "!! $*"; exit 1; }
 
 SENTINEL_FILE="steamos-session-select"
 
+# Stop any lingering graphical sessions
+systemctl --user stop graphical-session.target || true
+sleep 1
+
 # If we proceed, execute this
 CHAINED_SESSION="/usr/bin/gnome-session"
 # If we decide the sentinel is consumed, execute this command instead and fail


### PR DESCRIPTION
This fixes an issue where switching to desktop mode from Gamescope would crash GNOME with 'A graphical session is already running' by explicitly tearing down the prior session.

Tested via `sudo rpm-ostree usroverlay`.