### PR TITLE
fix: try to work around an issue with unusable controllers in Plasma 6.7

### DIFF
--- a/system_files/desktop/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
+++ b/system_files/desktop/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
@@ -1,0 +1,6 @@
+[Wayland]
+InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop
+VirtualKeyboardEnabled=true
+
+[Plugins]
+gamecontrollerEnabled=false

--- a/system_files/desktop/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
+++ b/system_files/desktop/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
@@ -1,5 +1,5 @@
 [Wayland]
-InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop
+InputMethod[$e]=/usr/share/applications/org.kde.plasma.keyboard.desktop
 VirtualKeyboardEnabled=true
 
 [Plugins]


### PR DESCRIPTION
Plasma 6.7 enabled 'allow using as pointer and keyboard' again by default which makes nearly every game unplayable. This is an attempt to fix this issue.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
