### PR TITLE
fix(ujust): correct Filename in Decky Ujust for Decky Framegen

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
@@ -412,7 +412,7 @@ get-framegen ACTION="":
     REPO_OWNER="xXJSONDeruloXx"
     REPO_NAME="Decky-Framegen"
     PLUGIN_NAME="Decky-Framegen"
-    FILENAME="Decky.Framegen.zip"
+    FILENAME="Decky-Framegen.zip"
     PLUGIN_BASE_DIR="$HOME/homebrew/plugins"
     PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
     get_status_token() {


### PR DESCRIPTION
fix(ujust): Correct Filename in Decky Ujust for Decky Framegen

File name was mispelled causing ujust recipe to fail to pull it.  Corrected filename to Decky-Framegen.zip instead of Decky.Framegen.zip.