### PR TITLE
feat(just): FW16 Matrix LED setup in 80-bazzite.just

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -6,7 +6,7 @@ IMAGE_BRANCH=$(jq -r '."image-branch"' < $IMAGE_INFO)
 FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 
 # SCRIPT VERSION
-HWS_VER=71
+HWS_VER=72
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VER_FILE)
 
@@ -225,6 +225,14 @@ if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
         echo "ACTION==\"add\", SUBSYSTEM==\"serio\", DRIVERS==\"atkbd\", ATTR{power/wakeup}=\"disabled\"" > /etc/udev/rules.d/20-suspend-fixes.rules
       fi
     fi
+  fi
+fi
+
+# FRAMEWORK 16 LED MATRIX SETUP
+if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
+  if [[ "$SYS_ID" == "Laptop 16 ("* ]]; then
+    echo "Adding required udev rules for Framework 16 LED Matrix"
+    echo -e '# Framework Laptop 16 - LED Matrix\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="32ac", ATTRS{idProduct}=="0020", MODE="0660", TAG+="uaccess"' > /etc/udev/rules.d/50-framework-inputmodule.rules
   fi
 fi
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -786,7 +786,7 @@ enable-framework-fan-control:
 setup-fw-led-matrix ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    OPTION={{ ACTION }}
+    OPTION="{{ ACTION }}"
     if [[ "$OPTION" = "install" ]]; then
         mkdir -p ~/.tmp
         cd ~/.tmp
@@ -795,12 +795,33 @@ setup-fw-led-matrix ACTION="":
         sudo rm -f /etc/udev/rules.d/50-framework-inputmodule.rules
         sudo cp ~/.tmp/50-framework-inputmodule.rules /etc/udev/rules.d/
         sudo udevadm control --reload && sudo udevadm trigger
-        git clone https://github.com/MidnightJava/led-matrix.git ~/.tmp/
+        git clone https://github.com/MidnightJava/led-matrix.git ~/.tmp/led-matrix
         chmod +x ~/.tmp/led-matrix/build_and_install.sh
         ~/.tmp/led-matrix/
         chmod +x ~/.tmp/led-matrix/install_service.sh
         ~/.tmp/led-matrix/install_service.sh
+        exit 0
     fi
+    if [[ "OPTION" = "uninstall" ]]; then
+        systemctl disable --user fwledmonitor.service
+        rm -f $HOME/.config/systemd/user/fwledmonitor.service
+        sudo rm -rf /opt/led_mon
+        sudo rm -f /usr/local/bin/led_mon
+        sudo rm -rf /var/lib/led_mon
+        sudo rm -f /etc/led_mon
+        exit 0
+    fi
+    if [[ "OPTION" = "status" ]]; then
+        systemctl status --user fwledmonitor.service
+        exit 0
+    fi
+    if [[ "OPTION" = "restart" ]]; then
+        systemctl daemon-reload --user
+        systemctl stop fwledmonitor.service --user
+        systemctl start fwledmonitor.service --user --now
+        exit 0
+    fi
+    
 
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 [group("system")]

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -788,22 +788,15 @@ setup-fw-led-matrix ACTION="":
     source /usr/lib/ujust/ujust.sh
     OPTION="{{ ACTION }}"
     install_led_mon() {
-        mkdir -p ~/.tmp
-        cd ~/.tmp || exit 1
-        rm -f ~/.tmp/50-framework-inputmodule.rules
-        wget -P ~/.tmp https://raw.githubusercontent.com/FrameworkComputer/inputmodule-rs/refs/heads/main/release/50-framework-inputmodule.rules
-        sudo rm -f /etc/udev/rules.d/50-framework-inputmodule.rules
-        sudo cp ~/.tmp/50-framework-inputmodule.rules /etc/udev/rules.d/
-        sudo udevadm control --reload && sudo udevadm trigger
-        git clone https://github.com/MidnightJava/led-matrix.git ~/.tmp/led-matrix
-        cd ~/.tmp/led-matrix
-        chmod +x ~/.tmp/led-matrix/build_and_install.sh
-        ~/.tmp/led-matrix/build_and_install.sh
-        chmod +x ~/.tmp/led-matrix/install_service.sh
-        ~/.tmp/led-matrix/install_service.sh
+        mkdir -p /tmp/fw-led
+        cd /tmp/fw-led || exit 1
+        git clone https://github.com/MidnightJava/led-matrix.git
+        cd ./led-matrix
+        chmod +x ./build_and_install.sh
+        chmod +x ./install_service.sh
+        ./build_and_install.sh
         exit 0
     }
