### PR TITLE
fix(just): replace uupd with bazzite-updater with jq parsing

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
@@ -6,7 +6,7 @@ alias upgrade := update
 [group("system")]
 update:
     #!/usr/bin/bash
-    uupd --hw-check=false --json --log-level=debug | jq -r '[(.title, .msg, .description) | select(.)] | join(" ")'
+    bazzite-updater --update | jq -r -R 'fromjson? | [(.title, .msg, .description) | select(.)] | join(" ")'
 
 alias changelog := changelogs
 


### PR DESCRIPTION
In the current state, ujust update fails because it lacks privileges 
this fix makes use of bazzite-updater and correctly parses the JSON with jq
Co-authored-by: biebel <badk666@hotmail.com>