### PR TITLE
feat: add ujust get-couchside (phone remote & dashboard for the couch)

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -1025,6 +1025,63 @@ opentabletdriver ACTION="":
         exit 0
     fi
 
+alias install-couchside := get-couchside
+
+# Install Couchside (https://couchside.tv) - phone remote & dashboard for this machine. Options: status | install | uninstall
+[group("gaming")]
+get-couchside ACTION="":
+    #!/usr/bin/bash
+    set -eo pipefail
+    get_status_token() {
+        if systemctl list-unit-files couchside.service &>/dev/null && \
+           [[ -f "$HOME/.local/opt/couchside/couchsided.py" ]]; then
+            echo "install"
+        else
+            echo "uninstall"
+        fi
+    }
+    get_current_status() {
+        if [[ "$(get_status_token)" == "install" ]]; then
+            echo "Installed"
+        else
+            echo "Not Installed"
+        fi
+    }
+    install_couchside() {
+        curl --retry 3 -fsSL https://couchside.tv/install.sh | bash
+    }
+    uninstall_couchside() {
+        curl --retry 3 -fsSL https://couchside.tv/install.sh | bash -s -- --uninstall
+    }
+    OPTION="{{ ACTION }}"
+    if [[ "$OPTION" == "status" ]]; then
+        get_status_token
+        exit 0
+    elif [[ "$OPTION" == "install" ]]; then
+        install_couchside
+        exit 0
+    elif [[ "$OPTION" == "uninstall" ]]; then
+        uninstall_couchside
+        exit 0
+    elif [[ -z "$OPTION" ]]; then
+        current_status=$(get_current_status)
+        echo "${bold}Couchside${normal}"
+        echo "Current status: $current_status"
+        OPTION=$(ugum choose "Install" "Uninstall" "Exit without changes")
+        case "$OPTION" in
+            "Install")
+                install_couchside
+                ;;
+            "Uninstall")
+                uninstall_couchside
+                ;;
+            *)
+                echo "No changes made."
+                ;;
+        esac
+        exit 0
+    fi
+
 # Create fedora distrobox if it doesn't exist
 [private]
 distrobox-check-fedora:


### PR DESCRIPTION
Adds a `get-couchside` recipe to `82-bazzite-apps.just`, following the
`get-emudeck` shape exactly: `status | install | uninstall` plus the
interactive `ugum` menu when run bare. No yafti/portal change in this PR —
recipe only.

### What Couchside is

[Couchside](https://couchside.tv) turns a phone (iOS/Android) into the
dashboard, remote console, and game controller for a living-room Bazzite/
SteamOS machine: launch games, switch Game Mode ↔ Desktop, trackpad +
keyboard input, volume/TV control, power. **LAN-only, bearer-token
authenticated, no cloud, no accounts, no analytics.** The box-side agent is
MIT licensed, pure Python 3 stdlib, and runs as the desktop user (not root).

### Why this shape

- Same install mechanism as Decky Loader's recipe: `curl | bash` of an
  installer that sets up a systemd service. The installer **verifies an
  Ed25519 signature over every fetched file** (SHA256SUMS + SHA256SUMS.sig
  against a pinned public key) before installing anything — a corrupted or
  tampered fetch refuses to install. Verification code is in the installer
  itself: https://github.com/emerytech/couchside/blob/main/install.sh
- `status` checks the systemd unit + installed daemon — what the installer
  actually creates, not a filename heuristic.
- `uninstall` is complete and testable (`ujust get-couchside uninstall`):
  service, privileged helper + its units, udev rules, sudoers (prompted),
  Steam tile, Wake-on-LAN link.

### Anticipating the review questions

- **Privileged surface:** the agent executes only a frozen allowlist — client
  input selects entries, never becomes a command/path/shell string. Since
  2.9.69 the root-side work goes through a small socket-gated helper (eight
  fixed verbs, SO_PEERCRED-checked) rather than broad sudo rules.
- **Blast radius:** it can reboot/suspend the machine and switch sessions —
  that is the product. It is reachable only on the LAN and only with the
  pairing token the box displays.
- **Maintenance:** I maintain the recipe; the project ships weekly and the
  installer URL is stable (it is a signed release asset mirrored at
  couchside.tv).

Happy to adjust naming, grouping, or scope to fit — and no hard feelings if
the portal bar is "come back with more users"; the recipe alone already
gives Bazzite users a one-liner.