-
     uninstall_led_mon() {
         rm -f $HOME/.config/systemd/user/fwledmonitor.service
         sudo rm -rf /opt/led_mon

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -698,7 +698,7 @@ steamos-automount ACTION="":
       OPTION=$(ugum choose "Enable" "Disable" "Exit without changes")
       case "$OPTION" in
         "Enable")
-          enable_steamos_automount
+          enable_steamos_automountj
           ;;
         "Disable")
           disable_steamos_automount_action
@@ -787,7 +787,7 @@ setup-fw-led-matrix ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     OPTION="{{ ACTION }}"
-    if [[ "$OPTION" = "install" ]]; then
+    install_led_mon() {
         mkdir -p ~/.tmp
         cd ~/.tmp
         rm -f ~/.tmp/50-framework-inputmodule.rules
@@ -800,27 +800,67 @@ setup-fw-led-matrix ACTION="":
         ~/.tmp/led-matrix/
         chmod +x ~/.tmp/led-matrix/install_service.sh
         ~/.tmp/led-matrix/install_service.sh
-        exit 0
-    fi
-    if [[ "OPTION" = "uninstall" ]]; then
-        systemctl disable --user fwledmonitor.service
+        exit 0 
+    }
+
+    uninstall_led_mon() {
         rm -f $HOME/.config/systemd/user/fwledmonitor.service
         sudo rm -rf /opt/led_mon
         sudo rm -f /usr/local/bin/led_mon
         sudo rm -rf /var/lib/led_mon
         sudo rm -f /etc/led_mon
         exit 0
-    fi
-    if [[ "OPTION" = "status" ]]; then
+    }
+
+    status_led_mon() {
         systemctl status --user fwledmonitor.service
         exit 0
-    fi
-    if [[ "OPTION" = "restart" ]]; then
+    }
+
+    restart_led_mon() {
         systemctl daemon-reload --user
         systemctl stop fwledmonitor.service --user
         systemctl start fwledmonitor.service --user --now
         exit 0
+    }
+
+    gum_led_mon() {
+        OPTION=$(ugum choose "Install" "Uninstall" "Status" "Restart" "Exit")
+        if [[ "$OPTION" == "install" ]]; then
+            install_led_mon
+        fi
+        if [[ "$OPTION" == "uninstall" ]]; then
+            uninstall_led_mon
+        fi
+        if [[ "$OPTION" == "status" ]]; then
+            status_led_mon
+        fi
+        if [[ "$OPTION" == "restart" ]]; then
+            restart_led_mon
+        fi
+        if [[ "$OPTION" == "Exit" ]]; then
+            exit 0
+        fi
+        exit 0
+    }
+
+    if [[ "$OPTION" == "install" ]]; then
+        install_led_mon
     fi
