### PR TITLE
fix: update star history chart to working endpoint

### DIFF
--- a/README-AR.md
+++ b/README-AR.md
@@ -267,11 +267,11 @@ sudo mokutil --import secure_boot.der
 
 ## تاريخ النجوم
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-BR.md
+++ b/README-BR.md
@@ -276,11 +276,11 @@ Se uma senha for pedida, insira `universalblue`.
 
 ## Histórico de Estrelas
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-DE.md
+++ b/README-DE.md
@@ -270,11 +270,11 @@ Falls nach einem Passwort gefragt wird, verwende `universalblue`.
 
 ## Star-Verlauf
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-FR.md
+++ b/README-FR.md
@@ -265,11 +265,11 @@ Si on vous demande un mot de passe, utilisez `universalblue`.
 
 ## Historique des étoiles
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Graphique d'historique des étoiles" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Graphique d'historique des étoiles" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-NL.md
+++ b/README-NL.md
@@ -280,11 +280,11 @@ Als er voor een wachtwoord gevraagd wordt, gebruik `universalblue`.
 
 ## Ster Geschiedenis
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-RU.md
+++ b/README-RU.md
@@ -266,11 +266,11 @@ sudo mokutil --import secure_boot.der
 
 ## История звезд
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-SPA.md
+++ b/README-SPA.md
@@ -286,11 +286,11 @@ Si se te pide una contraseña, introduce `universalblue`.
 
 ## Historial de Estrellas
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-TR.md
+++ b/README-TR.md
@@ -247,11 +247,11 @@ Parola istenirse `universalblue` kullanın.
 
 ## Yıldız Geçmişi ⭐
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Yıldız Geçmişi Tablosu" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Yıldız Geçmişi Tablosu" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-ZH-TW.md
+++ b/README-ZH-TW.md
@@ -265,11 +265,11 @@ sudo mokutil --import secure_boot.der
 
 ## 歷史星星
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -279,11 +279,11 @@ sudo mokutil --import secure_boot.der
 
 ## Star History
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ If asked for a password, use `universalblue`.
 
 ## Star History
 
-<a href="https://star-history.com/#ublue-os/bazzite&Date">
+<a href="https://star-history.dera.page/#ublue-os/bazzite&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ublue-os/bazzite&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ublue-os/bazzite&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart is currently broken and no longer renders due to GitHub stargazer API restrictions. Update the chart links in the README and all its translations to point to an endpoint that works reliably.