### PR TITLE
fix(deck): scope OpenGamepadUI debug logging

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -710,7 +710,7 @@ RUN --mount=type=cache,dst=/var/cache \
     chmod +x /usr/share/gamescope-session-plus/gamescope-session-plus && \
     sed -i 's/- xbox-elite/- deck/g' /usr/share/inputplumber/devices/50-steam_deck.yaml && \
     sed -i 's/LOG_LEVEL=info/LOG_LEVEL=debug/g' /usr/lib/systemd/system/inputplumber.service && \
-    sed -i 's|^CLIENTCMD="opengamepadui --overlay-mode|/usr/libexec/hwsupport/non-valve-handheld-hardware \&\& CLIENTCMD="opengamepadui --accessibility disabled --overlay-mode|' /usr/share/gamescope-session-plus/sessions.d/ogui-steam && \
+    sed -i 's|^CLIENTCMD="opengamepadui --overlay-mode|/usr/libexec/hwsupport/non-valve-handheld-hardware \&\& CLIENTCMD="env LOG_LEVEL=debug opengamepadui --accessibility disabled --overlay-mode|' /usr/share/gamescope-session-plus/sessions.d/ogui-steam && \
     git clone https://gitlab.com/evlaV/jupiter-dock-updater-bin.git \
         --depth 1 \
         /tmp/jupiter-dock-updater-bin && \

--- a/system_files/deck/shared/etc/environment.d/99-ogui-logs.conf
+++ b/system_files/deck/shared/etc/environment.d/99-ogui-logs.conf
@@ -1,1 +1,0 @@
-LOG_LEVEL=debug

--- a/tests/dgoss/tests.d/00-smoke/goss.yaml
+++ b/tests/dgoss/tests.d/00-smoke/goss.yaml
@@ -100,6 +100,28 @@ command:
     stdout:
       - "/^(OK|SKIP):/"
 
+  opengamepadui_debug_logging_is_scoped:
+    exec: |
+      sh -lc '
+      session=/usr/share/gamescope-session-plus/sessions.d/ogui-steam
+      if [ ! -e "$session" ]; then
+        echo "SKIP: OpenGamepadUI session is not installed"
+        exit 0
+      fi
+      if [ -e /etc/environment.d/99-ogui-logs.conf ] || [ -e /usr/etc/environment.d/99-ogui-logs.conf ]; then
+        echo "FAIL: global LOG_LEVEL override is still installed"
+        exit 1
+      fi
+      if ! grep -Fq "CLIENTCMD=\"env LOG_LEVEL=debug opengamepadui " "$session"; then
+        echo "FAIL: OpenGamepadUI does not have a scoped debug log level"
+        exit 1
+      fi
+      echo "OK: OpenGamepadUI debug logging is scoped to its command"
+      '
+    exit-status: 0
+    stdout:
+      - "/^(OK|SKIP):/"
+
   kernel_modules_match_uname:
     exec: |
       sh -lc '


### PR DESCRIPTION
## Problem

Deck images currently export `LOG_LEVEL=debug` globally through `environment.d`. That variable leaks into unrelated desktop applications. Python logging treats lowercase `debug` as an invalid level name, which can prevent applications such as Bottles from starting.

## Fix

- remove the global `99-ogui-logs.conf` environment file
- set `LOG_LEVEL=debug` only in the OpenGamepadUI `CLIENTCMD`
- leave InputPlumber debug logging unchanged because its systemd unit already scopes the variable to that service
- add a dgoss smoke assertion that rejects a global override and requires the scoped OpenGamepadUI command

Addresses [bazzite-dx#221](https://github.com/ublue-os/bazzite-dx/issues/221). The issue was closed after this PR cross-referenced it; the source change remains here because the image-level file is owned by the Bazzite repository.

## Validation

- `git diff --check`
- parsed the dgoss YAML successfully
- verified the Containerfile transformation against the upstream OpenGamepadUI session line
- passed a disposable Fedora 44 Docker contract test for environment-generator masking, removal of the global file, and scoped OpenGamepadUI logging
- on a stable Bazzite ROG Xbox Ally X, verified that masking the global file removes `LOG_LEVEL` from a newly generated user environment and a new user unit, while a scoped child receives `LOG_LEVEL=debug` and InputPlumber retains `LOG_LEVEL=debug` through its own systemd unit

A full image build is left to CI.