### PR TITLE
feat(portal): Add Bazzite Portal autostart configuration

### DIFF
--- a/system_files/desktop/shared/etc/skel/.config/autostart/bazzite-portal.desktop
+++ b/system_files/desktop/shared/etc/skel/.config/autostart/bazzite-portal.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Bazzite Portal
+Comment=Helps you setup Bazzite
+Exec=yafti_gtk.py /usr/share/yafti/yafti.yml
+Icon=io.github.ublue_os.yafti_gtk
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
Added to ```system_files/desktop/shared/etc/skel/.config/autostart/bazzite-portal.desktop```, **please check my work on this one.**

Logic recently added to the Bazzite Portal reads ```~/.config/autostart``` to check for the presence of this .desktop file below.

Present = On
Absent = Off

The toggle either writes or delete the .desktop file from the same directory.

This change places that file in above noted directory to copy the .desktop file to new users and launch Bazzite Portal at first user login. Thereby presenting the user with our new Welcome section and introducing a useful tool at a critical time.  User then either toggles "Launch at Startup" on or off to control.