### PR TITLE
fix(input): suppress input-remapper autostart when service is disabled

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -703,6 +703,7 @@ RUN --mount=type=cache,dst=/var/cache \
     ; fi && \
     printf "[scx]\nscx_service = \"scx_loader.service\"\n" >> /usr/share/steamos-manager/platform.toml && \
     sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/input-remapper-gtk.desktop && \
+    sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /etc/xdg/autostart/input-remapper-autoload.desktop && \
     sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && \
     for copr in \
         ublue-os/staging \

--- a/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/deck/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -94,8 +94,10 @@ disable-ryzenadj-max-performance:
 # Re-enable input remapper feature on non-desktop images
 restore-input-remapper:
     systemctl enable --now input-remapper.service && \
+    mkdir -p ~/.local/share/applications ~/.config/autostart && \
     cp /usr/share/applications/input-remapper-gtk.desktop ~/.local/share/applications/input-remapper-gtk.desktop && \
-    sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop
+    sed -i '/NoDisplay=true/d' ~/.local/share/applications/input-remapper-gtk.desktop && \
+    if [[ -f /etc/xdg/autostart/input-remapper-autoload.desktop ]]; then cp /etc/xdg/autostart/input-remapper-autoload.desktop ~/.config/autostart/input-remapper-autoload.desktop && sed -i '/Hidden=true/d' ~/.config/autostart/input-remapper-autoload.desktop; fi
 
 # Configure video overrides for Steam
 configure-override-videos ACTION="":

--- a/system_files/desktop/shared/usr/share/ublue-os/just/85-bazzite-image.just
+++ b/system_files/desktop/shared/usr/share/ublue-os/just/85-bazzite-image.just
@@ -5,6 +5,7 @@ restore-input-remapper ACTION="":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     DESKTOP_FILE="$HOME/.local/share/applications/input-remapper-gtk.desktop"
+    AUTOSTART_FILE="$HOME/.config/autostart/input-remapper-autoload.desktop"
     get_status_token() {
         if systemctl is-enabled --quiet input-remapper.service && [[ -f "$DESKTOP_FILE" ]]; then
             echo "enable"
@@ -21,14 +22,18 @@ restore-input-remapper ACTION="":
     }
     enable_input_remapper() {
         systemctl enable --now input-remapper.service
-        mkdir -p "$HOME/.local/share/applications"
+        mkdir -p "$HOME/.local/share/applications" "$HOME/.config/autostart"
         cp /usr/share/applications/input-remapper-gtk.desktop "$DESKTOP_FILE"
         sed -i '/NoDisplay=true/d' "$DESKTOP_FILE"
+        if [[ -f /etc/xdg/autostart/input-remapper-autoload.desktop ]]; then
+            cp /etc/xdg/autostart/input-remapper-autoload.desktop "$AUTOSTART_FILE"
+            sed -i '/Hidden=true/d' "$AUTOSTART_FILE"
+        fi
         echo "Input Remapper has been enabled."
     }
     disable_input_remapper() {
         systemctl disable --now input-remapper.service
-        rm -f "$DESKTOP_FILE"
+        rm -f "$DESKTOP_FILE" "$AUTOSTART_FILE"
         echo "Input Remapper has been disabled."
     }
     OPTION="{{ ACTION }}"


### PR DESCRIPTION
### Problem
When Bazzite disables `input-remapper.service` by default in favor of `inputplumber.service`, systemd's XDG autostart generator still processes `/etc/xdg/autostart/input-remapper-autoload.desktop`. On user session login, `app-input-remapper-autoload@autostart.service` executes `input-remapper-control --autoload`, immediately fails because the service is inactive, and flags a persistent failed user unit (`systemctl --user --failed`).

### Solution
1. In `Containerfile`, add `Hidden=true` to `/etc/xdg/autostart/input-remapper-autoload.desktop` so the XDG autostart generator skips it by default (matching the existing `NoDisplay=true` treatment on `/usr/share/applications/input-remapper-gtk.desktop`).
2. Update `ujust restore-input-remapper` across desktop and deck justfiles to copy and unhide `input-remapper-autoload.desktop` into `~/.config/autostart` when enabled, and remove it on disable.

### Validation
- Verified on ROG Xbox Ally X on Bazzite 44.
- Confirmed `systemd --user` no longer generates a failing service on login, and `ujust restore-input-remapper enable` correctly unhides both the GTK menu entry and the autostart hook.