### PR TITLE
fix: removing hidden tag from a just command

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/80-bazzite.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 
-# Disable NTFS/exFAT monitor and notification service
-_disable-ntfs-service:
+# Disable NTFS/exFAT monitor and notification service - REMINDER: Gaming on NTFS will lead to data corruption/loss! 
+disable-ntfs-service:
     #!/usr/bin/bash
     systemctl disable --now --user ntfs-nag.service
     systemctl mask --now --user ntfs-nag.service


### PR DESCRIPTION
fix: removed the hidden tag "_" from disable-ntfs-service and added a warning message to again remind the user about the dangers of NTFS gaming.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
