### PR TITLE
chore(Bazaar): Add Mimic to the Utilities section

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/content.yaml
@@ -225,6 +225,7 @@ rows:
           - io.github.pwr_solaar.solaar
           - it.mijorus.gearlever
           - io.github.flattool.Ignition
+          - io.github.arijanj.Mimic
           - io.github.fastrizwaan.WineZGUI
           - io.github.berarma.Oversteer
           - io.github.lawstorant.boxflat


### PR DESCRIPTION
Add Mimic to the Curated tab. This is an app for management of MIME types. Mostly redundant on KDE, but GNOME does not have an integrated way of managing this.