### PR TITLE
feat(Portal): Open Bazaar after dialog ack

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -12,7 +12,7 @@ screens:
         title: "Browse your Bazaar"
         description: "Your software store! Check out our curated selection for apps like Discord, Heroic Games Launcher, or Viper."
         default: false
-        script: "yad --info --title=\"Tip\" --image=dialog-information --text \"You can launch Bazaar anytime from your pinned apps or the app menu.\" --button=\"I get it\"!gtk-ok!"
+        script: "yad --info --title=\"Tip\" --image=dialog-information --text \"You can launch Bazaar anytime from your pinned apps or the app menu.\" --button=\"I get it\"!gtk-ok! && nohup setsid gtk4-launch io.github.kolunmi.Bazaar >&/dev/null"
       - id: "bazzite-discord"
         title: "Get help through Discord"
         description: "Enter our official server for Bazzite user tech support. Bring your system logs!"


### PR DESCRIPTION
Modifies the Bazaar button script in `yafti-gtk` to open Bazaar as a detached process once the dialog is acknowledged. This is done using `gtk4-launch` to avoid a potential maintenance burden — as it will launch the program by sourcing the already present `.desktop` file. 

I figure that it only makes sense for this option to do what the user would expect, given the behavior you get everywhere else in Portal. Furthermore, the preemptive dialog remains, so that should keep the incentive to use the app pin instead.

This detaching method seems hacky to me, but it's the only thing that worked in my testing; there might be a better way.