### PR TITLE
feat: Add notifier for Nvidia Flatpak Runtime Mismatch

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -441,6 +441,12 @@ screens:
         description: "Remove the next image deployment, halting all updates or layering changes pending reboot."
         default: false
         script: 'rpm-ostree cleanup -p; status=$?; echo; echo "Press Enter to close..."; read -r _; exit $status'
+      - id: "update-nvidia-runtime"
+        title: "Update Nvidia Flatpak Runtime"
+        description: "Synchronizes Nvidia Flatpak Runtimes with system version. This is usually done automatically by the systemd service."
+        default: false
+        status_script: "ujust update-nvidia-runtime status"
+        script: "ujust update-nvidia-runtime upgrade"
       - id: "verify-image"
         title: "Move to a ‘verified’ image"
         description: "Detect if you are on an ‘unverified’ image of Bazzite and then, if applicable, move you to a signed one."

--- a/system_files/nvidia/shared/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
+++ b/system_files/nvidia/shared/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Sync NVIDIA system drivers with Flatpak runtime
+After=network-online.target flatpak-system-helper.service
+Wants=network-online.target
+ConditionPathExists=/sys/module/nvidia/version
+# To not run on live ISO
+ConditionPathExists=/run/ostree-booted
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/libexec/ublue-nvidia-flatpak-runtime-sync check
+ExecStart=/usr/libexec/ublue-nvidia-flatpak-runtime-sync sync
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/nvidia/shared/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-verify.service
+++ b/system_files/nvidia/shared/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-verify.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Verify NVIDIA system drivers are synced with Flatpak runtime
+After=graphical-session.target xdg-desktop-autostart.target xdg-desktop-portal.service ublue-nvidia-flatpak-runtime-sync.service
+ConditionPathExists=/sys/module/nvidia/version
+# To not run on live ISO
+ConditionPathExists=/run/ostree-booted
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/libexec/ublue-nvidia-flatpak-runtime-sync check
+ExecStartPre=/bin/sleep 5
+ExecStart=/usr/libexec/ublue-nvidia-flatpak-runtime-notify
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+TimeoutStartSec=600
+
+[Install]
+WantedBy=graphical-session.target

--- a/system_files/nvidia/shared/usr/libexec/ublue-nvidia-flatpak-runtime-notify
+++ b/system_files/nvidia/shared/usr/libexec/ublue-nvidia-flatpak-runtime-notify
@@ -1,0 +1,37 @@
+#!/usr/bin/bash
+# Notifier if Nvidia flatpak runtimes mismatch with system.
+#
+# Related files:
+#   - /usr/libexec/ublue-nvidia-flatpak-runtime-sync: checker for Nvidia runtime version.
+#   - /usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service: service to try to sync flatpak runtimes.
+#   - /usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-notifier.service: service that starts this script.
+
+set -euo pipefail
+
+title="Nvidia Flatpak Runtime Mismatch"
+body="Bazzite noticed that there is an Nvidia flatpak runtime mismatch!\n\nHardware acceleration will not work in Flatpak Apps before you update it.\n"
+see_more_url="https://docs.bazzite.gg/General/issues_and_resolutions/#flatpak-apps-have-no-hardware-acceleration-on-nvidia"
+
+notify_cmd="/usr/bin/notify-send --app-name=\"Bazzite Nvidia Runtime Checker\" --expire-time=0"
+notify_cmd+=" \"${title:+$title}\" \"${body:+$body}\""
+notify_cmd+=" --action=\"see_more=See more\""
+notify_cmd+=" --action=\"update_flatpak=Update all Flatpaks\""
+notify_cmd+=" --action=\"update_runtime_only=Update Runtime Only\""
+
+
+action=$(eval "$notify_cmd") || exit
+        case "$action" in
+        see_more)
+            xdg-open "$see_more_url"
+            ;;
+        update_flatpak)
+            /usr/bin/bazaar
+            ;;
+        update_runtime_only)
+            /usr/bin/yafti_gtk.py /usr/share/yafti/yafti.yml --action-id update-nvidia-runtime
+            ;;
+        *)
+            # Do nothing
+            :
+            ;;
+        esac

