### PR TITLE
fix(deck): set inputplumber Steam Deck target to vhci deck

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -725,6 +725,7 @@ RUN --mount=type=cache,dst=/var/cache \
         python-vdf \
         python-crcmod && \
     chmod +x /usr/share/gamescope-session-plus/gamescope-session-plus && \
+    sed -i 's/- xbox-elite/- deck/g' /usr/share/inputplumber/devices/50-steam_deck.yaml && \
     git clone https://github.com/bazzite-org/jupiter-dock-updater-bin.git \
         --depth 1 \
         /tmp/jupiter-dock-updater-bin && \


### PR DESCRIPTION
OpenGamepadUI relies on inputplumber to manage inputs, but inputplumber defaults to virtualizing the Steam Deck controller as an Xbox pad. This causes Steam to show incorrect button prompts and breaks native Steam Deck features. By changing the target to 'deck' (VHCI), Steam natively recognizes the virtual controller as a Steam Deck.