### PR TITLE
fix(deck): persist steamosctl login mode

### DIFF
--- a/system_files/deck/shared/usr/libexec/bazzite-autologin
+++ b/system_files/deck/shared/usr/libexec/bazzite-autologin
@@ -5,19 +5,19 @@ BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
 
 USER=$(id -nu 1000)
 
-BAZZITE_CONF='/etc/sddm.conf.d/zz-bazzite-autologin.conf'
-DESKTOP_AUTOLOGIN='/etc/bazzite/desktop_autologin'
+BAZZITE_CONF="/etc/sddm.conf.d/zz-bazzite-autologin.conf"
+HOLO_CONF="/etc/sddm.conf.d/zz-holo-autologin.conf"
+DESKTOP_AUTOLOGIN="/etc/bazzite/desktop_autologin"
 
 rm -f /etc/sddm.conf.d/zz-steamos-autologin.conf \
-      /etc/sddm.conf.d/zz-holo-autologin.conf \
       /etc/sddm.conf.d/steamos.conf
 
 if [[ ! -f ${DESKTOP_AUTOLOGIN} ]]; then
-  SESSION='gamescope-session-ogui-steam.desktop'
+  SESSION="gamescope-session-ogui-steam.desktop"
 elif [[ ${BASE_IMAGE_NAME} =~ "kinoite" ]]; then
-  SESSION='plasma.desktop'
+  SESSION="plasma.desktop"
 elif [[ ${BASE_IMAGE_NAME} =~ "silverblue" ]]; then
-  SESSION='gnome.desktop'
+  SESSION="gnome.desktop"
 else
   echo "Unknown base image ${BASE_IMAGE_NAME}, leaving autologin alone" >&2
   exit 0
@@ -26,6 +26,12 @@ fi
 mkdir -p /etc/sddm.conf.d
 cat > ${BAZZITE_CONF} <<EOF
 [Autologin]
-Session=${SESSION}
 User=${USER}
 EOF
+
+if [[ ! -f ${HOLO_CONF} ]]; then
+  cat > ${HOLO_CONF} <<EOF
+[Autologin]
+Session=${SESSION}
+EOF
+fi


### PR DESCRIPTION
This PR changes how the `bazzite-autologin` script works, so that it doesn't override what the user sets the default login mode to with `steamosctl set-default-login-mode`.

Currently, when `bazzite-autologin` runs at every startup it will:

1. Delete `/etc/sddm.conf.d/zz-holo-autologin.conf` (Along with the old config files).
2. Evaluate what the default session should be based off it's checks.
3. Writes/overwrites the file at `/etc/sddm.conf.d/zz-bazzite-autologin.conf` with that determined session and the username of the user (With the `1000` UID).

This change will have `bazzite-autologin`:

1. Delete the old config files.
2. Evaluate what the default session should be based off it's checks. 
3. Writes/overwrites the file at `/etc/sddm.conf.d/zz-bazzite-autologin.conf` with the username of the user (With the `1000` UID).
4. Write the file at `/etc/sddm.conf.d/zz-holo-autologin.conf`, **if it does not exist**, with the determined default session.

This will allow users to set their preferred login mode with `steamosctl` and have it persist across reboots.