### PR TITLE
fix(just): add sudo to lsblk in configure-beesd for non-root detection

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-beesd.just
@@ -56,7 +56,7 @@ configure-beesd ACTION="":
 
     while true; do
         # Get btrfs filesystem info
-        mapfile -t raw_btrfs_output < <(lsblk --fs --list --noheadings --output "NAME,UUID,SIZE" --filter 'FSTYPE == "btrfs"' --bytes)
+        mapfile -t raw_btrfs_output < <(sudo lsblk --fs --list --noheadings --output "NAME,UUID,SIZE" --filter 'FSTYPE == "btrfs"' --bytes)
 
         if [[ ${#raw_btrfs_output[@]} -eq 0 ]]; then
           echo "No BTRFS filesystems found."


### PR DESCRIPTION
The `configure-beesd` recipe uses `lsblk --f` to detect BTRFS filesystems, but lsblk requires root to read filesystem info on Fedora 44. When run without sudo, it returns empty and reports `No BTRFS filesystems found.`, even though the system has BTRFS volumes.

Prepend sudo to the lsblk command so the recipe works regardless of whether it's invoked directly or through the Bazzite Portal (yafti) which runs ujust as the regular user.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
