### PR TITLE
chore(Portal): Give HDMI 2.1 toggle another pass

### DIFF
--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -680,8 +680,8 @@ screens:
             label: "Disable Autoupgrading FSR"
             script: "ujust global-fsr4 disable"
       - id: "configure-amd-hdmi21"
-        title: "Enable HDMI 2.1 for AMD Graphics Cards"
-        description: "Sets a karg to unlock additional functionality on AMD graphics cards. However, this may also cause flickering and instability on some displays."
+        title: "Enable HDMI 2.1 for AMD graphics cards"
+        description: "Set a kernel argument for booting AMD graphics with additional functionality. Currently, this may induce flickering and/or signal instability to some displays."
         status_script: "ujust configure-amd-hdmi21 status"
         default: false
         options:


### PR DESCRIPTION
Revise phrasing for the HDMI 2.1 toggle. Use imperative for the starting verb, and be specific about kernel arguments applying on boot; also use “induce”, as opposed to “cause”, given that the flickering isn't contingent on HDMI 2.1 itself, but on current issues. 

From what I've read on the [freedesktop issue](https://gitlab.freedesktop.org/drm/amd/-/work_items/5649), flickering is dependent on VRR being enabled — use “and/or”. Finally, also be specific about instability applying to the video signal.