### PR TITLE
fix: restore privileged user setup service enablement

### DIFF
--- a/system_files/deck/shared/usr/lib/systemd/system/steam-web-debug-portforward@.service
+++ b/system_files/deck/shared/usr/lib/systemd/system/steam-web-debug-portforward@.service
@@ -1,9 +1,9 @@
 [Unit]
-Description="Portforward CEF remote debug port for user %f"
+Description="Portforward CEF remote debug port for user %I"
 
 [Service]
 ExecStart=/usr/bin/socat TCP4-LISTEN:8081,fork TCP4:127.0.0.1:8080
-User=%f
+User=%I
 Restart=always
 
 [Install]

--- a/system_files/desktop/shared/usr/libexec/bazzite-privileged-user-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-privileged-user-setup
@@ -4,7 +4,7 @@
 timedatectl set-ntp true
 
 # Allow Tailscale Control
-tailscale set --operator="$(systemd-escape $1)"
+tailscale set --operator="$(systemd-escape "$1")"
 
 # Enable Steam Web Debug Service
-systemctl enable steam-web-debug-portforward@$(systemd-escape $1).service && \
+systemctl enable "steam-web-debug-portforward@$(systemd-escape "$1").service"


### PR DESCRIPTION
## Summary

- Finish the `steam-web-debug-portforward@...` enable command in `bazzite-privileged-user-setup` so the script parses and runs again.
- Use the unescaped systemd instance specifier for the port-forward service user, avoiding the invalid `/user` expansion from `%f`.
- Quote the username before passing it to `systemd-escape`.

## Why

`bazzite-privileged-user-setup` currently ends with a trailing `&& \`, so `bash -n` reports an unexpected EOF and the privileged first-login setup path cannot run. After completing that command, the enabled template also needs `User=%I`; `User=%f` expands to a path-like `/instance` value and systemd rejects the unit.

## Testing

- `bash -n system_files/desktop/shared/usr/libexec/bazzite-privileged-user-setup`
- shell syntax sweep over executable shell entrypoints
- `systemd-analyze verify system_files/deck/shared/usr/lib/systemd/system/steam-web-debug-portforward@.service`
- `just just-check`
- `git diff --check`
