### PR TITLE
chore(Portal): Correct information on iwd

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -821,15 +821,15 @@ screens:
             script: "ujust cec-mode native"
       - id: "iwd"
         title: "Change Wi-Fi system back-end"
-        description: "Toggle between the default «iwd» and legacy «wpa_supplicant» as the software Wi-Fi back-end."
+        description: "Toggle between the default «wpa_supplicant» and «iwd» as the software Wi-Fi back-end."
         default: false
         status_script: "ujust iwd status"
         options:
           - id: "enable"
-            label: "Reset to «iwd»"
+            label: "Switch to «iwd»"
             script: "ujust iwd enable"
           - id: "disable"
-            label: "Switch to «wpa_supplicant»"
+            label: "Reset to «wpa_supplicant»"
             script: "ujust iwd disable"
       - id: "intel-i915-sleep-fix"
         title: "Configure power saving for Intel HD Graphics"


### PR DESCRIPTION
Wasn't aware the default had been changed back to `wpa_supplicant`; correct information regarding which back-end is the current one.