### PR TITLE
fix(just): trust LizardByte Homebrew repository

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-sunshine.just
@@ -100,6 +100,7 @@ setup-sunshine ACTION="":
           echo "Setting up Homebrew environment..."
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         fi
+        brew trust LizardByte/homebrew
         brew tap LizardByte/homebrew
         echo "${b}Cleaning${n} up any existing stable ${yellow}Sunshine${n} install before installing beta..."
         flatpak run --command=remove-additional-install.sh dev.lizardbyte.app.Sunshine || true


### PR DESCRIPTION
The Beta option for susnhine brew was missing the trust line needed and errored out as a result.

```brew trust LizardByte/homebrew``` added to fix and require no intervention from users.