### PR TITLE
chore: trust ublue tap in Bazzite Portal and ujust

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/82-bazzite-apps.just
@@ -254,6 +254,7 @@ install-jetbrains-toolbox:
     if ! command -v brew >/dev/null 2>&1 && [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
     fi
+    brew trust ublue-os/tap 
     brew tap ublue-os/tap
     brew install --cask jetbrains-toolbox-linux
     if ! command -v jetbrains-toolbox >/dev/null 2>&1; then
@@ -352,6 +353,7 @@ asus ACTION="":
         done
 
         if [ ${#brew_packages[@]} -gt 0 ]; then
+            brew trust ublue-os/tap 
             brew tap ublue-os/tap
             echo "Installing: ${brew_packages[*]}"
             brew install --cask "${brew_packages[@]}"

--- a/system_files/desktop/shared/usr/share/yafti/yafti.yml
+++ b/system_files/desktop/shared/usr/share/yafti/yafti.yml
@@ -41,7 +41,7 @@ screens:
         title: "Antigravity"
         description: "AI-powered IDE from Google — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask antigravity-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask antigravity-linux'
       - id: "asus"
         title: "asusctl & ROG Control Center"
         description: "Utilities for management of ASUS hardware."
@@ -168,12 +168,12 @@ screens:
         title: "JetBrains Toolbox"
         description: "Utility for managing IDE installs from JetBrains — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask jetbrains-toolbox-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask jetbrains-toolbox-linux'
       - id: "lm-studio-linux"
         title: "LM Studio"
         description: "Suite for locally utilizing large language models (LLMs) — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask lm-studio-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask lm-studio-linux'
       - id: "lsfg-vk"
         title: "Lossless Scaling — Vulkan Layer"
         description: "Install «lsfg-vk», the adapter for Lossless Scaling frame generation on Linux."
@@ -300,7 +300,7 @@ screens:
         title: "Visual Studio Code"
         description: "Open source code editor and debugger from Microsoft — installed using Brew."
         default: false
-        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap ublue-os/tap && brew install --cask visual-studio-code-linux'
+        script: 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew trust ublue-os/tap && brew tap ublue-os/tap && brew install --cask visual-studio-code-linux'
       - id: "vscodium-linux"
         title: "VSCodium"
         description: "Strictly open source community edition of Visual Studio Code — installed using Brew."


### PR DESCRIPTION
mainly for the ROG Control Center script in the Bazzite Portal (regular users just see the script fail and get told to run a trust command), also adds it to other casks from the tap where it is still missing for both `ujust` and Bazzite Portal