### PR TITLE
docs: remove image selector section from README

### DIFF
--- a/README-SPA.md
+++ b/README-SPA.md
@@ -16,12 +16,9 @@
 </p>
 
 ---
-# Seleccionador de Imágenes
-Usa nuestro [seleccionador de imágenes](https://bazzite.gg/#image-picker) para encontrar la imagen correcta basada en tu hardware y tus preferencias.
 
 # Tabla de Contenidos
 - [🇺🇸 🇪🇸 🇮🇩 🇫🇷 🇧🇷 🇳🇱 🇹🇼](#------)
-- [Seleccionador de Imágenes](#seleccionador-de-imágenes)
 - [Tabla de Contenidos](#tabla-de-contenidos)
   - [Acerca de y Características](#acerca-de-y-características)
     - [Computadoras de Escritorio](#computadoras-de-escritorio)


### PR DESCRIPTION
Removed the section about the image picker selector from the README.

Redundant.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
