### PR TITLE
fix(deck): Enable steamos-powerbuttond at start

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -798,6 +798,8 @@ RUN --mount=type=cache,dst=/var/cache \
     done && unset -v copr && \
     { rm -v /usr/share/applications/bazzite-steam-bpm.desktop || true; } && \
     sed -i "s|^github = .*|github = https://raw.githubusercontent.com/ublue-os/bazzite-gamemode-news/refs/heads/${IMAGE_BRANCH}/announcements.json|" /etc/gamemode-news-hook.conf && \
+    mkdir -p /usr/lib/systemd/user/gamescope-session-plus@.service.wants && \
+    ln -s /usr/lib/systemd/user/steamos-powerbuttond.service /usr/lib/systemd/user/gamescope-session-plus@.service.wants/ && \
     systemctl enable --global steamos-manager.service && \
     systemctl enable --global steamos-manager-session-cleanup.service && \
     systemctl enable --global steamos-manager-configure-cecd.service && \


### PR DESCRIPTION
Manually creates a link for `steamos-powerbuttond.service` to a wants for `gamescope-session-plus@.service`. Without it, the service will never start due to how upstream handles installation from source.

See also: https://gitlab.steamos.cloud/holo/powerbuttond/-/blob/9392e68883fdb0c40bc01ab39ae75c83a541e413/Makefile#L36