### PR TITLE
fix(CEC): Prevent suspend from being triggered on wake

### DIFF
--- a/system_files/desktop/shared/usr/bin/cec-control
+++ b/system_files/desktop/shared/usr/bin/cec-control
@@ -52,6 +52,10 @@ function perform_standby {
         for id in $CEC_TVID; do
             cec-ctl -d "$CEC_DEVICE" --to "$id" --standby 2>/dev/null || \
                 echo "Warning: Failed to send standby to CEC device $id" >&2
+            
+            #delay after sending standby command, to prevent the TV's Standby response
+            #from being saved during the suspend process, and causing re-suspend on wake
+            sleep 5
         done
     else
         # libcec path


### PR DESCRIPTION
Fixes #5200 and #5240

This is how I understand the problem:
- cec-control sends the standby command to the TV
- A second or two later, the TV sends the standby command to all connected devices, including the origin device (Bazzite)
- The standby command sent by the TV to Bazzite happens to be queued or cached in some way, and is saved during the suspend-to-ram/suspend-to-disk process
- On resume, the saved standby command is processed, triggering an immediate system suspend.

One remaining quirk of the non-native CEC implementation is that the TV cannot suspend Bazzite, as cec-ctl only runs when triggered by cec-onboot.service, cec-onpoweroff.service, and cec-onsleep.service. This can explain why (before this fix) suspend happened reliably as the system resumed, but cec standby commands do not work normally. As cec-ctl runs when triggered by cec-onboot.service, allowing the standby command to be processed.