### PR TITLE
chore(portal): Add welcome screen and update actions to Bazzite Portal

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -880,3 +880,5 @@ screens:
         description: "Use the current parameters to generate a new GRUB configuration file. This will probe again for a Windows installation to appear as a boot option."
         default: false
         script: "ujust regenerate-grub"
+
+        

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -1,5 +1,33 @@
 title: Bazzite Portal
 screens:
+  - title: "Welcome"
+    description: "Get to know Bazzite"
+    actions:
+      - id: "bazzite-documentation"
+        title: "Bazzite Documentation"
+        description: "New to Bazzite or Linux? Check out our helpful documentation. An offline version can be access by searching for Documentation in your app menu."
+        default: false
+        script: "xdg-open https://docs.bazzite.gg/"
+      - id: "bazaar"
+        title: "Check Out Bazaar"
+        description: "Your software store! Check out our curated selection for things like Discord, ProtonPlus, or Heroic Game Launcher."
+        default: false
+        script: "yad --info --text \"You can launch Bazaar anytime from your pinned apps or the app menu.\""
+      - id: "bazzite-discord"
+        title: "Get help through Discord"
+        description: "Enter our official server for Bazzite user tech support. Bring in your system logs!"
+        default: false
+        script: "xdg-open https://discord.gg/JQq48bYzrc"
+      - id: "bazzite-discourse"
+        title: "Check out Announcements on our Bazzite Discourse"
+        description: "For the latest big news on Bazzite!"
+        default: false
+        script: "xdg-open https://universal-blue.discourse.group/c/bazzite/"
+      - id: "reddit"
+        title: "Browse our official Reddit community."
+        description: "Come join the conversation, ask questions, and show off your build!"
+        default: false
+        script: "xdg-open https://www.reddit.com/r/Bazzite/"
   - title: "Install Applications"
     description: "Get and configure software"
     actions:
@@ -725,11 +753,6 @@ screens:
   - title: "Troubleshoot"
     description: "Tools and resources for diagnosing and fixing issues"
     actions:
-      - id: "bazzite-discord"
-        title: "Get help through Discord"
-        description: "Enter our official server for Bazzite user tech support. Bring in your system logs!"
-        default: false
-        script: "xdg-open https://discord.gg/JQq48bYzrc"
       - id: "get-logs"
         title: "Collect system logs"
         description: "Gather system records and information into a shareable web page report."


### PR DESCRIPTION
Adds a Welcome tab as the first screen in the Bazzite Portal. Users don't always discover the portal or the documentation on their own, and this gives both more visibility in a natural way. The tab surfaces documentation, Bazaar, and community links for new users landing on Bazzite for the first time.