### PR TITLE
chore(Portal): Link directly to announcements tag

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -22,7 +22,7 @@ screens:
         title: "Check out Announcements on our Bazzite Discourse"
         description: "For the latest big news on Bazzite!"
         default: false
-        script: "xdg-open https://universal-blue.discourse.group/c/bazzite/"
+        script: "xdg-open https://universal-blue.discourse.group/tags/c/bazzite/announcements/"
       - id: "reddit"
         title: "Browse our official Reddit community."
         description: "Come join the conversation, ask questions, and show off your build!"


### PR DESCRIPTION
Changes the URL opened by the Discourse button from #5052 to link directly to the announcements tag. This should improve user onboarding by reducing ambiguity.

Can be merged in any order with #5076. 