### PR TITLE
feat(sunshine): add notice for deck images

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -79,12 +79,20 @@ setup-sunshine ACTION="":
       OPTION=$(Choose "Enable" "Enable Beta" "Update" "Disable Service" "Uninstall" "Open Portal" "Exit")
     fi
     if [[ "${OPTION,,}" =~ ^enable[-[:space:]]beta ]]; then
-      echo "Sunshine does not provide a beta repo for their flatpak."
-      echo "You will need to either: "
-      echo "  1) obtain and install the beta flatpak manually from their GitHub repository;"
-      echo "  2) or proceed with the experimental Brew package."
-      echo "Only proceed if you know what you are doing. Read http://docs.bazzite.gg/Advanced/sunshine/#installing-sunshine-beta to learn more."
-      if confirm "Confirm to proceed with installing the experimental Brew beta package? (This will remove your existing Sunshine installation!)"; then
+      if [[ $(cat /etc/bazzite/image_name) =~ deck ]]; then
+        echo "You are about to install the experimental Sunshine-beta package via brew."
+        echo "If you encounter issues with the Sunshine-beta brew package, consider layering from either the official or community-maintained COPR."
+        echo "Read http://docs.bazzite.gg/Advanced/sunshine/#setting-up-sunshine-on-deck-images to learn more."
+      else
+        echo "This option is primarily intended for users of the Deck image as the flatpak package does not support capture via Kernel Mode Setting."
+        echo "Installing Sunshine stable with the 'Enable' option is going to be better for just about everyone else."
+        echo "You may also use this to install Sunshine Beta as Sunshine does not provide a beta repo for their flatpak."
+        echo "Alternatively, you may also install sunshine by: "
+        echo "  1) obtaining and installing the beta flatpak manually from their GitHub repository;"
+        echo "  2) layering from either the official or community-maintained COPR."
+        echo "Only proceed if you know what you are doing. Read http://docs.bazzite.gg/Advanced/sunshine/#installing-sunshine-beta to learn more."
+      fi
+      if confirm "Confirm to proceed with installing the experimental Brew beta package? (This will remove any existing Sunshine installation!)"; then
         echo "Disabling any previous Sunshine services..."
         systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
         if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
@@ -105,22 +113,34 @@ setup-sunshine ACTION="":
           exit 1
         fi
         sudo /usr/libexec/sunshine-postinst
-        SUNSHINE_CONF="$HOME/.config/sunshine/sunshine.conf"
-        mkdir -p "$(dirname "$SUNSHINE_CONF")"
-        if grep -q "^capture" "$SUNSHINE_CONF" 2>/dev/null; then
-          sed -i 's/^capture=.*/capture = kms/' "$SUNSHINE_CONF"
-        else
-          echo "capture = kms" >> "$SUNSHINE_CONF"
-        fi
-        if grep -q "^system_tray" "$SUNSHINE_CONF" 2>/dev/null; then
-          sed -i 's/^system_tray=.*/system_tray = disabled/' "$SUNSHINE_CONF"
-        else
-          echo "system_tray = disabled" >> "$SUNSHINE_CONF"
+        if [[ $(cat /etc/bazzite/image_name) =~ deck ]]; then
+          echo "Automatically configuring options for streaming on Game Mode..."
+          SUNSHINE_CONF="$HOME/.config/sunshine/sunshine.conf"
+          mkdir -p "$(dirname "$SUNSHINE_CONF")"
+          if grep -q "^capture" "$SUNSHINE_CONF" 2>/dev/null; then
+            sed -i 's/^capture=.*/capture = kms/' "$SUNSHINE_CONF"
+          else
+            echo "capture = kms" >> "$SUNSHINE_CONF"
+          fi
+          if grep -q "^system_tray" "$SUNSHINE_CONF" 2>/dev/null; then
+            sed -i 's/^system_tray=.*/system_tray = disabled/' "$SUNSHINE_CONF"
+          else
+            echo "system_tray = disabled" >> "$SUNSHINE_CONF"
+          fi
         fi
         brew services start sunshine-beta
         override_service
       fi
     elif [[ "${OPTION,,}" =~ ^enable ]]; then
