### PR TITLE
fix(deck): Add Ally X controller udev rule

### DIFF
--- a/system_files/deck/shared/usr/lib/udev/rules.d/50-ally-x-controller.rules
+++ b/system_files/deck/shared/usr/lib/udev/rules.d/50-ally-x-controller.rules
@@ -1,0 +1,6 @@
+# ASUS ROG Ally X / ASUS ROG Xbox Ally / ASUS ROG Xbox Ally X Controller
+
+# Disable the internal controller from being a wakeup source, so that unintentional
+# input events (Like analog stick movements) don't prematurely wake up the device
+# before it fully suspends.
+ACTION=="add", SUBSYSTEM=="usb", DRIVER=="usb", ATTR{idVendor}=="0b05", ATTR{idProduct}=="1b4c", ATTR{power/wakeup}="disabled"


### PR DESCRIPTION
## Description

This fixes input events from the internal controller, on the ASUS ROG Ally X, Xbox Ally, and Xbox Ally X, causing the device to wake up prematurely before the device fully suspends by adding a `udev` rule to disable the controller as a wakeup source. Basically during the window of putting the device to sleep and it fully suspending, a single unintentional input event from the controller (Like just slightly moving an analog stick) could cause the device to wake right back up.