### PR TITLE
fix(deck): Change logind HandlePowerKey to ignore

### DIFF
--- a/system_files/deck/shared/etc/systemd/logind.conf.d/deck.conf
+++ b/system_files/deck/shared/etc/systemd/logind.conf.d/deck.conf
@@ -1,3 +1,3 @@
 [Login]
-HandlePowerKey=suspend
+HandlePowerKey=ignore
 KillUserProcesses=true


### PR DESCRIPTION
This changes the `deck.conf` `logind` config file to have the `HandlePowerKey` property be set to `ignore`. It should fix any issues with devices that struggle to wake up from sleep mode when `steamos-powerbuttond` is running. Also allows for those devices to show the Steam power menu when the power button is long-pressed (As long as `steamos-powerbuttond` is running).

This is based off of what SteamOS is doing at `/etc/systemd/logind.conf.d/suspendbutton.conf`:

```
[Login]
HandlePowerKey=ignore
```

The only caveat to implementing this right now is that we need to have `steamos-powerbuttond.service` running at startup. Without that running, power button events are completely ignored in the `gamescope` session.