### PR TITLE
fix(deck): configure native Steam input without OGUI

### DIFF
--- a/system_files/deck/shared/usr/lib/systemd/user/bazzite-native-steam-input.service
+++ b/system_files/deck/shared/usr/lib/systemd/user/bazzite-native-steam-input.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Configure InputPlumber for native Steam Gaming Mode
+ConditionPathExists=%h/.config/gamescope-session-plus/sessions.d/ogui-steam
+StartLimitIntervalSec=30
+StartLimitBurst=15
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/inputplumber device 0 targets set deck-uhid keyboard mouse
+ExecStart=/usr/bin/inputplumber device 0 profile load /usr/share/inputplumber/profiles/default.yaml
+RemainAfterExit=yes
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -207,6 +207,7 @@ configure-opengamepadui ACTION="":
     if [[ "${OPTION,,}" =~ ^enable ]]; then
       echo "Enabling OpenGamepadUI Overlay"
       rm -f $OGUI_STEAM
+      systemctl --user disable --now bazzite-native-steam-input.service 2>/dev/null || true
     elif [[ "${OPTION,,}" =~ ^disable ]]; then
       echo "Disabling OpenGamepadUI Overlay"
       # Create directory if it doesn't exist.
@@ -219,4 +220,5 @@ configure-opengamepadui ACTION="":
     [[ -f "\${STEAM_SESSION_FILE}" ]] && . "\${STEAM_SESSION_FILE}"
     EOF'
       chmod +x $OGUI_STEAM
+      systemctl --user enable --now bazzite-native-steam-input.service
     fi


### PR DESCRIPTION
## Summary

- select the Steam Deck UHID, keyboard, and mouse InputPlumber targets when OpenGamepadUI is disabled
- load InputPlumber’s native default shortcut profile instead of leaving the OGUI DBus profile active
- reapply the native configuration at login and disable the helper when OGUI is re-enabled

## Why

`ujust configure-opengamepadui disable` currently changes only the gamescope session. On an ROG Xbox Ally X, InputPlumber retained OGUI’s Xbox Elite target and OGUI-specific profile after the overlay was disabled. That left the Control Center shortcut routed to an absent OGUI DBus endpoint and reproduced the QAM/chord behavior reported in [bazzite#5521](https://github.com/ublue-os/bazzite/issues/5521).

The Steam Deck UHID target also avoids leaving the Xbox Elite target active in native Steam mode, which is relevant to the trigger-rumble behavior reported in [bazzite#5549](https://github.com/ublue-os/bazzite/issues/5549).

## Testing

Tested on an ROG Xbox Ally X (RC73XA) running Bazzite Deck 44:

- `systemd-analyze --user verify` passes for the new unit
- the project justfile passes `just --unstable --fmt --check`
- the service starts successfully and sets `deck-uhid`, `keyboard`, and `mouse`
- the native `Default` InputPlumber profile loads successfully
- Steam detects and opens the resulting ROG Ally controller
- controlled InputPlumber force-feedback pulses at 5%, 25%, 40%, 80%, and 100% produced progressively stronger physical feedback
- longer two-second pulses at 40%, 80%, and 100% stopped normally, with no InputPlumber errors

The force-feedback test confirms that the device and InputPlumber backend preserve requested rumble intensity. It does not by itself simulate every game-specific trigger-haptic report.

Fixes [bazzite#5521](https://github.com/ublue-os/bazzite/issues/5521).

Related: [bazzite#5549](https://github.com/ublue-os/bazzite/issues/5549).