### PR TITLE
feat: Add ujust for generating inputplumber ignore configs

### DIFF
--- a/system_files/deck/shared/usr/libexec/bazzite-inputplumber-ignorelist
+++ b/system_files/deck/shared/usr/libexec/bazzite-inputplumber-ignorelist
@@ -1,0 +1,89 @@
+#!/usr/bin/bash
+source /usr/lib/ujust/ujust.sh
+
+# Check if we are run with sudo
+if [ "$EUID" -ne 0 ]
+  then echo "Please run with sudo"
+  exit
+fi
+
+inputplumber devices list
+echo "${b}This script is just for external controllers, not handheld controls! CTRL+C to exit${n}"
+read -rp "${b}Enter the ID for the controller to generate an ignore list for: ${n}" id
+if [ -z "$id" ] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
+    echo "No Composite Device ID provided!"
+    exit 1
+fi
+# Grab all devices for the controller that inputplumber finds
+# shellcheck disable=SC2207
+DEVICES=($(inputplumber device "$id" info | grep "/dev" | perl -pe 's/.+\[(.+)\].+/\1/' | sed 's/[",]//g'))
+# Process the evdev devices
+for DEVICE in "${DEVICES[@]}"
+do
+    if [[ "$DEVICE" =~ event  ]];  then
+        echo "Processing $DEVICE"
+        UDEVINFO=$(udevadm info -a $DEVICE | grep -P "id/(vendor|product|name)")
+        VENDORID=""
+        PRODUCTID=""
+        NAME=""
+        # Grab the attribute information we need for the device to generate a config
+        # shellcheck disable=SC2046
+        while read -r UDEVINFO
+        do
+            if [[ "$UDEVINFO" =~ vendor ]]; then
+                VENDORID=$(echo $UDEVINFO | perl -pe 's/.+=="([a-f0-9]{4})"/\1/')
+            elif [[ "$UDEVINFO" =~ product ]]; then
+                PRODUCTID=$(echo $UDEVINFO | perl -pe 's/.+=="([a-f0-9]{4})"/\1/')
+            elif [[ "$UDEVINFO" =~ name ]]; then
+                NAME=$(echo $UDEVINFO | perl -pe 's/.+=="(.+)"/\1/')
+            fi
+        done <<< $(udevadm info -a "$DEVICE" | grep -P "id/(vendor|product)")
+        # Exit with error if VendorID or ProductID is still empty
+        if [ -z "$VENDORID" ] || [ -z "$PRODUCTID" ] || ! [[ "$VENDORID" =~ ^[a-f0-9]+$ ]] || ! [[ "$PRODUCTID" =~ ^[a-f0-9]+$ ]]; then
+            echo "${NAME}: No valid VendorID(${VENDORID}) or ProductID(${PRODUCTID}) detected!"
+            exit 2
+        fi
+        # If no valid name is detected then ask for one
+        if [ -z "$NAME" ]; then
+            read -rp "${b}Provide a name for the controller: ${n}" NAME
+            if [ -z "$NAME" ]; then
+                echo "No name provided"
+                exit 3
+            fi
+        fi
+        # Generate config for the controller and tell inputplumber to ignore it
+        mkdir -p "/etc/inputplumber/devices.d"
+        VENDORID=$VENDORID PRODUCTID=$PRODUCTID NAME=$NAME bash -c 'cat << INPUTPLUMBER_CONFIG > /etc/inputplumber/devices.d/19-custom-${VENDORID}_${PRODUCTID}.yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: $NAME
+## THIS CONFIG IS MEANT TO BE TEMPORARY AND SHOULD BE REMOVED
+## ONCE INPUTPLUMBER HAS FULL SUPPORT FOR THESE CONTROLLERS!
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Dinput/SteamInput Mode & Dongle mode
+  - group: gamepad
+    ignore: true
+    evdev:
+      vendor_id: "$VENDORID"
+      product_id: "$PRODUCTID"
+INPUTPLUMBER_CONFIG'
+
+        echo "${b}Config file generated at:${n} /etc/inputplumber/devices.d/19-custom-${VENDORID}_${PRODUCTID}.yaml"
+        echo "The config file will take effect on the next reboot."
+        echo "Consider providing a copy of this file to the Bazzite team so we can add the IDs to the global config."
+    fi
+done

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -175,3 +175,7 @@ restore-gamemode-shortcut:
     chmod +x "$SHORTCUT_FILE"
     echo "Shortcut restored successfully at $SHORTCUT_FILE."
     echo "Note: The first time you use the shortcut, it may ask you to trust it. Please accept."
+
+# Generate ignore configs for unknown external controllers not yet in our system-provided ignore list
+generate-inputplumber-ignorelist:
+    sudo /usr/libexec/bazzite-inputplumber-ignorelist


### PR DESCRIPTION
Lets users generate ignore configs for controllers we do not have in our vendor provided ignore list yet. This also makes it easy for them to provide us with any missing IDs for the ignore list.

Custom configs start with the 19-custom prefix to differenciate from the vendor provided 20- prefix.
the naming format is `19-custom-VendorID_ProductID.yaml` this way the user cant accidentally generate multiple yaml files for the exact same device.

This script generates 1 file per device, it does not check if they belong to any existing VendorID and merge them, i wanted this to just be a simple solution the users can use while giving us the IDs so we can add them properly to our lists ourselves.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
