### PR TITLE
feat(kde): add fcitx5-table-extra for more Chinese IME

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -424,6 +424,7 @@ RUN --mount=type=cache,dst=/var/cache \
             kdeplasma-addons \
             rom-properties-kf6 \
             fcitx5-chewing \
+            fcitx5-table-extra \
             fcitx5-mozc \
             fcitx5-chinese-addons \
             fcitx5-hangul \


### PR DESCRIPTION
This PR adds `fcitx5-table-extra`, which includes quick and cangjie. These IMEs are very commonly used among Traditional Chinese users in Hong Kong