### PR TITLE
fix(deck): tear down graphical session before launching KDE oneshot

### DIFF
--- a/system_files/deck/kinoite/usr/bin/startplasma-steamos-oneshot
+++ b/system_files/deck/kinoite/usr/bin/startplasma-steamos-oneshot
@@ -7,6 +7,10 @@ die() { echo >&2 "!! $*"; exit 1; }
 SENTINEL_FILE="steamos-session-select"
 SENTINEL_VALUE="wayland"
 
+# Stop any lingering graphical sessions
+systemctl --user stop graphical-session.target || true
+sleep 1
+
 # If we proceed, execute this
 CHAINED_SESSION="/usr/bin/startplasma-wayland"
 


### PR DESCRIPTION
Replicates GNOME PR #4989 for KDE (Kinoite). Stops any lingering user graphical sessions before starting plasma in the oneshot session.