+    if [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_led_mon
+    fi
+    if [[ "$OPTION" == "status" ]]; then
+        status_led_mon
+    fi
+    if [[ "$OPTION" == "restart" ]]; then
+        restart_led_mon
+    fi
+
+    if [[ -z "$OPTION" ]]; then
+        gum_led_mon
+    fi
+        
     
 
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -789,18 +789,19 @@ setup-fw-led-matrix ACTION="":
     OPTION="{{ ACTION }}"
     install_led_mon() {
         mkdir -p ~/.tmp
-        cd ~/.tmp
+        cd ~/.tmp || exit 1
         rm -f ~/.tmp/50-framework-inputmodule.rules
         wget -P ~/.tmp https://raw.githubusercontent.com/FrameworkComputer/inputmodule-rs/refs/heads/main/release/50-framework-inputmodule.rules
         sudo rm -f /etc/udev/rules.d/50-framework-inputmodule.rules
         sudo cp ~/.tmp/50-framework-inputmodule.rules /etc/udev/rules.d/
         sudo udevadm control --reload && sudo udevadm trigger
         git clone https://github.com/MidnightJava/led-matrix.git ~/.tmp/led-matrix
+        cd ~/.tmp/led-matrix
         chmod +x ~/.tmp/led-matrix/build_and_install.sh
-        ~/.tmp/led-matrix/
+        ~/.tmp/led-matrix/build_and_install.sh
         chmod +x ~/.tmp/led-matrix/install_service.sh
         ~/.tmp/led-matrix/install_service.sh
-        exit 0 
+        exit 0
     }
 
     uninstall_led_mon() {
@@ -826,16 +827,16 @@ setup-fw-led-matrix ACTION="":
 
     gum_led_mon() {
         OPTION=$(ugum choose "Install" "Uninstall" "Status" "Restart" "Exit")
-        if [[ "$OPTION" == "install" ]]; then
+        if [[ "$OPTION" == "Install" ]]; then
             install_led_mon
         fi
-        if [[ "$OPTION" == "uninstall" ]]; then
+        if [[ "$OPTION" == "Uninstall" ]]; then
             uninstall_led_mon
         fi
-        if [[ "$OPTION" == "status" ]]; then
+        if [[ "$OPTION" == "Status" ]]; then
             status_led_mon
         fi
-        if [[ "$OPTION" == "restart" ]]; then
+        if [[ "$OPTION" == "Restart" ]]; then
             restart_led_mon
         fi
         if [[ "$OPTION" == "Exit" ]]; then
@@ -862,7 +863,6 @@ setup-fw-led-matrix ACTION="":
     fi
         
     
-
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 [group("system")]
 configure-watchdog ACTION="":

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -781,13 +781,26 @@ tailscale ACTION="":
 enable-framework-fan-control:
     systemctl enable --now fw-fanctrl.service
 
-# Setup LED Matrix module for the Framework 16 laptop
+# Setup LED Matrix module for the Framework 16 laptop. Options: install | uninstall | status | restart
 [group("hardware")]
 setup-fw-led-matrix ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     OPTION={{ ACTION }}
-    
+    if [[ "$OPTION" = "install" ]]; then
+        mkdir -p ~/.tmp
+        cd ~/.tmp
+        rm -f ~/.tmp/50-framework-inputmodule.rules
+        wget -P ~/.tmp https://raw.githubusercontent.com/FrameworkComputer/inputmodule-rs/refs/heads/main/release/50-framework-inputmodule.rules
+        sudo rm -f /etc/udev/rules.d/50-framework-inputmodule.rules
+        sudo cp ~/.tmp/50-framework-inputmodule.rules /etc/udev/rules.d/
+        sudo udevadm control --reload && sudo udevadm trigger
+        git clone https://github.com/MidnightJava/led-matrix.git ~/.tmp/
+        chmod +x ~/.tmp/led-matrix/build_and_install.sh
+        ~/.tmp/led-matrix/
+        chmod +x ~/.tmp/led-matrix/install_service.sh
+        ~/.tmp/led-matrix/install_service.sh
+    fi
 
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 [group("system")]

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -698,7 +698,7 @@ steamos-automount ACTION="":
       OPTION=$(ugum choose "Enable" "Disable" "Exit without changes")
       case "$OPTION" in
         "Enable")
-          enable_steamos_automountj
+          enable_steamos_automount
           ;;
         "Disable")
           disable_steamos_automount_action

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -786,76 +786,79 @@ enable-framework-fan-control:
 setup-fw-led-matrix ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
-    OPTION="{{ ACTION }}"
+    FWLED_STATE="$(systemctl is-enabled fwledmonitor.service 2>/dev/null || true)"
+    get_status_token() {
+      if [[ -z "$FWLED_STATE" ]]; then
+        return 1
+      elif [[ "$FWLED_STATE" == "enabled" ]]; then
+        echo "install"
+      else
+        echo "uninstall"
+      fi
+    }
+    get_current_status() {
+      if [[ "$(get_status_token)" == "install" ]]; then
+        echo "${green}${bold}Enabled${normal}"
+      else
+        echo "${yellow}${bold}Disabled${normal}"
+      fi
+    }
     install_led_mon() {
-        mkdir -p /tmp/fw-led
-        cd /tmp/fw-led || exit 1
-        git clone https://github.com/MidnightJava/led-matrix.git
-        cd ./led-matrix
-        chmod +x ./build_and_install.sh
-        chmod +x ./install_service.sh
-        ./build_and_install.sh
-        exit 0
+      mkdir -p /tmp/fw-led
+      cd /tmp/fw-led || exit 1
+      git clone https://github.com/MidnightJava/led-matrix.git
+      cd ./led-matrix
+      chmod +x ./build_and_install.sh
+      chmod +x ./install_service.sh
+      ./build_and_install.sh
+      exit 0
     }
     uninstall_led_mon() {
-        rm -f $HOME/.config/systemd/user/fwledmonitor.service
-        sudo rm -rf /opt/led_mon
-        sudo rm -f /usr/local/bin/led_mon
-        sudo rm -rf /var/lib/led_mon
-        sudo rm -rf /etc/led_mon
-        exit 0
+      systemctl --user disable --now fwledmonitor.service
+      sudo rm -rf /opt/led_mon
+      sudo rm -f /usr/local/bin/led_mon
+      sudo rm -rf /var/lib/led_mon
+      sudo rm -rf /etc/led_mon
+      exit 0
     }
-
-    status_led_mon() {
-        systemctl status --user fwledmonitor.service
-        exit 0
-    }
-
     restart_led_mon() {
-        systemctl daemon-reload --user
-        systemctl stop fwledmonitor.service --user
-        systemctl start fwledmonitor.service --user --now
-        exit 0
+      systemctl --user daemon-reload
+      systemctl --user restart fwledmonitor.service
+      exit 0
     }
-
-    gum_led_mon() {
-        OPTION=$(ugum choose "Install" "Uninstall" "Status" "Restart" "Exit")
-        if [[ "$OPTION" == "Install" ]]; then
-            install_led_mon
-        fi
-        if [[ "$OPTION" == "Uninstall" ]]; then
-            uninstall_led_mon
-        fi
-        if [[ "$OPTION" == "Status" ]]; then
-            status_led_mon
-        fi
-        if [[ "$OPTION" == "Restart" ]]; then
-            restart_led_mon
-        fi
-        if [[ "$OPTION" == "Exit" ]]; then
-            exit 0
-        fi
-        exit 0
-    }
-
-    if [[ "$OPTION" == "install" ]]; then
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+      echo "Usage: ujust setup-fw-led-matrix <option>"
+      echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'status' to print the current portal token"
+      echo "  Use 'install' to enable LED Matrix"
+      echo "  Use 'uninstall' to disable LED Matrix"
+      exit 0
+    elif [[ -z "$OPTION" ]]; then
+      echo "${bold}Framework 16 LED Matrix${normal}"
+      echo "Current status: $(get_current_status)"
+      OPTION=$(ugum choose "Install" "Uninstall" "Status" "Restart" "Exit without changes")
+    fi
+    case "$OPTION" in
+      Install|install)
         install_led_mon
