### PR TITLE
fix: workaround for selinux mprotect on composefs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -260,6 +260,7 @@ RUN --mount=type=cache,dst=/var/cache \
         iwd \
         greenboot \
         greenboot-default-health-checks \
+        ublue-os-selinux-workaround \
         bazzite_updater \
         ScopeBuddy \
         twitter-twemoji-fonts \

--- a/tests/dgoss/tests.d/00-smoke/goss.yaml
+++ b/tests/dgoss/tests.d/00-smoke/goss.yaml
@@ -8,3 +8,7 @@ command:
 file:
   /etc/os-release:
     exists: true
+
+package:
+  ublue-os-selinux-workaround:
+    installed: true


### PR DESCRIPTION
This installs the selinux workaround to narrowly reduce protection on a narrow scope of mmap/mprotect syscalls which are always reproduced by 32-bit games on nvidia GPUs, and have also been reported for at least one 64-bit game even when not on nvidia.

This installs the `ublue-os-selinux-workaround` package added here: https://github.com/ublue-os/packages/pull/1255

This is not a final fix! This is a workaround deemed a reasonable security tradeoff for the context. It should be removed once root cause research results in a better upstream solution.

Relates: https://github.com/ublue-os/akmods/issues/537