### PR TITLE
chore: trust ublue tap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,7 +468,7 @@ jobs:
       - name: Setup Syft
         id: setup-syft
         if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action/download-syft@aa80c8c5bd439a416a62804f2151ab38c671a638 # v0.24.1
+        uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
           # FIXME: a renovate rule for this would be nice
           syft-version: v1.44.0

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Builds with the GNOME desktop environment are available in both desktop and deck
 - [Variable refresh rate support and fractional scaling enabled under Wayland](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1154).
 - Custom menu in the top bar for returning to game mode, launching Steam, and opening a number of useful utilities.
 - [GSConnect](https://extensions.gnome.org/extension/1319/gsconnect/) preinstalled and ready to use.
-- [Hanabi extension](https://github.com/jeffshee/gnome-ext-hanabi) included to offer similar features to Wallpaper Engine in KDE.
 - Numerous optional extensions pre-installed, including [important user experience fixes](https://www.youtube.com/watch?v=nbCg9_YgKgM).
 - Automatic updates for the [Firefox GNOME theme](https://github.com/rafaelmardojai/firefox-gnome-theme) and [Thunderbird GNOME theme](https://github.com/rafaelmardojai/thunderbird-gnome-theme). <sup><sub>(If installed)</sub></sup>
 

--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -254,6 +254,7 @@ install-jetbrains-toolbox:
     if ! command -v brew >/dev/null 2>&1 && [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
     fi
+    brew trust ublue-os/tap 
     brew tap ublue-os/tap
     brew install --cask jetbrains-toolbox-linux
     if ! command -v jetbrains-toolbox >/dev/null 2>&1; then
@@ -352,6 +353,7 @@ asus ACTION="":
         done
 
         if [ ${#brew_packages[@]} -gt 0 ]; then
+            brew trust ublue-os/tap 
             brew tap ublue-os/tap
             echo "Installing: ${brew_packages[*]}"
             brew install --cask "${brew_packages[@]}"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -41,7 +41,7 @@ screens:
         title: "Antigravity"
         description: "AI-powered IDE from Google — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask antigravity-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask antigravity-linux'
       - id: "asus"
         title: "asusctl & ROG Control Center"
         description: "Utilities for management of ASUS hardware."
@@ -168,12 +168,12 @@ screens:
         title: "JetBrains Toolbox"
         description: "Utility for managing IDE installs from JetBrains — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask jetbrains-toolbox-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask jetbrains-toolbox-linux'
       - id: "lm-studio-linux"
         title: "LM Studio"
         description: "Suite for locally utilizing large language models (LLMs) — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask lm-studio-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask lm-studio-linux'
       - id: "lsfg-vk"
         title: "Lossless Scaling — Vulkan Layer"
         description: "Install «lsfg-vk», the adapter for Lossless Scaling frame generation on Linux."
@@ -300,7 +300,7 @@ screens:
         title: "Visual Studio Code"
         description: "Open source code editor and debugger from Microsoft — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask visual-studio-code-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask visual-studio-code-linux'
       - id: "vscodium-linux"
         title: "VSCodium"
         description: "Strictly open source community edition of Visual Studio Code — installed using Brew."


### PR DESCRIPTION
mainly for the ROG Control Center script in the Bazzite Portal (regular users just see the script fail and get told to run a trust command), also adds it to other casks from the tap where it is still missing for both `ujust` and Bazzite Portal