-    fi
-    if [[ "$OPTION" == "uninstall" ]]; then
+        ;;
+      Uninstall|uninstall)
         uninstall_led_mon
-    fi
-    if [[ "$OPTION" == "status" ]]; then
-        status_led_mon
-    fi
-    if [[ "$OPTION" == "restart" ]]; then
+        ;;
+      Status|status)
+        get_status_token
+        exit $?
+        ;;
+      Restart|restart)
         restart_led_mon
-    fi
+        ;;
+      *)
+        echo "No changes made."
+        ;;
+    esac
+    exit 0
 
-    if [[ -z "$OPTION" ]]; then
-        gum_led_mon
-    fi
-        
-    
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 [group("system")]
 configure-watchdog ACTION="":

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -781,6 +781,12 @@ tailscale ACTION="":
 enable-framework-fan-control:
     systemctl enable --now fw-fanctrl.service
 
+# Setup LED Matrix module for the Framework 16 laptop
+[group("system)]
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    
+
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 [group("system")]
 configure-watchdog ACTION="":

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -787,6 +787,18 @@ setup-fw-led-matrix ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     FWLED_STATE="$(systemctl is-enabled fwledmonitor.service 2>/dev/null || true)"
+    confirm_install() {
+      SYS_ID="$(/usr/libexec/hwsupport/sysid)"
+      msg="Your device is not a Framework 16! Continue anyways?"
+      if [[ ! "$SYS_ID" =~ "Laptop 16 ("* ]]; then
+        echo -n "$msg ${yellow}(Y/n)${normal} "
+        read -r reply
+        if ! [[ -z "$reply" || "${reply,,}" =~ ^y ]]; then
+          echo "Exiting..."
+          exit 0
+        fi
+      fi
+    }
     get_status_token() {
       if [[ -z "$FWLED_STATE" ]]; then
         return 1
@@ -804,6 +816,7 @@ setup-fw-led-matrix ACTION="":
       fi
     }
     install_led_mon() {
+      confirm_install
       mkdir -p /tmp/fw-led
       cd /tmp/fw-led || exit 1
       git clone https://github.com/MidnightJava/led-matrix.git

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -782,9 +782,11 @@ enable-framework-fan-control:
     systemctl enable --now fw-fanctrl.service
 
 # Setup LED Matrix module for the Framework 16 laptop
-[group("system)]
+[group("hardware")]
+setup-fw-led-matrix ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
+    OPTION={{ ACTION }}
     
 
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -781,6 +781,88 @@ tailscale ACTION="":
 enable-framework-fan-control:
     systemctl enable --now fw-fanctrl.service
 
+# Setup LED Matrix module for the Framework 16 laptop. Options: install | uninstall | status | restart
+[group("hardware")]
+setup-fw-led-matrix ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    OPTION="{{ ACTION }}"
+    install_led_mon() {
+        mkdir -p ~/.tmp
+        cd ~/.tmp || exit 1
+        rm -f ~/.tmp/50-framework-inputmodule.rules
+        wget -P ~/.tmp https://raw.githubusercontent.com/FrameworkComputer/inputmodule-rs/refs/heads/main/release/50-framework-inputmodule.rules
+        sudo rm -f /etc/udev/rules.d/50-framework-inputmodule.rules
+        sudo cp ~/.tmp/50-framework-inputmodule.rules /etc/udev/rules.d/
+        sudo udevadm control --reload && sudo udevadm trigger
+        git clone https://github.com/MidnightJava/led-matrix.git ~/.tmp/led-matrix
+        cd ~/.tmp/led-matrix
+        chmod +x ~/.tmp/led-matrix/build_and_install.sh
+        ~/.tmp/led-matrix/build_and_install.sh
+        chmod +x ~/.tmp/led-matrix/install_service.sh
+        ~/.tmp/led-matrix/install_service.sh
+        exit 0
+    }
+
+    uninstall_led_mon() {
+        rm -f $HOME/.config/systemd/user/fwledmonitor.service
+        sudo rm -rf /opt/led_mon
+        sudo rm -f /usr/local/bin/led_mon
+        sudo rm -rf /var/lib/led_mon
+        sudo rm -rf /etc/led_mon
+        exit 0
+    }
+
+    status_led_mon() {
+        systemctl status --user fwledmonitor.service
+        exit 0
+    }
+
+    restart_led_mon() {
+        systemctl daemon-reload --user
+        systemctl stop fwledmonitor.service --user
+        systemctl start fwledmonitor.service --user --now
+        exit 0
+    }
+
+    gum_led_mon() {
+        OPTION=$(ugum choose "Install" "Uninstall" "Status" "Restart" "Exit")
+        if [[ "$OPTION" == "Install" ]]; then
+            install_led_mon
+        fi
+        if [[ "$OPTION" == "Uninstall" ]]; then
+            uninstall_led_mon
+        fi
+        if [[ "$OPTION" == "Status" ]]; then
+            status_led_mon
+        fi
+        if [[ "$OPTION" == "Restart" ]]; then
+            restart_led_mon
+        fi
+        if [[ "$OPTION" == "Exit" ]]; then
+            exit 0
+        fi
+        exit 0
+    }
+
+    if [[ "$OPTION" == "install" ]]; then
+        install_led_mon
+    fi
+    if [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_led_mon
+    fi
+    if [[ "$OPTION" == "status" ]]; then
+        status_led_mon
+    fi
+    if [[ "$OPTION" == "restart" ]]; then
+        restart_led_mon
+    fi
+
+    if [[ -z "$OPTION" ]]; then
+        gum_led_mon
+    fi
+        
+    
 # Configure watchdog (default: enabled, recovers the system in the event of a malfunction)
 [group("system")]
 configure-watchdog ACTION="":

--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -809,7 +809,7 @@ setup-fw-led-matrix ACTION="":
         sudo rm -rf /opt/led_mon
         sudo rm -f /usr/local/bin/led_mon
         sudo rm -rf /var/lib/led_mon
-        sudo rm -f /etc/led_mon
+        sudo rm -rf /etc/led_mon
         exit 0
     }
 

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -674,6 +674,21 @@ screens:
           - id: "uninstall"
             label: "Uninstall DisplayLink Support"
             script: 'ujust install-displaylink uninstall; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "setup-fw-led-matrix"
+        title: "Setup Framework 16 LED Matrix"
+        description: "Install a service to enable the LED Matrix on Framework Laptop 16."
+        default: false
+        status_script: "ujust setup-fw-led-matrix status"
+        options:
+          - id: "install"
+            label: "Install LED Matrix Service"
+            script: 'ujust setup-fw-led-matrix install'
+          - id: "uninstall"
+            label: "Uninstall LED Matrix Service"
+            script: 'ujust setup-fw-led-matrix uninstall'
+          - id: "restart"
+            label: "Restart LED Matrix Service"
+            script: 'ujust setup-fw-led-matrix restart'
       - id: "configure-beesd"
         title: "Setup btrfs deduplication"
         description: "Configure «beesd» for deduplication of btrfs file systems."


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Adding FW16 Matrix setup
For some context
Led Matrix part: https://frame.work/products/16-led-matrix?v=FRAKDE0001
Input module: https://github.com/FrameworkComputer/inputmodule-rs/blob/main/ledmatrix/README.md
Matrix control software: https://github.com/MidnightJava/led-matrix
Another guide: https://knowledgebase.frame.work/led-matrix-controls-on-linux-ByJKHV7axg