### PR TITLE
fix(portal): explain media app Steam shortcuts

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -34,6 +34,14 @@ get-media-app service="":
     }
     # Check for StreamingServiceLauncher and install if needed
     [ ! -f "$HOME/Applications/StreamingServiceLauncher.AppImage" ] && install_launcher
+    notify_shortcut_added() {
+        local service_name="$1"
+        if command -v notify-send >/dev/null 2>&1; then
+            notify-send --app-name=Bazzite \
+                "Steam shortcut added" \
+                "$service_name is now available in your Steam library."
+        fi
+    }
     # Create scripts directory
     mkdir -p "$HOME/Applications/streaming_scripts"
     # Display menu
@@ -74,6 +82,7 @@ get-media-app service="":
         echo "\"$HOME/.local/bin/streaming-service-launcher\" \"$2\"" >> "$script_path"
         chmod +x "$script_path"
         steamos-add-to-steam "$script_path"
+        notify_shortcut_added "$1"
         echo "Added $1 to Steam successfully!"
     }
     install_vacuumtube() {

--- a/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/88-bazzite-webapps.just
@@ -81,9 +81,13 @@ get-media-app service="":
         echo "#!/bin/bash" > "$script_path"
         echo "\"$HOME/.local/bin/streaming-service-launcher\" \"$2\"" >> "$script_path"
         chmod +x "$script_path"
-        steamos-add-to-steam "$script_path"
-        notify_shortcut_added "$1"
-        echo "Added $1 to Steam successfully!"
+        if steamos-add-to-steam "$script_path"; then
+            notify_shortcut_added "$CHOICE"
+            echo "Added $CHOICE to Steam successfully!"
+        else
+            echo "Failed to add $CHOICE to Steam." >&2
+            return 1
+        fi
     }
     install_vacuumtube() {
         local installed=false


### PR DESCRIPTION
## What

Clarifies that Bazzite Portal media apps add shortcuts to Steam and shows a desktop notification only after a shortcut is created successfully.

## Why

Addresses #5551, where the terminal flashes and users do not know what happened after selecting Netflix or another service.

The recipe now checks `steamos-add-to-steam` directly:

- success: show the generic Steam-library notification and success message
- failure: show an error, return non-zero, and do not display a success notification

## Validation

- `git diff --check`
- Yafti YAML remains unchanged
- extracted web-app recipe passes `bash -n`
- Docker `just --unstable --fmt --check` passes
- stubbed success path confirms notification and success output
- stubbed failure path confirms non-zero status, error output, and no false notification
- no host or immutable image changes made
