### PR TITLE
feat(kde): org.kde.krdc to KDE Bazaar blocklist

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/bazaar/blocklist.yaml
+++ b/system_files/desktop/shared/usr/share/ublue-os/bazaar/blocklist.yaml
@@ -31,3 +31,4 @@ blocklists:
     - org.kde.ark
     - org.kde.kfind
     - org.kde.konsole
+    - org.kde.krdc


### PR DESCRIPTION
KRDC comes pre-installed as a package in a KDE install, but its flatpak wasn't hidden in Bazaar

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
