### PR TITLE
Fix: removed sudo to fix issue-5529

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
@@ -6,7 +6,7 @@ alias upgrade := update
 [group("system")]
 update:
     #!/usr/bin/bash
-    sudo uupd --hw-check=false --json --log-level=debug | jq -r '[(.title, .msg, .description) | select(.)] | join(" ")'
+    uupd --hw-check=false --json --log-level=debug | jq -r '[(.title, .msg, .description) | select(.)] | join(" ")'
 
 alias changelog := changelogs
 


### PR DESCRIPTION
In [issue-5529](https://github.com/ublue-os/bazzite/issues/5529) they report that

"With Bazzite v44.20260820, ujust update is being executed as sudo. I'm now getting the following when it hits the flatpak portion:

```
Note that '/var/lib/flatpak/exports/share' is not in the search path
set by the XDG_DATA_HOME and XDG_DATA_DIRS
environment variables, so applications may not
be able to find it until you set them. The
directories currently searched are:

- /root/.local/share
- /usr/local/share/
- /usr/share/
```
"

Removed sudo from ujust update in system_files/desktop/shared/usr/share/ublue-os/just/10-update.just.
uupd handles its own privilege escalation internally, so running it via sudo was unnecessary and caused environment variables like XDG_DATA_DIRS to be stripped, triggering the Flatpak path warning.