### PR TITLE
chore: consolidate removals in one script

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -193,9 +193,6 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
     /ctx/global-remove && \
-    if grep -q "silverblue" <<< "${BASE_IMAGE_NAME}"; then \
-        dnf5 -y remove toolbox \
-    ; fi && \
     /ctx/cleanup
 
 # Install new packages

--- a/build_files/global-remove
+++ b/build_files/global-remove
@@ -3,7 +3,23 @@
 
 set -eoux pipefail
 
-dnf5 -y remove \
-  ublue-os-update-services \
-  firefox{,-langpacks} \
-  htop
+# Not quoted because we want the expanded words and not the raw strings themselves in the dnf command
+REMOVE_GLOBAL=(
+  firefox{,-langpacks} # we use the flatpak
+  htop # btop is better
+  ublue-os-update-services # we use uupd, from ublue-os/main
+)
+
+REMOVE_KDE=()
+
+REMOVE_GNOME=(
+  toolbox # This can be a global removal after KDE Gear 26.08 landed https://invent.kde.org/utilities/konsole/-/merge_requests/1207
+)
+
+if [[ "${BASE_IMAGE_NAME}" == "kinoite" ]]; then
+  REMOVE_ALL=( "${REMOVE_KDE[@]}" "${REMOVE_GLOBAL[@]}" )
+elif [[ "${BASE_IMAGE_NAME}" == "silverblue" ]]; then
+  REMOVE_ALL=( "${REMOVE_GNOME[@]}" "${REMOVE_GLOBAL[@]}" )
+fi
+
+dnf5 -y remove "${REMOVE_ALL[@]}"


### PR DESCRIPTION
A little bit cleaner, also one less dnf command during the GNOME build.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
