### PR TITLE
fix(just): call update script directly

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/10-update.just
@@ -6,7 +6,7 @@ alias upgrade := update
 [group("system")]
 update:
     #!/usr/bin/bash
-    bazzite-updater --update | jq -r -R 'fromjson? | [(.title, .msg, .description) | select(.)] | join(" ")'
+    /usr/etc/bazzite-updater/service-as-program.sh uupd-manual.service | jq -r -R 'fromjson? | [(.title, .msg, .description) | select(.)] | join(" ")'
 
 alias changelog := changelogs
 


### PR DESCRIPTION
`ujust update` may fail if `bazzite-updater` can't launch due to e.g. issues with Qt (as seen from a report in the Discord)

> ujust update 
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

> Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vkkhrdisplay, vnc, wayland-brcm, wayland-egl, wayland, xcb.