### PR TITLE
fix: Add ignore configs for external controllers

### DIFF
--- a/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-8bitdo-controllers.yaml
+++ b/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-8bitdo-controllers.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: 8BitDo Controllers
+## THIS CONFIG IS MEANT TO BE TEMPORARY AND SHOULD BE REMOVED
+## ONCE INPUTPLUMBER HAS FULL SUPPORT FOR THESE CONTROLLERS!
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Dinput/SteamInput Mode & Dongle mode
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "2dc8"

--- a/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-hhl-controllers.yaml
+++ b/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-hhl-controllers.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Handheld Legend Controllers
+## THIS CONFIG IS MEANT TO BE TEMPORARY AND SHOULD BE REMOVED
+## ONCE INPUTPLUMBER HAS SUPPORT FOR THESE CONTROLLERS!
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Dinput/SteamInput Mode
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "2e8a"

--- a/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-nintendo-controllers.yaml
+++ b/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-nintendo-controllers.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Nintendo Controllers & 3rd party
+## THIS CONFIG IS MEANT TO BE TEMPORARY AND SHOULD BE REMOVED
+## ONCE INPUTPLUMBER HAS FULL SUPPORT FOR THESE CONTROLLERS!
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Switch input Mode
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "057e"

--- a/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-sony-controllers.yaml
+++ b/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-sony-controllers.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Sony Controllers & 3rd Party
+## THIS CONFIG IS MEANT TO BE TEMPORARY AND SHOULD BE REMOVED
+## ONCE INPUTPLUMBER HAS FULL SUPPORT FOR THESE CONTROLLERS!
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Dinput/SteamInput Mode
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "054c"

--- a/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-xinput-controllers.yaml
+++ b/system_files/deck/shared/usr/share/inputplumber/devices/20-ignore-xinput-controllers.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Xinput Controllers
+## THIS CONFIG IS MEANT TO BE TEMPORARY AND SHOULD BE REMOVED
+## ONCE INPUTPLUMBER HAS FULL SUPPORT FOR THESE CONTROLLERS!
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # XInput mode
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "045e"
+      # Add product ids for 3rd party controllers
+      # Gulikit Controllers,
+      product_id: "{02e0}"
+  
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "0079"
+      # Add product ids for 3rd party controllers
+      # EasySMX D05,
+      product_id: "{181c}"


### PR DESCRIPTION
Ideally this will be temporary and we would remove files as inputplumber gains support for the controllers. We cannot blanket ignore all "xinput" controllers as this would then affect the ROG Ally controls and maybe other handhelds.

I will try make an ujust to generate "per-controller" ignore configs which grabs vendorID and productID that users can have on their system and even provide to us to update these lists.

You can find the needed vendorID and productID by:
1. connecting your controller (on the deck image or after having gone into the gamemode session once in the dx image)
2. run `inputplumber devices list` and note down the id for the controller you connected
3. run `inputplumber device ID info` (replace `ID` with the id you noted down)
4. run `udevadm -a SOURCEDEVICE` replace `SOURCEDEVICE` with the source device shown by inputplumber, from this info we can grab the vendorID and productID to add to our ignore lists (and possibly generate) an ignore config for the user.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
