### PR TITLE
fix(ujust): adjust decky framegen temp filename syntax to avoid installation failures

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
@@ -461,14 +461,15 @@ get-framegen ACTION="":
             echo "Removing existing $PLUGIN_NAME directory..."
             sudo rm -rf "$PLUGIN_DIR"
         fi
-        echo "Downloading $PLUGIN_NAME from $plugin_url..."
-        local temp_file="$(basename "${plugin_url%.*}")"
-        if ! timeout 60 curl -L -o "$temp_file" "$plugin_url"; then
-            echo "Download failed or timed out!"
-            cd - > /dev/null
-            rm -rf "$temp_dir"
-            return 1
-        fi
+       echo "Downloading $PLUGIN_NAME from $plugin_url..."
+       local temp_file="$FILENAME"
+
+       if ! timeout 60 curl -L -o "$temp_file" "$plugin_url"; then
+           echo "Download failed or timed out!"
+           cd - > /dev/null
+           rm -rf "$temp_dir"
+           return 1
+       fi
         echo "Extracting $PLUGIN_NAME..."
         if [[ "$plugin_url" == *.tar.gz ]]; then
             if ! tar -xzf "$temp_file"; then

--- a/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/91-bazzite-decky.just
@@ -464,7 +464,7 @@ get-framegen ACTION="":
        echo "Downloading $PLUGIN_NAME from $plugin_url..."
        local temp_file="$FILENAME"
 
-       if ! timeout 60 curl -L -o "$temp_file" "$plugin_url"; then
+       if ! timeout 120 curl -L -o "$temp_file" "$plugin_url"; then
            echo "Download failed or timed out!"
            cd - > /dev/null
            rm -rf "$temp_dir"


### PR DESCRIPTION
Tested and working locally.

Changed temp $filename to ensure directory creation would not fail when decompressing. Also adjusted timeout to account for slower connections.

