### PR TITLE
chore: pin just-action to v3 tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           tar -xC "$DOCS_DIR" -f artifact.tar
 
       - name: Check just syntax
-        uses: ublue-os/just-action@25ce72803385f5097fe169ebfc4f1bdec90567ac # main
+        uses: ublue-os/just-action@v3
 
       - name: Pull Images and find versions
         id: labels

--- a/.github/workflows/just-syntax-check.yml
+++ b/.github/workflows/just-syntax-check.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check just syntax
-        uses: ublue-os/just-action@25ce72803385f5097fe169ebfc4f1bdec90567ac # main
+        uses: ublue-os/just-action@v3


### PR DESCRIPTION
Pins just-action to the newly created v3 tag.