### PR TITLE
feat(deck): Add Bazzite-Deck-Sleep-Inhibitor

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -664,6 +664,7 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf5 -y copr enable ublue-os/bazzite && \
     dnf5 -y copr enable ublue-os/bazzite-multilib && \
     dnf5 -y copr enable ycollet/audinux && \
+    dnf5 -y copr enable addmixbb/Bazzite-Deck-Sleep-Inhibitor && \
     dnf5 config-manager unsetopt skip_if_unavailable && \
     /ctx/cleanup
 
@@ -702,7 +703,9 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
-    dnf5 -y install --enable-repo=terra \
+    dnf5 -y install \
+        --enable-repo=terra \
+        --enable-repo=copr:copr.fedorainfracloud.org:addmixbb:Bazzite-Deck-Sleep-Inhibitor \
         jupiter-fan-control \
         jupiter-hw-support-btrfs \
         galileo-mura \
@@ -712,6 +715,7 @@ RUN --mount=type=cache,dst=/var/cache \
         gamescope-session-ogui-steam \
         steamos-manager-powerstation \
         steamos-manager-powerstation-gamescope-session-plus \
+        bazzite-deck-sleep-inhibitor \
         vpower \
         steam-notif-daemon \
         acpica-tools \
@@ -814,6 +818,8 @@ RUN --mount=type=cache,dst=/var/cache \
     systemctl disable vpower.service && \
     systemctl disable jupiter-biosupdate.service && \
     systemctl disable jupiter-controller-update.service && \
+    systemctl enable sleep-inhibitor-root.service && \
+    systemctl --global enable sleep-inhibitor.service && \
     dnf5 config-manager setopt skip_if_unavailable=1 && \
     /ctx/image-info && \
     /ctx/build-initramfs && \


### PR DESCRIPTION
Fixes #4972 (with a Steam client caveat)

Bazzite-Deck-Sleep-Inhibitor is a minimal implementation of the freedesktop.ScreenSaver interface which allows user programs to request sleep inhibitors. This is necessary for game mode, as the typical services (ScreenSaver and PowerDevil) are not active to provide the functionality.

The source is available here: https://github.com/addmix/Bazzite-Deck-Sleep-Inhibitor

The one caveat being [this issue](https://github.com/ValveSoftware/SteamOS/issues/2619) that the Steam client (which tracks user inactivity, and issues sleep commands) does not have a mechanism to handle rejected sleep requests. This results in the Steam client doing it's sleep animation, and blacking out the screen, while the system stays awake. The Steam client does not make any further attempts to sleep the system, or to recover from this false-sleep state. I wanted to create this PR as a real example of why Valve must fix this error in the steam client.

Related issues:
https://github.com/ValveSoftware/SteamOS/issues/1881
https://github.com/ValveSoftware/gamescope/issues/2167