### PR TITLE
fix(deck): keep OneXFly F1 boot orientation consistent

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -6,7 +6,7 @@ IMAGE_BRANCH=$(jq -r '."image-branch"' < $IMAGE_INFO)
 FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 
 # SCRIPT VERSION
-HWS_VER=71
+HWS_VER=72
 HWS_VER_FILE="/etc/bazzite/hws_version"
 HWS_VER_RAN=$(cat $HWS_VER_FILE)
 
@@ -66,6 +66,15 @@ if [[ $IMAGE_NAME =~ "deck" && ":AOKZOE A1 AR07:" =~ ":$SYS_ID:" ]]; then
   if [[ ! $KARGS =~ "drm.edid_firmware" ]]; then
     NEEDED_KARGS+=("--append-if-missing=drm.edid_firmware=eDP-1:edid/aokzoea1ar07_edid.bin")
   fi
+fi
+
+# OneXFly F1 uses a portrait-native panel mounted in landscape. Wait for
+# amdgpu, which understands the connector orientation, before starting
+# Plymouth to avoid a portrait simpledrm splash and early console output.
+if [[ ":ONEXPLAYER F1:ONEXPLAYER F1 EVA-01:" =~ ":$SYS_ID:" ]]; then
+  NEEDED_KARGS+=("--append-if-missing=video=eDP-1:panel_orientation=left_side_up")
+  NEEDED_KARGS+=("--append-if-missing=plymouth.use-simpledrm=0")
+  NEEDED_KARGS+=("--append-if-missing=loglevel=0")
 fi
 
 if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then


### PR DESCRIPTION
## Summary

- restore the OneXFly F1 panel orientation kernel argument
- make Plymouth wait for amdgpu instead of drawing through the portrait UEFI/simpledrm framebuffer
- suppress the remaining portrait early-console line
- bump the hardware setup version so existing installations receive the fix

## Background

The OneXFly F1 has a portrait-native 1080x1920 eDP panel mounted in landscape. Plymouth currently starts on simpledrm before amdgpu can expose `eDP-1` and its orientation. This briefly renders the Bazzite splash in portrait.

Boot logs from the affected hardware showed simpledrm and Plymouth starting about three seconds before amdgpu took over. The following device-specific arguments were then verified together on the physical device:

```text
video=eDP-1:panel_orientation=left_side_up
plymouth.use-simpledrm=0
loglevel=0
```

The resulting sequence is a correctly oriented firmware logo, a black handoff while amdgpu initializes, and a correctly oriented Plymouth splash without portrait console text.

## Validation

- `bash -n system_files/desktop/shared/usr/libexec/bazzite-hardware-setup`
- `git diff --check`
- multiple live reboots on an original/Kickstarter OneXPlayer OneXFly F1 with Ryzen 7 7840U
- frame-by-frame review of the resulting boot sequence
- verified that Gaming Mode display and touch remain correctly oriented with the internal-panel fix proposed for ublue-os/bazzite#5581

Fixes #5583
