### PR TITLE
fix(bazzite_portal): default file name for downloaded decky plugins in ujust

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
@@ -412,7 +412,7 @@ get-framegen ACTION="":
     REPO_OWNER="xXJSONDeruloXx"
     REPO_NAME="Decky-Framegen"
     PLUGIN_NAME="Decky-Framegen"
-    FILENAME="Decky.Framegen.zip"
+    FILENAME="Decky-Framegen.zip"
     PLUGIN_BASE_DIR="$HOME/homebrew/plugins"
     PLUGIN_DIR="$HOME/homebrew/plugins/Decky-Framegen"
     get_status_token() {

--- a/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
@@ -462,7 +462,7 @@ get-framegen ACTION="":
             sudo rm -rf "$PLUGIN_DIR"
         fi
         echo "Downloading $PLUGIN_NAME from $plugin_url..."
-        local temp_file="${plugin_url##*/}"
+        local temp_file="$(basename "${plugin_url%.*}")"
         if ! timeout 60 curl -L -o "$temp_file" "$plugin_url"; then
             echo "Download failed or timed out!"
             cd - > /dev/null

--- a/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
@@ -462,7 +462,7 @@ get-framegen ACTION="":
             sudo rm -rf "$PLUGIN_DIR"
         fi
         echo "Downloading $PLUGIN_NAME from $plugin_url..."
-        local temp_file="plugin_file"
+        local temp_file="${plugin_url##*/}"
         if ! timeout 60 curl -L -o "$temp_file" "$plugin_url"; then
             echo "Download failed or timed out!"
             cd - > /dev/null


### PR DESCRIPTION
- fixes the Bazzite ujust command to install Decky Framegen
