### PR TITLE
fix: correct ublue-os-selinux-workarounds typo

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -260,7 +260,7 @@ RUN --mount=type=cache,dst=/var/cache \
         iwd \
         greenboot \
         greenboot-default-health-checks \
-        ublue-os-selinux-workaround \
+        ublue-os-selinux-workarounds \
         bazzite_updater \
         ScopeBuddy \
         twitter-twemoji-fonts \

--- a/tests/dgoss/tests.d/00-smoke/goss.yaml
+++ b/tests/dgoss/tests.d/00-smoke/goss.yaml
@@ -8,7 +8,3 @@ command:
 file:
   /etc/os-release:
     exists: true
-
-package:
-  ublue-os-selinux-workaround:
-    installed: true


### PR DESCRIPTION
Relates: https://github.com/ublue-os/akmods/issues/537
