### PR TITLE
fix(kde): restore Plasma virtual keyboard

### DIFF
--- a/spec_files/steamdeck-kde-presets/kwinrc
+++ b/spec_files/steamdeck-kde-presets/kwinrc
@@ -1,3 +1,3 @@
 [Wayland]
-InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop
+InputMethod[$e]=/usr/share/applications/org.kde.plasma.keyboard.desktop
 VirtualKeyboardEnabled=true

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -145,10 +145,9 @@ restore-virtual-keyboard:
     if [[ ${BASE_IMAGE_NAME} == 'silverblue' ]]; then
       gnome-extensions disable block-caribou-36@lxylxy123456.ercli.dev
     else
-      if [[ ! -f ~/.local/share/applications/com.github.maliit.keyboard.desktop ]]; then
-        mkdir -p ~/.local/share/applications/
-        cp /usr/share/ublue-os/backup/com.github.maliit.keyboard.desktop ~/.local/share/applications/com.github.maliit.keyboard.desktop
-      fi
+      kwriteconfig6 --file kwinrc --group Wayland --key InputMethod /usr/share/applications/org.kde.plasma.keyboard.desktop
+      kwriteconfig6 --file kwinrc --group Wayland --key VirtualKeyboardEnabled --type bool true
+      echo "The Plasma virtual keyboard will be enabled after logging out and back in."
     fi
 
 # Restore the "Return to Gaming Mode" shortcut on the Desktop


### PR DESCRIPTION
## Summary

- select the installed Plasma Keyboard instead of the removed Maliit input method in the Steam Deck KDE preset
- update `ujust restore-virtual-keyboard` to configure Plasma Keyboard directly
- tell users that a the user needs to logout and login back to the Desktop Mode

## Why

Deck KDE images no longer ship Maliit, but the preset and recovery command still reference `com.github.maliit.keyboard.desktop`. This leaves KWin pointing to a missing input method, and the recovery command fails because `/usr/share/ublue-os/backup/com.github.maliit.keyboard.desktop` is absent.

## Testing

Verified on an ROG Xbox Ally X running Bazzite stable `44.20260820`:

- `plasma-keyboard-6.7.4-1.fc44.x86_64` provides `/usr/share/applications/org.kde.plasma.keyboard.desktop`
- the effective KWin input method was the missing `/usr/share/applications/com.github.maliit.keyboard.desktop`
- applying the two `kwriteconfig6` commands changed the effective input method to `/usr/share/applications/org.kde.plasma.keyboard.desktop` and kept `VirtualKeyboardEnabled=true`
- `git diff --check` passes

Fixes the broken KDE path in `ujust restore-virtual-keyboard`; the GNOME path is unchanged.