### PR TITLE
fix(deck): fix: set capture=kms and system_tray=disabled for sunshine-beta install

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -105,6 +105,18 @@ setup-sunshine ACTION="":
           exit 1
         fi
         sudo /usr/libexec/sunshine-postinst
+        SUNSHINE_CONF="$HOME/.config/sunshine/sunshine.conf"
+        mkdir -p "$(dirname "$SUNSHINE_CONF")"
+        if grep -q "^capture" "$SUNSHINE_CONF" 2>/dev/null; then
+          sed -i 's/^capture=.*/capture = kms/' "$SUNSHINE_CONF"
+        else
+          echo "capture = kms" >> "$SUNSHINE_CONF"
+        fi
+        if grep -q "^system_tray" "$SUNSHINE_CONF" 2>/dev/null; then
+          sed -i 's/^system_tray=.*/system_tray = disabled/' "$SUNSHINE_CONF"
+        else
+          echo "system_tray = disabled" >> "$SUNSHINE_CONF"
+        fi
         brew services start sunshine-beta
         override_service
       fi


### PR DESCRIPTION
When installing Sunshine Beta via the Brew package, the service would fail to start because sunshine.conf was missing required configuration for Deck/KMS environments. This fix writes capture = kms and system_tray = disabled to ~/.config/sunshine/sunshine.conf before the service starts, ensuring the beta install works out of the box for Deck users without requiring manual config edits.