### PR TITLE
fix(deck): correct InputPlumber unmask commands

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -18,7 +18,7 @@ KNOWN_IMAGE_BRANCH=$(cat $KNOWN_IMAGE_BRANCH_FILE)
 KNOWN_FEDORA_VERSION_FILE="/etc/bazzite/fedora_version"
 KNOWN_FEDORA_VERSION=$(cat $KNOWN_FEDORA_VERSION_FILE)
 
-# Take care of autologin for non -deck or -dx images where this file is not needed.
+# Take care of autologin for non-deck or -dx images where this file is not needed.
 if [[ "$IMAGE_NAME" != *deck* && "$IMAGE_NAME" != *dx* ]]; then
   rm -f /etc/sddm.conf.d/steamos.conf
 fi
@@ -107,12 +107,12 @@ if [[ $IMAGE_NAME =~ "deck" ]]; then
     elif /usr/libexec/hwsupport/steamos-manager-hardware; then
       echo "SteamOS Manager supported hardware detected, masking powerstation".
       systemctl mask powerstation.service
-      systemclt unmask inputplumber.service
+      systemctl unmask inputplumber.service
     else
       echo "Other handheld detected, unmasking powerstation and inputplumber".
       systemctl unmask powerstation.service
       systemctl enable powerstation.service
-      systemclt unmask inputplumber.service
+      systemctl unmask inputplumber.service
     fi
   else
     echo "Non-handheld hardware detected, unmasking PPD and masking powerstation".

--- a/tests/dgoss/tests.d/00-smoke/goss.yaml
+++ b/tests/dgoss/tests.d/00-smoke/goss.yaml
@@ -5,6 +5,14 @@ command:
     stdout:
       - "dgoss smoketest"
 
+  hardware_setup_unmasks_inputplumber:
+    exec: |
+      sh -lc '
+      setup=/usr/libexec/bazzite-hardware-setup
+      test "$(grep -Fc "systemctl unmask inputplumber.service" "$setup")" -eq 2
+      '
+    exit-status: 0
+
   # steamosctl only ships on deck images, so this is a no-op elsewhere.
   steamosctl_selinux_label:
     exec: |


### PR DESCRIPTION
## Summary

- correct both `systemclt` misspellings in the handheld hardware setup paths
- fix the nearby `non -deck` comment typo found during a full-file spelling pass
- add a dgoss smoke assertion that verifies both InputPlumber unmask commands use `systemctl`

## Root cause and impact

The hardware setup script called a nonexistent `systemclt` command when SteamOS Manager-supported or other non-Valve handhelds needed InputPlumber unmasked. Because the script does not exit on that command failure, setup could continue and record itself as complete while leaving InputPlumber masked from a prior system state.

## Validation

- `bash -n system_files/desktop/shared/usr/libexec/bazzite-hardware-setup`
- `shellcheck --severity=error system_files/desktop/shared/usr/libexec/bazzite-hardware-setup`
- `codespell system_files/desktop/shared/usr/libexec/bazzite-hardware-setup`
- parsed `tests/dgoss/tests.d/00-smoke/goss.yaml` with Ruby YAML
- executed the new command-count assertion against the updated script
- `git diff --check upstream/testing...HEAD`

The full image-backed dgoss suite is left to the repository CI.
