### PR TITLE
test(dgoss): check podman dependency

### DIFF
--- a/tests/dgoss/README.md
+++ b/tests/dgoss/README.md
@@ -2,6 +2,8 @@
 
 This directory relies on some conventional structure inside of tests to make running multiple isolated dgoss test suites viable.
 
+The test runner expects `dgoss` and `podman` to be available in `PATH`.
+
 Inside of the tests.d directory, each test needs to be defined in its own subdirectory.
 
 Each test subdirectory must contain at least two things:
@@ -9,4 +11,4 @@ Each test subdirectory must contain at least two things:
 1. A `goss.yaml` file containing any [valid gossfile configuration](https://goss.readthedocs.io/en/stable/gossfile/). This file is where all of your goss test assertions will be defined.
 2. A `test.sh` file that runs `dgoss run`. This file MUST take $1 as an argument for the image to perform the test on. Additional volume mounts can be specified using the `-v` flag to inject fixture data into the filesystem.
 
-Addition documentation for goss' capabilities can be found at [https://goss.readthedocs.io](https://goss.readthedocs.io).
+Additional documentation for goss' capabilities can be found at [https://goss.readthedocs.io](https://goss.readthedocs.io).

--- a/tests/dgoss/dgoss-tests.sh
+++ b/tests/dgoss/dgoss-tests.sh
@@ -16,9 +16,14 @@ fi
 # Force dgoss to use podman
 export CONTAINER_RUNTIME=podman
 
-# Fail fast if dgoss not present
+# Fail fast if required test tools are not present
 if ! command -v dgoss >/dev/null 2>&1; then
     echo "dgoss not found in PATH" >&2
+    exit 2
+fi
+
+if ! command -v podman >/dev/null 2>&1; then
+    echo "podman not found in PATH" >&2
     exit 2
 fi
 


### PR DESCRIPTION
## Summary

- Add an explicit `podman` availability check to the dgoss test runner before invoking dgoss with `CONTAINER_RUNTIME=podman`.
- Document the dgoss test runner prerequisites and fix a small typo in the dgoss README.

## Why

The runner already forces dgoss to use podman, so failing early with a clear message makes local and CI troubleshooting more direct when the container runtime is missing.

## Testing

- `bash -n tests/dgoss/dgoss-tests.sh tests/dgoss/tests.d/00-smoke/test.sh`
- `git diff --check`
- `just just-check`
