### PR TITLE
fix(deck): use release channel for gamemode news

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -777,7 +777,12 @@ RUN --mount=type=cache,dst=/var/cache \
         dnf5 -y copr disable -y $copr; \
     done && unset -v copr && \
     { rm -v /usr/share/applications/bazzite-steam-bpm.desktop || true; } && \
-    sed -i "s|^github = .*|github = https://raw.githubusercontent.com/ublue-os/bazzite-gamemode-news/refs/heads/${IMAGE_BRANCH}/announcements.json|" /etc/gamemode-news-hook.conf && \
+    news_branch="${IMAGE_BRANCH}" && \
+    case "${news_branch}" in \
+        testing|unstable) ;; \
+        *) news_branch="stable" ;; \
+    esac && \
+    sed -i "s|^github = .*|github = https://raw.githubusercontent.com/ublue-os/bazzite-gamemode-news/refs/heads/${news_branch}/announcements.json|" /etc/gamemode-news-hook.conf && \
     mkdir -p /usr/lib/systemd/user/gamescope-session-plus@ogui-steam.service.wants && \
     ln -s /usr/lib/systemd/user/steamos-powerbuttond.service /usr/lib/systemd/user/gamescope-session-plus@ogui-steam.service.wants/ && \
     sed -i 's/@steam/@ogui-steam/g' /usr/lib/systemd/user/gamemode-news-hook.service && \

--- a/tests/dgoss/tests.d/00-smoke/goss.yaml
+++ b/tests/dgoss/tests.d/00-smoke/goss.yaml
@@ -13,6 +13,29 @@ command:
       '
     exit-status: 0
 
+  gamemode_news_hook_uses_release_channel:
+    exec: |
+      sh -lc '
+      config=/etc/gamemode-news-hook.conf
+      if [ ! -f "$config" ]; then
+        echo "SKIP: gamemode-news-hook is not installed"
+        exit 0
+      fi
+      url=$(sed -n "s/^github[[:space:]]*=[[:space:]]*//p" "$config")
+      case "$url" in
+        */refs/heads/stable/announcements.json|*/refs/heads/testing/announcements.json|*/refs/heads/unstable/announcements.json)
+          echo "OK: gamemode-news-hook uses a release channel ($url)"
+          ;;
+        *)
+          echo "FAIL: gamemode-news-hook uses a non-release announcement URL: ${url:-<missing>}"
+          exit 1
+          ;;
+      esac
+      '
+    exit-status: 0
+    stdout:
+      - "/^(OK|SKIP):/"
+
   selinux_label_probe_works:
     exec: |
       sh -lc '


### PR DESCRIPTION
Fixes [bazzite#5523](https://github.com/ublue-os/bazzite/issues/5523).

## Summary

- map stable builds from the repository `main` branch to the announcements repository `stable` branch
- preserve the `testing` and `unstable` announcement channels
- fall back pull-request and unknown build refs to `stable` instead of generating a dead URL
- add a dgoss regression check that rejects non-release announcement branches

## Root cause

The build passes `github.ref_name` as `IMAGE_BRANCH`. Stable scheduled builds therefore use `main`, but `ublue-os/bazzite-gamemode-news` only has `stable`, `testing`, and `unstable` branches. The resulting `main/announcements.json` URL returns 404.

## Device validation

Reproduced on a ROG Xbox Ally X running `bazzite-deck:stable` 44.20260820:

- installed config targeted `refs/heads/main/announcements.json`
- `main` returned HTTP 404 (14 bytes)
- `stable` returned HTTP 200 (891145 bytes)
- `testing` returned HTTP 200
- `gamemode-news-hook` logged `All repo mirrors failed` 881 times during approximately ten minutes in Gaming Mode

## Focused validation

- `git diff --check`
- parsed the updated goss YAML with Ruby `YAML.load_file`
- exercised the shell mapping for `main`, `testing`, `unstable`, `stable`, a pull-request ref, and an arbitrary feature ref
- confirmed every result is one of `stable`, `testing`, or `unstable`

A full image build is left to repository CI.