### PR TITLE
fix: trim NUL bytes from dnf repo override

### DIFF
--- a/build_files/finalize
+++ b/build_files/finalize
@@ -4,6 +4,14 @@ set -eoux pipefail
 
 dnf5 config-manager setopt keepcache=0
 
+# dnf5 config-manager can leave trailing NUL bytes in this generated INI file.
+# libdnf rejects those bytes when the file is read during rpm-ostree rebases.
+repo_override=/etc/dnf/repos.override.d/99-config_manager.repo
+if [[ -f "$repo_override" ]]; then
+    tr -d '\000' < "$repo_override" > "${repo_override}.new"
+    mv -f "${repo_override}.new" "$repo_override"
+fi
+
 rm -rf /tmp/* || true
 find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 mkdir -p /var/tmp


### PR DESCRIPTION
Fixes #5604.

`dnf5 config-manager` can emit trailing NUL padding in `99-config_manager.repo`. libdnf rejects that generated INI file during an rpm-ostree rebase.

The final image build now removes only NUL bytes from the generated override after the last `dnf5 config-manager` invocation.

Tested locally with the exact affected file:
- `bash -n build_files/finalize`
- sanitization leaves the 3,145-byte valid INI prefix byte-for-byte unchanged
- no NUL bytes remain after sanitization