### PR TITLE
fix: use scaleable SVG for Bazzite logo

### DIFF
--- a/build_files/image-info
+++ b/build_files/image-info
@@ -8,7 +8,7 @@ HOME_URL="https://bazzite.gg"
 DOCUMENTATION_URL="https://docs.bazzite.gg"
 SUPPORT_URL="https://discord.bazzite.gg"
 BUG_SUPPORT_URL="https://github.com/ublue-os/bazzite/issues/"
-LOGO_ICON="bazzite-logo-icon"
+LOGO_ICON="bazzite-logo"
 LOGO_COLOR="0;38;2;138;43;226"
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"


### PR DESCRIPTION
this fixes the 16-px PNG being incorrectly used in apps such as Mission Center.
before:
<img width="831" height="470" alt="image" src="https://github.com/user-attachments/assets/f9fccda1-f5bb-488c-9db7-d8e3f4a8d906" />

after:
<img width="1256" height="845" alt="image2" src="https://github.com/user-attachments/assets/8cee648f-0455-4c1c-8867-30d75368ccba" />

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