+      if [[ $(cat /etc/bazzite/image_name) =~ deck ]]; then
+        echo "Deck Images make use of Valve's gamescope microcompositor while in Game Mode."
+        echo "To stream on Game Mode, capture using Kernel Mode Setting must be used, which is not supported by the Flatpak package."
+        echo "Read http://docs.bazzite.gg/Advanced/sunshine/#setting-up-sunshine-on-deck-images to learn more."
+        if ! confirm "You may still stream on Desktop Mode by installing the flatpak. Continue?"; then
+          echo "Exiting..."
+          exit 0
+        fi
+      fi
       echo "Disabling any previous Flatpak Sunshine service..."
       systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
       if [[ "$(get_status_token)" == "enable-brew" ]]; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -210,10 +210,15 @@ setup-sunshine ACTION="":
         brew unpin sunshine-beta || true
         brew uninstall sunshine || true
         brew uninstall sunshine-beta || true
+      else
+        systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
+        flatpak run --command=remove-additional-install.sh dev.lizardbyte.app.Sunshine || true
+        if confirm "Also delete ${yellow}Sunshine${n} configurations?"; then
+          flatpak uninstall --delete-data -y dev.lizardbyte.app.Sunshine || true
+        else
+          flatpak uninstall -y dev.lizardbyte.app.Sunshine || true
+        fi
       fi
-      systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
-      flatpak run --command=remove-additional-install.sh dev.lizardbyte.app.Sunshine || true
-      flatpak uninstall --delete-data -y dev.lizardbyte.app.Sunshine || true
       echo "${yellow}Sunshine${n} is now uninstalled."
     elif [[ "${OPTION,,}" =~ ^(portal|open) ]]; then
       echo "Opening ${yellow}Sunshine${n} management portal..."

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -80,27 +80,28 @@ setup-sunshine ACTION="":
     fi
     if [[ "${OPTION,,}" =~ ^enable[-[:space:]]beta ]]; then
       if [[ $(cat /etc/bazzite/image_name) =~ deck ]]; then
-        echo "You are about to install the experimental Sunshine-beta package via brew."
-        echo "If you encounter issues with the Sunshine-beta brew package, consider layering from either the official or community-maintained COPR."
-        echo "Read http://docs.bazzite.gg/Advanced/sunshine/#setting-up-sunshine-on-deck-images to learn more."
+        echo "You are about to install the experimental ${yellow}Sunshine Beta${n} package via brew."
+        echo "If you encounter issues with the ${yellow}Sunshine Beta${n} brew package, consider layering from either the official or community-maintained COPR."
+        echo "Read ${b}http://docs.bazzite.gg/Advanced/sunshine/#setting-up-sunshine-on-deck-images${n} to learn more."
       else
         echo "This option is primarily intended for users of the Deck image as the flatpak package does not support capture via Kernel Mode Setting."
-        echo "Installing Sunshine stable with the 'Enable' option is going to be better for just about everyone else."
-        echo "You may also use this to install Sunshine Beta as Sunshine does not provide a beta repo for their flatpak."
+        echo "Installing ${yellow}Sunshine${n} stable with the ${b}'Enable Sunshine'${n} option is going to be better for just about everyone else."
+        echo "You may also use this to install ${yellow}Sunshine Beta${n} as Sunshine does not provide a beta repo for their flatpak."
         echo "Alternatively, you may also install sunshine by: "
         echo "  1) obtaining and installing the beta flatpak manually from their GitHub repository;"
         echo "  2) layering from either the official or community-maintained COPR."
-        echo "Only proceed if you know what you are doing. Read http://docs.bazzite.gg/Advanced/sunshine/#installing-sunshine-beta to learn more."
+        echo "Only proceed if you know what you are doing. Read ${b}http://docs.bazzite.gg/Advanced/sunshine/#installing-sunshine-beta${n} to learn more."
       fi
-      if confirm "Confirm to proceed with installing the experimental Brew beta package? (This will remove any existing Sunshine installation!)"; then
-        echo "Disabling any previous Sunshine services..."
+      echo ""
+      if confirm "Confirm to proceed with installing the ${b}experimental${n} ${yellow}Sunshine Beta${n} package via brew? (This will remove any existing Sunshine installation!)"; then
+        echo "Disabling any previous ${yellow}Sunshine${n} services..."
         systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
         if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
           echo "Setting up Homebrew environment..."
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         fi
         brew tap LizardByte/homebrew
-        echo "Cleaning up any existing stable Sunshine install before installing beta..."
+        echo "${b}Cleaning${n} up any existing stable ${yellow}Sunshine${n} install before installing beta..."
         flatpak run --command=remove-additional-install.sh dev.lizardbyte.app.Sunshine || true
         flatpak uninstall -y dev.lizardbyte.app.Sunshine || true
         brew services stop sunshine || true
