### PR TITLE
feat(gnome): Add the gnome-rounded-blur package (Fixes #5070)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -437,6 +437,7 @@ RUN --mount=type=cache,dst=/var/cache \
             gnome-shell-extension-user-theme \
             gnome-shell-extension-gsconnect \
             gnome-search-yafti \
+            gnome-rounded-blur \
             rom-properties-gtk4 \
             rom-properties-localsearch3 \
             ibus-mozc \


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
The goal of this contribution is to fix #5070 . As such, it's the continuation of ublue-os/packages#1336.

Basically, the Blur my Shell extension, which is shipped by default in both bluefin and bazzite-gnome, has chosen to use a [C library](https://github.com/kancko/gnome-rounded-blur) which allows it to implement dynamic corner blur. While the actual features that utilise this have been disabled by default for now, this package would allow that functionality.

This package will work on fedora 44, and is currently working on fedora rawhide (Gnome 51.alpha)