### PR TITLE
fix: mask appstream refresh service causing slow boot

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -297,6 +297,7 @@ RUN --mount=type=cache,dst=/var/cache \
     ln -s /dev/null /etc/NetworkManager/dispatcher.d/04-iscsi && \
     systemctl mask iscsi && \
     systemctl mask systemd-remount-fs.service && \
+    systemctl mask fedora-atomic-desktop-appstream-cache-refresh && \
     mkdir -p /usr/lib/extest/ && \
     /ctx/ghcurl "$(/ctx/ghcurl https://api.github.com/repos/ublue-os/extest/releases/latest | jq -r '.assets[] | select(.name| test(".*so$")).browser_download_url')" -Lo /usr/lib/extest/libextest.so && \
     /ctx/ghcurl "https://github.com/ykshek/Sunshine/raw/1347f9ef290c089b815cf186f7d361470bdb9ef7/src_assets/linux/misc/postinst" -Lo /usr/libexec/sunshine-postinst && \


### PR DESCRIPTION
In the systemd unit:

`Description=Workaround for Atomic Destkops to refresh the appstream cache`
`Documentation=https://gitlab.com/fedora/ostree/sig/-/work_items/103`

thus should be safely maskable as Bazzite uses uupd and doesn't use discover.

Funnily enough it doesn't actually run on my machine due to 

```console
bazzite systemd[1]: [🡕] multi-user.target: Found ordering cycle: fedora-atomic-desktop-appstream-cache-refresh.service/start after graphical.target/start after multi-user.target/start - after fedora-atomic-desktop-ap>
bazzite systemd[1]: [🡕] multi-user.target: Job fedora-atomic-desktop-appstream-cache-refresh.service/start deleted to break ordering cycle starting with multi-user.target/start
```
though some users seems to have it, and take one and a half minute extra to boot.