@@ -109,12 +110,12 @@ setup-sunshine ACTION="":
         brew install sunshine-beta
         brew pin sunshine-beta
         if ! sunshine_bin="$(command -v sunshine)"; then
-          echo "sunshine was not found on PATH after installation." >&2
+          echo "${yellow}Sunshine${n} was not found on PATH after installation." >&2
           exit 1
         fi
         sudo /usr/libexec/sunshine-postinst
         if [[ $(cat /etc/bazzite/image_name) =~ deck ]]; then
-          echo "Automatically configuring options for streaming on Game Mode..."
+          echo "${b}Deck Image detected.${n} Automatically configuring options for streaming on Game Mode..."
           SUNSHINE_CONF="$HOME/.config/sunshine/sunshine.conf"
           mkdir -p "$(dirname "$SUNSHINE_CONF")"
           if grep -q "^capture" "$SUNSHINE_CONF" 2>/dev/null; then
@@ -134,14 +135,14 @@ setup-sunshine ACTION="":
     elif [[ "${OPTION,,}" =~ ^enable ]]; then
       if [[ $(cat /etc/bazzite/image_name) =~ deck ]]; then
         echo "Deck Images make use of Valve's gamescope microcompositor while in Game Mode."
-        echo "To stream on Game Mode, capture using Kernel Mode Setting must be used, which is not supported by the Flatpak package."
-        echo "Read http://docs.bazzite.gg/Advanced/sunshine/#setting-up-sunshine-on-deck-images to learn more."
+        echo "To stream on Game Mode, capture using ${b}Kernel Mode Setting${n} must be used, which is not supported by the Flatpak package."
+        echo "Read ${b}http://docs.bazzite.gg/Advanced/sunshine/#setting-up-sunshine-on-deck-images${n} to learn more."
         if ! confirm "You may still stream on Desktop Mode by installing the flatpak. Continue?"; then
           echo "Exiting..."
           exit 0
         fi
       fi
-      echo "Disabling any previous Flatpak Sunshine service..."
+      echo "Disabling any previous Flatpak ${yellow}Sunshine${n} service..."
       systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
       if [[ "$(get_status_token)" == "enable-brew" ]]; then
         if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
@@ -149,7 +150,7 @@ setup-sunshine ACTION="":
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         fi
         brew tap LizardByte/homebrew
-        echo "Cleaning up any existing brew Sunshine installs"
+        echo "Cleaning up any existing brew ${yellow}Sunshine${n} installs"
         brew services stop sunshine-beta || true
         brew unpin sunshine-beta || true
         brew uninstall sunshine-beta || true
@@ -163,11 +164,11 @@ setup-sunshine ACTION="":
 
     elif [[ "${OPTION,,}" =~ ^(update|upgrade) ]]; then
       if [[ "$(get_status_token)" == "uninstall" ]]; then
-        echo "An upgrade was attempted but Sunshine was not installed." >&2
+        echo "An upgrade was attempted but ${yellow}Sunshine${n} was not installed." >&2
         exit 1
       fi
       if [[ "$(journalctl --no-hostname -b 0 -g 'Setting default sink to:')" != "-- No entries --" ]]; then
-        if ! confirm "Updating Sunshine while streaming may leave you with a broken stream if you don't have physical access to the machine! Continue anyways?"; then
+        if ! confirm "Updating ${yellow}Sunshine${n} while streaming may leave you with a broken stream if you don't have physical access to the machine! Continue anyways?"; then
           echo "Exiting..."
           exit 0
         fi
@@ -213,9 +214,9 @@ setup-sunshine ACTION="":
       systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service || true
       flatpak run --command=remove-additional-install.sh dev.lizardbyte.app.Sunshine || true
       flatpak uninstall --delete-data -y dev.lizardbyte.app.Sunshine || true
-      echo "Sunshine is now uninstalled."
+      echo "${yellow}Sunshine${n} is now uninstalled."
     elif [[ "${OPTION,,}" =~ ^(portal|open) ]]; then
-      echo "Opening Sunshine management portal..."
+      echo "Opening ${yellow}Sunshine${n} management portal..."
       xdg-open https://localhost:47990
     elif [[ "${OPTION,,}" =~ ^exit ]]; then
       echo "Exiting without making changes."


### PR DESCRIPTION
- Add and updated notices for deck and desktop users.
- Also adds a conditional to make #5036 activate on deck only.
- Add yellow coloring to any "Sunshine" that refers to the installed package of Sunshine.
- Add bold to links and keywords.
- Add an option to keep data on delete for flatpak installations.