### PR TITLE
chore(Bazaar): Update Thunderbird ID

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
@@ -165,7 +165,7 @@ rows:
           pt_BR: "Que nosso camarada clipe de papel tenha piedade de nós."
       appids:
         list:
-          - org.mozilla.Thunderbird
+          - org.mozilla.thunderbird
           - org.libreoffice.LibreOffice
           - org.onlyoffice.desktopeditors
           - org.gimp.GIMP


### PR DESCRIPTION
Mozilla changed the last portion of the Flatpak ID to lowercase (I know, tell me about it). Use the new one for the Curated tab.