### PR TITLE
feat: improve switcherooctl shim

### DIFF
--- a/system_files/desktop/shared/usr/bin/switcherooctl
+++ b/system_files/desktop/shared/usr/bin/switcherooctl
@@ -1,10 +1,24 @@
 #!/usr/bin/bash
 
+# shellcheck disable=SC1091
+source /usr/lib/ujust/ujust.sh
+
+MSG1="switcherooctl is deprecated on Bazzite and has been replaced by cardwire."
+MSG2="Please use 'cardwire' instead. Run 'cardwire --help' for usage."
+
+# If we are not in gamemode session or tty
+if [ "$XDG_CURRENT_DESKTOP" != "gamescope" ] && [ -n "$XDG_CURRENT_DESKTOP" ]; then
+    # Send a notification that sticks around for 20 seconds (so it is visible when launched through steam)
+    notify-send -t 20000 -a "switcherooctl is deprecated" "$MSG1" "$MSG2"
+fi
+
 if [[ "$1" == "launch" ]]; then
     shift
     exec /usr/bin/cardwire launch "$@"
 fi
 
-echo "switcherooctl is deprecated on Bazzite and has been replaced by cardwire." >&2
-echo "Please use 'cardwire' instead. Run 'cardwire --help' for usage." >&2
+# shellcheck disable=SC2154
+echo "${b}$MSG1${n}" >&2
+echo "$MSG2" >&2
+cardwire list
 exit 1


### PR DESCRIPTION
currently the notification in desktop mode is set to stick around for 20 seconds, can make it require manual closing instead
<img width="360" height="139" alt="image" src="https://github.com/user-attachments/assets/27819009-69f0-411b-ae91-d87fcc8aa4c3" />

<img width="1048" height="175" alt="image" src="https://github.com/user-attachments/assets/62282b84-fac0-41c0-9ba5-070b8861ec7b" />

the notification is only fired off in desktop mode, it is not fired off in tty or gamemode

also if the user does not use `switcherooctl launch` then it will just spit out `cardwire list` with the warning before exiting with exit code 1

this way the shim still provides the bare minimum functionality the user would expect while still being told "move to the new thing"

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