--- a/system_files/nvidia/shared/usr/libexec/ublue-nvidia-flatpak-runtime-sync
+++ b/system_files/nvidia/shared/usr/libexec/ublue-nvidia-flatpak-runtime-sync
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# Workaround for: https://github.com/flatpak/flatpak/issues/3907
+set -euo pipefail
+
+SYSTEM_NVIDIA_VERSION=$(cat /sys/module/nvidia/version)
+FLATPAK_NVIDIA_VERSION=$(echo "${SYSTEM_NVIDIA_VERSION}" | tr '.' '-')
+
+case "${1}" in
+    check)
+        # Exit 0 if sync is needed (versions mismatch), exit 1 if already in sync
+        if flatpak info --system org.freedesktop.Platform.GL.nvidia-"${FLATPAK_NVIDIA_VERSION}" >/dev/null 2>&1 && \
+           flatpak info --system org.freedesktop.Platform.GL32.nvidia-"${FLATPAK_NVIDIA_VERSION}" >/dev/null 2>&1; then
+            echo "NVIDIA Flatpak runtime ${SYSTEM_NVIDIA_VERSION} already installed"
+            exit 1
+        fi
+        echo "NVIDIA Flatpak runtime ${SYSTEM_NVIDIA_VERSION} needs to be installed"
+        exit 0
+        ;;
+    sync)
+        echo "Installing NVIDIA Flatpak runtime version ${SYSTEM_NVIDIA_VERSION}"
+        flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak install --system --noninteractive -y flathub \
+            org.freedesktop.Platform.GL.nvidia-"${FLATPAK_NVIDIA_VERSION}" \
+            org.freedesktop.Platform.GL32.nvidia-"${FLATPAK_NVIDIA_VERSION}"
+        ;;
+    *)
+        echo "Usage: $0 {check|sync}"
+        exit 1
+        ;;
+esac

--- a/system_files/nvidia/shared/usr/share/ublue-os/just/95-bazzite-nvidia.just
+++ b/system_files/nvidia/shared/usr/share/ublue-os/just/95-bazzite-nvidia.just
@@ -62,3 +62,34 @@ enable-supergfxctl ACTION="":
         exit 0
     fi
     enable_supergfxctl
+
+update-nvidia-runtime ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    get_status_token() {
+        local service_state
+        service_state="$(/usr/libexec/ublue-nvidia-flatpak-runtime-sync check)"
+        if ! service_state; then
+            echo "upgraded"
+        else
+            echo "mismatch"
+        fi
+    }
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "help" ]]; then
+        echo "Usage: ujust update-nvidia-runtime <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'status' to print the current portal token"
+        echo "  Use 'upgrade' to upgrade"
+        exit 0
+    elif [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit $?
+    elif [[ "$OPTION" == "upgrade" ]]; then
+        /usr/libexec/ublue-nvidia-flatpak-runtime-sync sync
+    elif [[ -z "$OPTION" ]]; then
+        echo "${bold}No option specified.${normal}"
+        exit 0
+    fi
+
+    exit 0


### PR DESCRIPTION
1. Add the oneshot systemd service to sync flatpak runtimes from aurorafin
2. Add a systemd service that starts after log in and sends the notification
3. Adds a Bazzite Portal Entry to manually sync the runtime (requires https://github.com/ublue-os/yafti-gtk/pull/24 to properly display)

Note on 3: Currently there doesn't seem to be a way to make it show/hide based on the image, so it looks like this on non-nvidia images. imo this is fine but let me know if it needs to be hidden(maybe make Bazzite Portal automatically source everything under `/usr/share/yafti/`, and adding an extra file under the nvidia section, similar to ujust scripts?)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cf02e06c-e83b-4674-86e9-25498e39120c" />

How the notification looks like:
<img width="547" height="266" alt="image" src="https://github.com/user-attachments/assets/feb04b2f-fa08-4c20-b0bf-a66e1b8bf96e" />

Note: I don't have an nvidia device to test this on, so will need help to test that it works.