### PR TITLE
fix: unhide the gigabyte wake fix ujust

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/81-bazzite-fixes.just
@@ -450,7 +450,7 @@ toggle-i915-sleep-fix ACTION="":
 
 # Toggle GPP0 wakeup fix to prevent unwanted system wake-ups, primarily affects Gigabyte motherboards.
 [group("hardware")]
-_toggle-gigabyte-wake-fix:
+toggle-gigabyte-wake-fix:
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     SERVICE_FILE="/etc/systemd/system/biosWakeupWorkaround.service"


### PR DESCRIPTION
I do not think this ujust should be hidden as it prevents users from finding it with ujust --choose

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
