### PR TITLE
Re add akmods packages droped during OGC Kernel Migration

### DIFF
--- a/build_files/install-kernel-akmods
+++ b/build_files/install-kernel-akmods
@@ -49,6 +49,7 @@ dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel
     /tmp/rpms/{extra,kmods-extra}/*hid-tmff2*.rpm \
     /tmp/rpms/{extra,kmods-extra}/*t150-driver*.rpm \
     /tmp/rpms/{extra,kmods-extra}/*hid-fanatecff*.rpm \
+    /tmp/rpms/{extra,kmods-extra}/*ryzen-smu*.rpm \
     /tmp/rpms/{extra,kmods-extra}/*sc0710*.rpm \
     /tmp/rpms/{extra,kmods-extra}/*system76*.rpm
 

--- a/build_files/install-kernel-akmods
+++ b/build_files/install-kernel-akmods
@@ -35,6 +35,7 @@ dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel
     /tmp/rpms/{common,kmods}/*framework-laptop*.rpm \
     /tmp/rpms/{common,kmods}/*openrazer*.rpm \
     /tmp/rpms/{common,kmods}/*v4l2loopback*.rpm \
+    /tmp/rpms/{common,kmods}/*wl*.rpm \
     /tmp/rpms/{common,kmods}/*xone*.rpm \
     /tmp/rpms/{common,kmods}/*xpadneo*.rpm
 

--- a/build_files/install-kernel-akmods
+++ b/build_files/install-kernel-akmods
@@ -33,6 +33,7 @@ dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel
 
 /ctx/install-kmods \
     /tmp/rpms/{common,kmods}/*framework-laptop*.rpm \
+    /tmp/rpms/{common,kmods}/*kvmfr*.rpm \
     /tmp/rpms/{common,kmods}/*openrazer*.rpm \
     /tmp/rpms/{common,kmods}/*v4l2loopback*.rpm \
     /tmp/rpms/{common,kmods}/*wl*.rpm \


### PR DESCRIPTION
Resolves #4843 & #4922 

It seems the `wl` akmods package, which adds support for some legacy Broadcom Wi-Fi devices, including the BCM4360, was likely accidentally dropped in the switchover to the OGC Kernel.

https://github.com/ublue-os/bazzite/commit/e54b4555ac66cf4a657b5f18b48e7ca0f9755438#diff-55ff6682381e23108ec5b29f56197cfd0293376de2e26e02062da7f0d7feaa28L35
https://github.com/ublue-os/bazzite/commit/6a419847e6f33fda2cb3afaa26a5cbb9ed774bd2#diff-55ff6682381e23108ec5b29f56197cfd0293376de2e26e02062da7f0d7feaa28R35

It seems the following may have also been unintentionally dropped, so I took the liberty of adding them as well:
`kvmfr` KVM framebuffer relay kernel module for use with Looking Glass
`ryzen-smu` AMD Ryzen SMU (System Management Unit) driver
If either or both were intentionally dropped, let me know, and I will drop the corresponding commits from my PR.