### PR TITLE
chore: bump setup-just to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           tar -xC "$DOCS_DIR" -f artifact.tar
 
       - name: Check just syntax
-        uses: ublue-os/just-action@bda593098a84a84973b002b4377709166a68be52 # v2
+        uses: ublue-os/just-action@25ce72803385f5097fe169ebfc4f1bdec90567ac # main
 
       - name: Pull Images and find versions
         id: labels

--- a/.github/workflows/just-syntax-check.yml
+++ b/.github/workflows/just-syntax-check.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check just syntax
-        uses: ublue-os/just-action@bda593098a84a84973b002b4377709166a68be52 # v2
+        uses: ublue-os/just-action@25ce72803385f5097fe169ebfc4f1bdec90567ac # main


### PR DESCRIPTION
Bumps setup-just to v4 to fix Node 20 deprecation warning.