### PR TITLE
chore: remove patched fwupd

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -167,7 +167,6 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf5 -y config-manager setopt "*staging*".exclude="scx-tools scx-scheds kf6-* mesa* mutter*" && \
     /ctx/cleanup
 
-# Install patched fwupd
 # Install Valve's patched Mesa, Bluez, and Xwayland
 RUN --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/cache/libdnf5 \
@@ -181,7 +180,6 @@ RUN --mount=type=cache,dst=/var/cache \
         ["copr:copr.fedorainfracloud.org:ublue-os:bazzite"]="wireplumber" \
         ["copr:copr.fedorainfracloud.org:ublue-os:bazzite-multilib"]="bluez xorg-x11-server-Xwayland" \
         ["terra-mesa"]="mesa-filesystem" \
-        ["copr:copr.fedorainfracloud.org:ublue-os:staging"]="fwupd" \
     ) && \
     for repo in "${!toswap[@]}"; do \
         for package in ${toswap[$repo]}; do dnf5 -y swap --from-repo=$repo $package $package; done; \
@@ -200,10 +198,6 @@ RUN --mount=type=cache,dst=/var/cache \
         mesa-libGL \
         mesa-libgbm \
         mesa-vulkan-drivers \
-        fwupd \
-        fwupd-plugin-flashrom \
-        fwupd-plugin-modem-manager \
-        fwupd-plugin-uefi-capsule-data \
         NetworkManager \
         NetworkManager-wifi \
         NetworkManager-libnm && \


### PR DESCRIPTION
This used to be needed because of [1]. See this comment [2].

Aurora and Bluefin already have this [3].

[1]: https://github.com/ublue-os/bazzite/issues/1400
[2]: https://github.com/fwupd/fwupd/blob/862012c6c5f850ddcebbc5cdf5c96005475b3861/plugins/uefi-capsule/fu-uefi-capsule-device.c#L721-L732
[3]: https://github.com/ublue-os/aurora/pull/2273