### PR TITLE
chore(just): cleanup 2 obsolete lines from the inputplumber ujust

### DIFF
--- a/system_files/deck/shared/usr/libexec/bazzite-inputplumber-ignorelist
+++ b/system_files/deck/shared/usr/libexec/bazzite-inputplumber-ignorelist
@@ -22,7 +22,6 @@ for DEVICE in "${DEVICES[@]}"
 do
     if [[ "$DEVICE" =~ event  ]];  then
         echo "Processing $DEVICE"
-        UDEVINFO=$(udevadm info -a $DEVICE | grep -P "id/(vendor|product|name)")
         VENDORID=""
         PRODUCTID=""
         NAME=""
@@ -74,7 +73,6 @@ matches: []
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
-  # Dinput/SteamInput Mode & Dongle mode
   - group: gamepad
     ignore: true
     evdev:


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
